### PR TITLE
feat: add chroma-mcp server for ChromaDB vector database operations

### DIFF
--- a/registry/chroma-mcp/spec.yaml
+++ b/registry/chroma-mcp/spec.yaml
@@ -1,0 +1,75 @@
+# Docker/OCI image reference (REQUIRED)
+image: ghcr.io/stacklok/dockyard/uvx/chroma-mcp:0.2.6
+
+# One-line description (REQUIRED)
+description: MCP server for ChromaDB vector database operations
+
+# Communication protocol (REQUIRED)
+transport: stdio
+
+# Source code repository (HIGHLY RECOMMENDED)
+repository_url: https://github.com/chroma-core/chroma-mcp
+
+# License identifier (OPTIONAL)
+license: Apache-2.0
+
+# Author/organization (OPTIONAL)
+author: Chroma Core
+
+# Classification tier
+tier: Official
+
+# Development status
+status: Active
+
+# Categorization tags (RECOMMENDED)
+tags:
+  - database
+  - vector-database
+  - embeddings
+  - ai
+  - chromadb
+
+# List of tools provided (HIGHLY RECOMMENDED)
+tools:
+  - chroma_list_collections
+  - chroma_create_collection
+  - chroma_peek_collection
+  - chroma_get_collection_info
+  - chroma_get_collection_count
+  - chroma_modify_collection
+  - chroma_delete_collection
+  - chroma_add_documents
+  - chroma_query_documents
+  - chroma_get_documents
+  - chroma_update_documents
+  - chroma_delete_documents
+
+# Environment variables (IF APPLICABLE)
+env_vars:
+  - name: CHROMA_SERVER_URL
+    description: ChromaDB server URL
+    required: false
+    default: "http://localhost:8000"
+  
+  - name: CHROMA_API_KEY
+    description: API key for ChromaDB authentication
+    required: false
+    secret: true
+
+# Security permissions - Chroma MCP can connect to various backends
+permissions:
+  network:
+    outbound:
+      # Allow all outbound since users may self-host Chroma anywhere
+      # or use Chroma Cloud at api.trychroma.com
+      insecure_allow_all: true
+
+# Provenance for supply chain security (Dockyard build)
+provenance:
+  sigstore_url: tuf-repo-cdn.sigstore.dev
+  repository_uri: https://github.com/stacklok/dockyard
+  repository_ref: refs/heads/main
+  signer_identity: /.github/workflows/build-containers.yml
+  runner_environment: github-hosted
+  cert_issuer: https://token.actions.githubusercontent.com


### PR DESCRIPTION
This PR adds the chroma-mcp server to the ToolHive registry.

## Description
Adds MCP server for ChromaDB vector database operations, enabling AI models to create collections over generated data and user inputs, and retrieve that data using vector search, full text search, metadata filtering, and more.

## Details
- **Package**: chroma-mcp v0.2.6
- **Repository**: https://github.com/chroma-core/chroma-mcp
- **Docker Image**: ghcr.io/stacklok/dockyard/uvx/chroma-mcp:0.2.6
- **Protocol**: stdio

## Features
- Collection management (create, modify, delete, list)
- Document operations (add, query, update, delete)
- Advanced filtering using metadata and document content
- Support for multiple client types (ephemeral, persistent, HTTP, cloud)
- Multiple embedding functions support

## Related
Part of the effort to add official MCP servers from Dockyard PRs.
Reference: https://github.com/stacklok/dockyard/pull/34