### PR TITLE
feat: add astra-db-mcp server for DataStax Astra DB operations

### DIFF
--- a/registry/astra-db-mcp/spec.yaml
+++ b/registry/astra-db-mcp/spec.yaml
@@ -1,0 +1,86 @@
+# Docker/OCI image reference (REQUIRED)
+image: ghcr.io/stacklok/dockyard/npx/astra-db-mcp:1.2.0
+
+# One-line description (REQUIRED)
+description: Model Context Protocol server for interacting with DataStax Astra DB
+
+# Communication protocol (REQUIRED)
+transport: stdio
+
+# Source code repository (HIGHLY RECOMMENDED)
+repository_url: https://github.com/datastax/astra-db-mcp
+
+# Project homepage/documentation (OPTIONAL)
+homepage: https://astra.datastax.com
+
+# License identifier (OPTIONAL)
+license: Apache-2.0
+
+# Author/organization (OPTIONAL)
+author: DataStax
+
+# Classification tier
+tier: Official
+
+# Development status
+status: Active
+
+# Categorization tags (RECOMMENDED)
+tags:
+  - database
+  - nosql
+  - cassandra
+  - vector-database
+  - datastax
+  - astra
+
+# List of tools provided (HIGHLY RECOMMENDED)
+tools:
+  - GetCollections
+  - CreateCollection
+  - UpdateCollection
+  - DeleteCollection
+  - ListRecords
+  - GetRecord
+  - CreateRecord
+  - UpdateRecord
+  - DeleteRecord
+  - FindRecord
+  - BulkCreateRecords
+  - BulkUpdateRecords
+  - BulkDeleteRecords
+  - OpenBrowser
+  - HelpAddToClient
+  - EstimateDocumentCount
+
+# Environment variables (IF APPLICABLE)
+env_vars:
+  - name: ASTRA_DB_APPLICATION_TOKEN
+    description: Astra DB application token for authentication
+    required: true
+    secret: true
+  
+  - name: ASTRA_DB_API_ENDPOINT
+    description: Astra DB API endpoint URL
+    required: true
+  
+  - name: ASTRA_DB_KEYSPACE
+    description: Astra DB keyspace to use (defaults to default_keyspace)
+    required: false
+    default: "default_keyspace"
+
+# Security permissions (IF APPLICABLE)
+permissions:
+  network:
+    outbound:
+      # Astra DB endpoints vary by region and instance
+      insecure_allow_all: true
+
+# Provenance for supply chain security (Dockyard build)
+provenance:
+  sigstore_url: tuf-repo-cdn.sigstore.dev
+  repository_uri: https://github.com/stacklok/dockyard
+  repository_ref: refs/heads/main
+  signer_identity: /.github/workflows/build-containers.yml
+  runner_environment: github-hosted
+  cert_issuer: https://token.actions.githubusercontent.com


### PR DESCRIPTION
This PR adds the astra-db-mcp server to the ToolHive registry.

## Description
Adds MCP server for DataStax Astra DB operations, enabling AI models to interact with Astra DB databases for vector search, document operations, and database management.

## Details
- **Package**: astra-db-mcp v1.2.0
- **Repository**: https://github.com/datastax/astra-db-mcp
- **Docker Image**: ghcr.io/stacklok/dockyard/npx/astra-db-mcp:1.2.0
- **Protocol**: stdio

## Features
- Database management (create, list, get info, delete)
- Collection operations (create, list, delete)
- Document CRUD operations
- Vector search capabilities
- Index management
- Bulk operations support
- Query filtering and sorting

## Related
Part of the effort to add official MCP servers from Dockyard PRs.
Reference: https://github.com/stacklok/dockyard/pull/37