### PR TITLE
feat: add agentql-mcp server for web data extraction

### DIFF
--- a/registry/agentql-mcp/spec.yaml
+++ b/registry/agentql-mcp/spec.yaml
@@ -1,0 +1,65 @@
+# Docker/OCI image reference (REQUIRED)
+image: ghcr.io/stacklok/dockyard/npx/agentql-mcp:1.0.0
+
+# One-line description (REQUIRED)
+description: Model Context Protocol server that integrates AgentQL data extraction capabilities
+
+# Communication protocol (REQUIRED)
+transport: stdio
+
+# Source code repository (HIGHLY RECOMMENDED)
+repository_url: https://github.com/tinyfish-io/agentql-mcp
+
+# Project homepage/documentation (OPTIONAL)
+homepage: https://agentql.com
+
+# License identifier (OPTIONAL)
+license: MIT
+
+# Author/organization (OPTIONAL)
+author: TinyFish
+
+# Classification tier
+tier: Official
+
+# Development status
+status: Active
+
+# Categorization tags (RECOMMENDED)
+tags:
+  - web-scraping
+  - data-extraction
+  - ai
+  - automation
+  - web
+
+# List of tools provided (HIGHLY RECOMMENDED)
+tools:
+  - extract-web-data
+
+# Environment variables (IF APPLICABLE)
+env_vars:
+  - name: AGENTQL_API_KEY
+    description: API key for AgentQL service
+    required: true
+    secret: true
+
+# Security permissions (IF APPLICABLE)
+permissions:
+  network:
+    outbound:
+      # The MCP server only connects to AgentQL API
+      # However, AgentQL service itself scrapes any website provided by the user
+      allow_host:
+        - api.agentql.com
+      allow_port:
+        - 443
+
+# Provenance for supply chain security (Dockyard build)
+provenance:
+  sigstore_url: tuf-repo-cdn.sigstore.dev
+  repository_uri: https://github.com/stacklok/dockyard
+  repository_ref: refs/heads/main
+  signer_identity: /.github/workflows/build-containers.yml
+  runner_environment: github-hosted
+  cert_issuer: https://token.actions.githubusercontent.com


### PR DESCRIPTION
This PR adds the agentql-mcp server to the ToolHive registry.

## Description
Adds MCP server for web data extraction using AgentQL, enabling AI models to extract structured data from websites using natural language queries.

## Details
- **Package**: agentql-mcp v1.0.0
- **Repository**: https://github.com/AgentQL/agentql-mcp
- **Docker Image**: ghcr.io/stacklok/dockyard/npx/agentql-mcp:1.0.0
- **Protocol**: stdio

## Features
- Extract structured data from any website
- Natural language queries for data extraction
- Automatic handling of dynamic content
- Support for complex web structures
- No need for CSS selectors or XPath

## Related
Part of the effort to add official MCP servers from Dockyard PRs.
Reference: https://github.com/stacklok/dockyard/pull/39