### PR TITLE
feat: add mcp-server-circleci for CircleCI CI/CD operations

### DIFF
--- a/registry/mcp-server-circleci/spec.yaml
+++ b/registry/mcp-server-circleci/spec.yaml
@@ -1,0 +1,99 @@
+# Docker/OCI image reference (REQUIRED)
+image: ghcr.io/stacklok/dockyard/npx/mcp-server-circleci:0.14.0
+
+# One-line description (REQUIRED)
+description: Official CircleCI MCP server for CI/CD operations, enabling AI models to manage pipelines, analyze test results, debug build failures, and optimize resource usage
+
+# Communication protocol (REQUIRED)
+transport: stdio
+
+# Source code repository (HIGHLY RECOMMENDED)
+repository_url: https://github.com/CircleCI-Public/mcp-server-circleci
+
+# License identifier (OPTIONAL)
+license: MIT
+
+# Author/organization (OPTIONAL)
+author: CircleCI
+
+# Classification tier (OPTIONAL, defaults to "Community")
+tier: Official
+
+# Development status (OPTIONAL, defaults to "Active")
+status: Active
+
+# Categorization tags (RECOMMENDED)
+tags:
+  - circleci
+  - ci-cd
+  - devops
+  - testing
+  - automation
+  - pipeline
+  - continuous-integration
+  - continuous-deployment
+  - build-automation
+
+# List of tools provided (HIGHLY RECOMMENDED)
+tools:
+  - get_build_failure_logs
+  - find_flaky_tests
+  - get_latest_pipeline_status
+  - get_job_test_results
+  - config_helper
+  - create_prompt_template
+  - recommend_prompt_template_tests
+  - list_followed_projects
+  - run_pipeline
+  - run_rollback_pipeline
+  - rerun_workflow
+  - analyze_diff
+  - list_component_versions
+  - download_usage_api_data
+  - find_underused_resource_classes
+
+# Environment variables (IF APPLICABLE)
+env_vars:
+  - name: CIRCLECI_TOKEN
+    description: CircleCI Personal API Token for authentication
+    required: true
+    secret: true
+  
+  - name: CIRCLECI_BASE_URL
+    description: CircleCI base URL (optional, defaults to https://circleci.com)
+    required: false
+    default: "https://circleci.com"
+  
+  - name: FILE_OUTPUT_DIRECTORY
+    description: Directory for file outputs (optional, used by some tools)
+    required: false
+
+# Security permissions (IF APPLICABLE)
+permissions:
+  # Network access
+  network:
+    outbound:
+      allow_host:
+        - circleci.com
+        - app.circleci.com
+      allow_port:
+        - 443
+        - 80
+  
+  # File system access
+  read:
+    - .circleci/config.yml
+    - .cursorrules
+    - .cursor/rules
+  
+  write:
+    - ${FILE_OUTPUT_DIRECTORY}
+
+# Provenance information for supply chain security
+provenance:
+  sigstore_url: tuf-repo-cdn.sigstore.dev
+  repository_uri: https://github.com/stacklok/dockyard
+  repository_ref: refs/heads/main
+  signer_identity: /.github/workflows/build-containers.yml
+  runner_environment: github-hosted
+  cert_issuer: https://token.actions.githubusercontent.com


### PR DESCRIPTION
This PR adds the mcp-server-circleci to the ToolHive registry.

## Description
Adds the official CircleCI MCP server for CI/CD operations, enabling AI models to manage pipelines, analyze test results, debug build failures, and optimize resource usage.

## Details
- **Package**: @circleci/mcp-server-circleci v0.14.0
- **Repository**: https://github.com/CircleCI-Public/mcp-server-circleci
- **Docker Image**: ghcr.io/stacklok/dockyard/npx/mcp-server-circleci:0.14.0
- **Protocol**: stdio

## Features
- Build failure log retrieval and analysis
- Flaky test detection
- Pipeline status monitoring
- Test result analysis
- Configuration validation
- Pipeline triggering and rollback
- Workflow rerun capabilities
- Usage data analysis for cost optimization
- Git diff analysis against cursor rules
- Component version management

## Tools (15 total)
- `get_build_failure_logs` - Retrieve detailed failure logs
- `find_flaky_tests` - Identify unreliable tests
- `get_latest_pipeline_status` - Monitor pipeline status
- `get_job_test_results` - Analyze test metadata
- `config_helper` - Validate CircleCI configuration
- `list_followed_projects` - List accessible projects
- `run_pipeline` - Trigger pipeline execution
- `run_rollback_pipeline` - Execute rollback operations
- `rerun_workflow` - Rerun workflows from failure point
- `analyze_diff` - Analyze code changes against rules
- `list_component_versions` - Manage component versions
- `download_usage_api_data` - Export usage data
- `find_underused_resource_classes` - Optimize resource usage
- Plus prompt template tools for AI applications

## Related
Part of the effort to add official MCP servers from Dockyard PRs.
Reference: https://github.com/stacklok/dockyard/pull/35