### PR TITLE
feat: add Kion MCP server spec

### DIFF
--- a/registry/kion/spec.yaml
+++ b/registry/kion/spec.yaml
@@ -26,8 +26,45 @@ tags:
   - governance
   - cloud-costs
 tools:
-  - check_config_status
-  - setup_kion_config
+  - add_project_spend_plan_entries
+  - allocate_funds
+  - create_budget
+  - create_funding_source
+  - create_ou
+  - create_project_with_budget
+  - create_project_with_spend_plan
+  - get_accounts
+  - get_cloud_access_role_details
+  - get_cloud_access_roles_on_entity
+  - get_cloud_provider_services
+  - get_cloud_providers
+  - get_compliance_check
+  - get_compliance_checks_paginated
+  - get_compliance_findings
+  - get_compliance_ous
+  - get_compliance_program
+  - get_compliance_standard
+  - get_compliance_standard_project
+  - get_compliance_standards_paginated
+  - get_entity_by_id
+  - get_label_key_id
+  - get_labels
+  - get_ou_budget
+  - get_ou_funding_sources
+  - get_ous
+  - get_permission_scheme
+  - get_project_budget
+  - get_project_spend_plan_with_totals
+  - get_projects
+  - get_spend_report
+  - get_suppressed_compliance_findings
+  - get_tag_keys
+  - get_tag_values
+  - get_user_cloud_access_roles
+  - get_user_groups
+  - get_user_info
+  - get_users
+  - update_budget
 metadata:
   stars: 7
   pulls: 114


### PR DESCRIPTION
Adds the [Kion MCP server](https://kion.io/resources/kion-mcp-server) for the Kion cloud management and FinOps platform.

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>