### PR TITLE
Add neo-x402-mcp: AI-powered web intelligence toolkit with x402 monetization

### DIFF
--- a/registries/toolhive/servers/neo-x402-mcp/server.json
+++ b/registries/toolhive/servers/neo-x402-mcp/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.atakanelik34/neo-x402-mcp",
   "title": "Neo x402 MCP",
-  "version": "1.0.0",
-  "description": "AI-powered web intelligence toolkit with pay-per-use monetization. Search, scrape, analyze PDFs, track crypto, and review code via x402 protocol.",
+  "version": "1.1.0",
+  "description": "AI-powered web intelligence toolkit with 8 tools: search, scrape, screenshot, SEO analysis, PDF/docs conversion, crypto tracking, and code review via x402 pay-per-use.",
   "repository": {
     "url": "https://github.com/atakanelik34/neo-x402-api-server",
     "source": "github"
@@ -27,6 +27,9 @@
         "tags": [
           "web-search",
           "scraping",
+          "screenshot",
+          "seo-analysis",
+          "document-conversion",
           "pdf-analysis",
           "crypto",
           "code-review",
@@ -38,7 +41,10 @@
           "scrape",
           "pdf_analyze",
           "crypto_price",
-          "code_review"
+          "code_review",
+          "screenshot",
+          "seo_analyze",
+          "convert_document"
         ]
       }
     }

--- a/registries/toolhive/servers/neo-x402-mcp/server.json
+++ b/registries/toolhive/servers/neo-x402-mcp/server.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.atakanelik34/neo-x402-mcp",
+  "title": "Neo x402 MCP",
+  "version": "1.0.0",
+  "description": "AI-powered web intelligence toolkit with pay-per-use monetization. Search, scrape, analyze PDFs, track crypto, and review code via x402 protocol.",
+  "repository": {
+    "url": "https://github.com/atakanelik34/neo-x402-api-server",
+    "source": "github"
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://neo.docly.work/mcp"
+    }
+  ],
+  "packages": [],
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "io.github.atakanelik34": {
+        "metadata": {
+          "last_updated": "2026-04-05T00:00:00Z",
+          "stars": 0
+        },
+        "status": "Active",
+        "tier": "Community",
+        "tags": [
+          "web-search",
+          "scraping",
+          "pdf-analysis",
+          "crypto",
+          "code-review",
+          "x402",
+          "pay-per-use"
+        ],
+        "tools": [
+          "web_search",
+          "scrape",
+          "pdf_analyze",
+          "crypto_price",
+          "code_review"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Neo x402 MCP Server

AI-powered web intelligence toolkit with pay-per-use monetization via x402 protocol.

### Tools
- **web_search** — Web search with AI-powered ranking
- **scrape** — Anti-bot web scraping with Cloudflare bypass
- **pdf_analyze** — PDF content analysis and summarization
- **crypto_price** — Real-time cryptocurrency prices
- **code_review** — AI-powered code review

### Details
- **Remote URL:** https://neo.docly.work/mcp
- **Transport:** streamable-http
- **Network:** Base mainnet (eip155:8453)
- **Registry:** Already published to official MCP Registry (io.github.atakanelik34/neo-x402-mcp)

### Repository
https://github.com/atakanelik34/neo-x402-api-server