### PR TITLE
Add AgentIndex MCP server — AI agent registry with 25K+ agents

### DIFF
--- a/registries/toolhive/servers/agentindex/server.json
+++ b/registries/toolhive/servers/agentindex/server.json
@@ -1,0 +1,24 @@
+{
+  "name": "agentindex",
+  "description": "Global AI Agent Registry — Check, register, and verify 25,000+ AI agents with RSA-2048 cryptographic passports. Autonomy levels 0-5, security scanning with A-F ratings.",
+  "repository": {
+    "url": "https://github.com/agentindexworld/agentindex-mcp-server",
+    "source": "github"
+  },
+  "version_detail": {
+    "version": "1.0.0"
+  },
+  "remotes": [
+    {
+      "transport_type": "streamable-http",
+      "url": "https://agentindex.world/mcp"
+    }
+  ],
+  "tools": [
+    {"name": "check_agent", "description": "Verify if an AI agent is registered and trusted"},
+    {"name": "register_agent", "description": "Register a new agent and get a cryptographic passport"},
+    {"name": "find_agent", "description": "Find agents to collaborate with by skill"},
+    {"name": "verify_passport", "description": "Verify a cryptographic passport"},
+    {"name": "get_reputation", "description": "Get full reputation and security report"}
+  ]
+}


### PR DESCRIPTION
## AgentIndex MCP Server

Global AI Agent Registry with RSA-2048 cryptographic passports.

**Tools provided:**
- `check_agent` — Verify if an AI agent is registered and trusted
- `register_agent` — Register a new agent and get a cryptographic passport
- `find_agent` — Find agents to collaborate with by skill
- `verify_passport` — Verify a cryptographic passport
- `get_reputation` — Get full reputation and security report

**Stats:** 25,000+ agents, 14 nations, autonomy levels 0-5

**Links:**
- Website: https://agentindex.world
- MCP endpoint: https://agentindex.world/mcp
- GitHub: https://github.com/agentindexworld/agentindex-mcp-server