### PR TITLE
docs: add skill inclusion criteria and split criteria docs

### DIFF
--- a/.claude/skills/mcp-review/SKILL.md
+++ b/.claude/skills/mcp-review/SKILL.md
@@ -12,7 +12,7 @@ allowed-tools: Read Grep Glob Bash WebFetch
 You are an expert reviewer for the ToolHive Registry. Evaluate server.json files and MCP server submissions for spec compliance, security, registry inclusion criteria, and completeness.
 
 For detailed field specs, see [server-json-spec.md](references/server-json-spec.md).
-For full registry inclusion criteria, see [registry-criteria.md](references/registry-criteria.md).
+For full registry inclusion criteria, see [registry-criteria.md](references/registry-criteria.md) and [server-criteria.md](references/server-criteria.md).
 
 ## Review Workflow
 
@@ -55,7 +55,7 @@ Run `task catalog:validate` to catch schema-level issues.
 ### Step 4: Repository Assessment (New Submissions)
 
 For new servers, assess the source repository against registry inclusion criteria.
-See [registry-criteria.md](references/registry-criteria.md) for the full checklist and verification commands.
+See [server-criteria.md](references/server-criteria.md) for the full checklist and verification commands.
 
 **Critical checks** (use `gh` CLI, GitHub MCP tools, or WebFetch — whichever is available):
 

--- a/.claude/skills/mcp-review/references/registry-criteria.md
+++ b/.claude/skills/mcp-review/references/registry-criteria.md
@@ -1,6 +1,8 @@
-# ToolHive Registry Inclusion Criteria
+# ToolHive Registry Inclusion Criteria (Shared)
 
 Source: [docs/registry-criteria.md](../../../../docs/registry-criteria.md)
+
+For MCP server-specific criteria, see [server-criteria.md](server-criteria.md).
 
 ## Table of Contents
 

--- a/.claude/skills/mcp-review/references/server-criteria.md
+++ b/.claude/skills/mcp-review/references/server-criteria.md
@@ -1,0 +1,79 @@
+# MCP Server Inclusion Criteria
+
+Source: [docs/server-criteria.md](../../../../docs/server-criteria.md)
+
+For shared criteria (open source, licensing, community health), see
+[registry-criteria.md](registry-criteria.md).
+
+## Security
+
+| Requirement | Severity |
+|-------------|----------|
+| Pinned dependencies / Actions pinned to SHAs | Required |
+| Secure auth mechanisms (OAuth, TLS, API keys marked secret) | Required |
+| Sensitive information handling | Required |
+| Encryption in transit (TLS) | Required |
+| No known unpatched critical/high CVEs | Required |
+| Software provenance (Sigstore / GitHub Attestations) | Expected |
+| Automated security scanning in CI | Expected |
+| SLSA compliance | Recommended |
+| Published SBOM | Recommended |
+| Security reporting (`SECURITY.md`) | Recommended |
+
+## Continuous Integration
+
+- Automated dependency updates (Dependabot, Renovate, etc.)
+- Automated security scanning
+- CVE monitoring
+- Code linting and quality checks
+
+## API Compliance
+
+- Full MCP API specification support
+- All required endpoints implemented (tools, resources, prompts as applicable)
+- Protocol version compatibility with current MCP spec
+- Transport type appropriate for the deployment model
+
+## Tool Stability
+
+- **Version consistency** -- semantic versioning (`vX.Y.Z` tags)
+- **Breaking change frequency** -- low frequency of breaking changes
+- **Backward compatibility** -- maintained across minor versions
+- **Tool signatures** -- tools don't disappear or change signatures unexpectedly
+
+## Code Quality
+
+- Automated tests with measurable coverage
+- Code linting and quality checks in CI/CD
+- Code review practices (branch protection, required reviews)
+- CI pipeline present and passing
+
+## Documentation
+
+- Clear README with setup/install instructions
+- API/tool documentation (what each tool does, inputs, outputs)
+- Deployment and operation guides
+- Documentation kept up to date with releases
+
+## Release Process
+
+- CI-based release automation (not manual artifact uploads)
+- Regular release cadence (no releases or meaningful commits in the last
+  6 months is a yellow flag)
+- Semantic versioning compliance
+- Maintained changelog (`CHANGELOG.md` or GitHub Releases with notes)
+
+## Verification Guide
+
+Use whichever tools are available -- `gh` CLI, GitHub MCP tools, or WebFetch.
+
+| Check | What to Look For | Where |
+|-------|------------------|-------|
+| License | SPDX identifier matches accepted list | Repo license endpoint, or `LICENSE` file |
+| Dependency automation | Dependabot OR Renovate configured | `.github/dependabot.yml`, `renovate.json`, `.renovaterc`, `.renovaterc.json`, `.github/renovate.json` |
+| Security policy | Incident reporting process exists | `SECURITY.md` in repo root |
+| CI/CD | Workflows exist and run | `.github/workflows/` directory; recent workflow runs |
+| Recent activity | Commits within last 6 months | Commit history (last 5-10 commits) |
+| Unanswered issues | Issues open >3 weeks with 0 comments | Open issues sorted by creation date |
+| Releases | Semver tags, changelog present | Releases list, tag names |
+| Provenance | Sigstore signatures or GitHub Attestations | Release artifacts, container image signatures |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,8 +68,10 @@ are a great place to start!
 - Once approved, all of your commits will be squashed into a single commit with
   your PR title.
 
-When adding a new MCP server to the registry, please review the
-[Registry Inclusion Criteria](docs/registry-criteria.md) before submitting.
+When adding a new entry to the registry, please review the
+[Registry Inclusion Criteria](docs/registry-criteria.md) before submitting,
+including the [MCP server criteria](docs/server-criteria.md) or the
+[skill criteria](docs/skill-criteria.md) as appropriate.
 
 ### Contributing to docs
 

--- a/README.md
+++ b/README.md
@@ -318,7 +318,9 @@ We evaluate submissions based on several criteria to ensure quality and usefulne
 - Follow security best practices
 - Be actively maintained with recent updates
 
-For detailed evaluation criteria, see the [Registry Inclusion Criteria](docs/registry-criteria.md).
+For detailed evaluation criteria, see the [Registry Inclusion Criteria](docs/registry-criteria.md),
+including [MCP server criteria](docs/server-criteria.md) and
+[skill criteria](docs/skill-criteria.md).
 
 ### Before Submitting, Please Ensure
 

--- a/docs/registry-criteria.md
+++ b/docs/registry-criteria.md
@@ -1,42 +1,68 @@
 # Registry Inclusion Criteria
 
-The ToolHive registry is a curated list of MCP servers that meet specific
-criteria. We aim to establish a community-auditable list of high-quality MCP
-servers through clear, observable, and objective criteria.
+The ToolHive registry is a curated list of MCP servers and skills that meet
+specific criteria. We aim to establish a community-auditable list of
+high-quality entries through clear, observable, and objective criteria.
 
-These criteria ensure that the servers in the registry meet the standards of
+These criteria ensure that entries in the registry meet the standards of
 security, quality, and usability that ToolHive aims to uphold.
+
+The registry accepts two types of entries:
+
+- **MCP servers** -- containerized or remote services that expose tools and
+  resources via the Model Context Protocol (MCP). See the
+  [MCP server criteria](server-criteria.md) for server-specific requirements.
+- **Skills** -- reusable prompts and workflows that leverage MCP server tools
+  to perform specific tasks. See the
+  [skill criteria](skill-criteria.md) for skill-specific requirements.
+
+This document covers the shared requirements and evaluation framework that
+apply to both entry types. The linked documents cover criteria specific to
+each type.
 
 ## Table of contents
 
 - [Contribute to the registry](#contribute-to-the-registry)
-- [Criteria for MCP servers](#criteria-for-mcp-servers)
+- [Key terms](#key-terms)
+- [Shared criteria](#shared-criteria)
   - [Open source requirements](#open-source-requirements)
   - [Acceptable licenses](#acceptable-licenses)
-  - [Security](#security)
-  - [Continuous integration](#continuous-integration)
-  - [API compliance](#api-compliance)
-  - [Tool stability](#tool-stability)
-  - [Code quality](#code-quality)
-  - [Documentation](#documentation)
-  - [Release process](#release-process)
+  - [Proprietary service references](#proprietary-service-references)
   - [Community health](#community-health)
-  - [Security requirements](#security-requirements)
 - [Evaluation framework](#evaluation-framework)
   - [Scoring system](#scoring-system)
   - [Tiered classifications](#tiered-classifications)
 
 ## Contribute to the registry
 
-If you have an MCP server that you'd like to add to the ToolHive registry, you
-can [open an issue](https://github.com/stacklok/toolhive-catalog/issues/new?template=add-an-mcp-server.md)
+If you have an MCP server or skill that you'd like to add to the ToolHive
+registry, you can
+[open an issue](https://github.com/stacklok/toolhive-catalog/issues/new)
 or submit a pull request. The ToolHive team will review your submission and
 consider adding it to the registry.
 
 For instructions on how to structure your submission, see the
-[README](../README.md#how-to-add-your-mcp-server).
+[README](../README.md). Automated validation is available:
 
-## Criteria for MCP servers
+- **MCP servers**: `task catalog:validate` checks server definitions.
+- **Skills**: `task catalog:validate` checks skill definitions, and
+  `thv skills validate` verifies compliance with the agent skill
+  specification.
+
+## Key terms
+
+| Term | Definition |
+|------|------------|
+| **MCP** | Model Context Protocol -- an open standard for connecting AI assistants to external tools and data sources. |
+| **OCI** | Open Container Initiative -- a set of standards for container image formats and distribution. Used as the canonical packaging format for skills in the catalog. |
+| **SLSA** | Supply chain Levels for Software Artifacts -- a framework for ensuring the integrity of software artifacts throughout the supply chain. |
+| **SBOM** | Software Bill of Materials -- a formal record of the components and dependencies in a piece of software. |
+| **Sigstore** | An open source project for signing, verifying, and protecting software supply chains. |
+| **Skill shadowing** | When a new version of a skill retains the same name and description but changes its behavior substantially, potentially in a malicious way. |
+
+## Shared criteria
+
+The following criteria apply to both MCP servers and skills.
 
 ### Open source requirements
 
@@ -51,76 +77,34 @@ For instructions on how to structure your submission, see the
 
 Licenses such as `Apache-2.0`, `MIT`, `BSD-2-Clause`, and `BSD-3-Clause` allow
 maximum flexibility for integration, modification, and redistribution with
-minimal restrictions, making MCP servers accessible across all project types and
+minimal restrictions, making entries accessible across all project types and
 commercial applications.
 
 **Excluded** (copyleft / restrictive):
 
 We exclude copyleft and restrictive licenses such as `AGPL-3.0`, `GPL-2.0`,
-`GPL-3.0`, and `LGPL-*` to ensure MCP servers can be freely integrated into
-various commercial and open source projects without legal complications or viral
-licensing requirements.
+`GPL-3.0`, and `LGPL-*` to ensure entries can be freely integrated into
+various commercial and open source projects without legal complications or
+viral licensing requirements.
 
 If the license is unclear or missing, we will request clarification from the
 submitter.
 
-### Security
+### Proprietary service references
 
-- Software provenance verification (Sigstore, GitHub Attestations).
-- SLSA compliance level assessment.
-- Pinned dependencies and GitHub Actions pinned to SHAs.
-- Published Software Bill of Materials (SBOMs).
-
-### Continuous integration
-
-- Automated dependency updates (Dependabot, Renovate, etc.).
-- Automated security scanning.
-- CVE monitoring.
-- Code linting and quality checks.
-
-### API compliance
-
-- Full MCP API specification support.
-- Implementation of all required endpoints (tools, resources, etc.).
-- Protocol version compatibility with the current MCP spec.
-- Transport type appropriate for the deployment model.
-
-### Tool stability
-
-- **Version consistency** -- semantic versioning (`vX.Y.Z` tags).
-- **Breaking change frequency** -- low frequency of breaking changes.
-- **Backward compatibility** -- maintained across minor versions.
-- **Tool signatures** -- tools don't disappear or change signatures
-  unexpectedly.
-
-### Code quality
-
-- Presence of automated tests with measurable coverage.
-- Quality CI/CD implementation.
-- Code linting and quality checks in CI.
-- Code review practices (branch protection, required reviews).
-
-### Documentation
-
-- Clear README with setup and install instructions.
-- API and tool documentation (what each tool does, inputs, outputs).
-- Deployment and operation guides.
-- Documentation kept up to date with releases.
-
-### Release process
-
-- CI-based release automation (not manual artifact uploads).
-- Regular release cadence (not stale for more than 6 months).
-- Semantic versioning compliance.
-- Maintained changelog (`CHANGELOG.md` or GitHub Releases with notes).
+Entries (both MCP servers and skills) may reference or integrate with
+proprietary services (e.g., GitHub, Stripe, Jira) provided the entry itself
+is published by the official vendor of that service. For example, a GitHub MCP
+server published by GitHub is acceptable, even though GitHub itself is not
+open source.
 
 ### Community health
 
 #### Responsiveness
 
-- **Issue response time**: issues open 3-4 weeks without any response is a red
-  flag.
-- Active bug resolution and resolution rate.
+- **Issue response time**: issues open for more than 3 weeks without any
+  response is a red flag.
+- Active bug triage and resolution rate.
 - PR review turnaround.
 - User support quality.
 
@@ -135,32 +119,13 @@ submitter.
 **Green flags**: regular commits, active issue triage, multiple contributors,
 good test coverage, clear documentation, organizational backing.
 
-**Yellow flags**: no activity for more than 6 months, many unanswered issues,
-missing tests, incomplete documentation, single maintainer with no org backing.
+**Yellow flags**: no releases or meaningful commits in the last 6 months, many
+unanswered issues, missing tests, incomplete documentation, single maintainer
+with no org backing.
 
-**Red flags**: copyleft license, no source code, known unpatched CVEs, abandoned
-project, no clear maintainer.
-
-### Security requirements
-
-#### Authentication and authorization
-
-- Secure authentication mechanisms.
-- Proper authorization controls.
-- Standard security protocol support (OAuth, TLS).
-- API keys and tokens marked as secret.
-
-#### Data protection
-
-- Encryption for data in transit (TLS for all external communication).
-- Proper sensitive information handling (secrets, tokens, and credentials
-  protected).
-
-#### Security practices
-
-- Security issue reporting mechanisms (`SECURITY.md` or equivalent).
-- Clear incident response channels.
-- No known unpatched critical or high CVEs.
+**Red flags**: copyleft or restricted license (see
+[Acceptable licenses](#acceptable-licenses)), no source code, known unpatched
+CVEs, abandoned project, no clear maintainer.
 
 ## Evaluation framework
 
@@ -175,27 +140,18 @@ The registry uses four severity levels to categorize criteria:
 | **Recommended** | Good practice indicators | Positive contribution to evaluation |
 | **Bonus** | Demonstrates excellence | No penalty for absence |
 
-The following table maps specific requirements to their severity levels:
+For the specific scoring tables, see:
 
-| Requirement | Severity |
-|-------------|----------|
-| Open source with public source code | Required |
-| Permissive license | Required |
-| Pinned dependencies / Actions pinned to SHAs | Required |
-| Secure auth mechanisms (OAuth, TLS, API keys marked secret) | Required |
-| Sensitive information handling | Required |
-| Encryption in transit (TLS) | Required |
-| No known unpatched critical/high CVEs | Required |
-| Software provenance (Sigstore / GitHub Attestations) | Expected |
-| Automated security scanning in CI | Expected |
-| SLSA compliance | Recommended |
-| Published SBOM | Recommended |
-| Security reporting (`SECURITY.md`) | Recommended |
+- [MCP server scoring](server-criteria.md#scoring)
+- [Skill scoring](skill-criteria.md#scoring)
 
 ### Tiered classifications
 
-- **Official** -- maintained by the MCP team or platform owners.
-- **Community** -- created and maintained by the community.
+- **Official** -- maintained by the ToolHive team, the MCP specification
+  authors, or the platform owners of the integrated service.
+- **Community** -- created and maintained by third-party contributors.
 
-Minimum threshold requirements (stars, maintainers, community indicators) and
-regular re-evaluation ensure entries continue to meet the criteria over time.
+Both tiers are subject to the same criteria. Community health signals (stars,
+active maintainers, community adoption) are evaluated during review and during
+periodic re-evaluation to ensure entries continue to meet the criteria over
+time.

--- a/docs/server-criteria.md
+++ b/docs/server-criteria.md
@@ -1,0 +1,115 @@
+# MCP Server Inclusion Criteria
+
+This document defines the criteria specific to MCP servers in the ToolHive
+registry. For shared criteria that apply to all registry entries (open source
+requirements, acceptable licenses, community health), see the
+[registry inclusion criteria](registry-criteria.md).
+
+An MCP server is a containerized or remote service that exposes tools and
+resources to AI assistants via the Model Context Protocol (MCP).
+
+## Table of contents
+
+- [Security](#security)
+- [Continuous integration](#continuous-integration)
+- [API compliance](#api-compliance)
+- [Tool stability](#tool-stability)
+- [Code quality](#code-quality)
+- [Documentation](#documentation)
+- [Release process](#release-process)
+- [Security requirements](#security-requirements)
+- [Scoring](#scoring)
+
+## Security
+
+- **Required** -- Pinned dependencies and GitHub Actions pinned to SHAs.
+- **Expected** -- Software provenance verification (Sigstore, GitHub
+  Attestations).
+- **Recommended** -- SLSA compliance level assessment.
+- **Recommended** -- Published Software Bill of Materials (SBOM).
+
+## Continuous integration
+
+- Automated dependency updates (Dependabot, Renovate, etc.).
+- Automated security scanning.
+- CVE monitoring.
+- Code linting and quality checks.
+
+## API compliance
+
+- Full MCP API specification support.
+- Implementation of all required endpoints (tools, resources, etc.).
+- Protocol version compatibility with the current MCP spec.
+- Transport type appropriate for the deployment model.
+
+## Tool stability
+
+- **Version consistency** -- semantic versioning (`vX.Y.Z` tags).
+- **Breaking change frequency** -- low frequency of breaking changes.
+- **Backward compatibility** -- maintained across minor versions.
+- **Tool signatures** -- tools don't disappear or change signatures
+  unexpectedly.
+
+## Code quality
+
+- Presence of automated tests with measurable coverage.
+- Quality CI/CD implementation.
+- Code linting and quality checks in CI.
+- Code review practices (branch protection, required reviews).
+
+## Documentation
+
+- Clear README with setup and install instructions.
+- API and tool documentation (what each tool does, inputs, outputs).
+- Deployment and operation guides.
+- Documentation kept up to date with releases.
+
+## Release process
+
+- CI-based release automation (not manual artifact uploads).
+- Regular release cadence (no releases or meaningful commits in the last
+  6 months is a yellow flag).
+- Semantic versioning compliance.
+- Maintained changelog (`CHANGELOG.md` or GitHub Releases with notes).
+
+## Security requirements
+
+### Authentication and authorization
+
+- Secure authentication mechanisms.
+- Proper authorization controls.
+- Standard security protocol support (OAuth, TLS).
+- API keys and tokens marked as secret.
+
+### Data protection
+
+- Encryption for data in transit (TLS for all external communication).
+- Proper sensitive information handling (secrets, tokens, and credentials
+  protected).
+
+### Security practices
+
+- Security issue reporting mechanisms (`SECURITY.md` or equivalent).
+- Clear incident response channels.
+- No known unpatched critical or high CVEs.
+
+## Scoring
+
+The following table maps specific requirements to their severity levels for
+MCP servers. See the [evaluation framework](registry-criteria.md#evaluation-framework)
+for an explanation of the severity levels.
+
+| Requirement | Severity |
+|-------------|----------|
+| Open source with public source code | Required |
+| Permissive license | Required |
+| Pinned dependencies / Actions pinned to SHAs | Required |
+| Secure auth mechanisms (OAuth, TLS, API keys marked secret) | Required |
+| Sensitive information handling | Required |
+| Encryption in transit (TLS) | Required |
+| No known unpatched critical/high CVEs | Required |
+| Software provenance (Sigstore / GitHub Attestations) | Expected |
+| Automated security scanning in CI | Expected |
+| SLSA compliance | Recommended |
+| Published SBOM | Recommended |
+| Security reporting (`SECURITY.md`) | Recommended |

--- a/docs/skill-criteria.md
+++ b/docs/skill-criteria.md
@@ -1,0 +1,207 @@
+# Skill Inclusion Criteria
+
+This document defines the criteria specific to skills in the ToolHive
+registry. For shared criteria that apply to all registry entries (open source
+requirements, acceptable licenses, community health), see the
+[registry inclusion criteria](registry-criteria.md).
+
+A skill is a reusable prompt or workflow that leverages MCP server tools to
+perform a specific task -- such as reviewing pull requests, triaging issues,
+or hardening CI pipelines. Skills bundle prompts, tool references, and
+optional scripts into a package that AI assistants can invoke.
+
+Because the skill ecosystem is still maturing, some criteria are intentionally
+relaxed compared to MCP servers. This document explains where the criteria
+align, where they differ, and the rationale behind each decision.
+
+## Table of contents
+
+- [MCP server dependencies](#mcp-server-dependencies)
+- [Specification compliance](#specification-compliance)
+- [Distribution and packaging](#distribution-and-packaging)
+- [Versioning](#versioning)
+- [Security and supply chain](#security-and-supply-chain)
+- [Skill stability](#skill-stability)
+- [Code quality](#code-quality)
+- [Documentation](#documentation)
+- [Release process](#release-process)
+- [Community health and repository signals](#community-health-and-repository-signals)
+- [Security requirements](#security-requirements)
+- [Scoring](#scoring)
+
+## MCP server dependencies
+
+If a skill declares a dependency on one or more MCP servers (via
+`allowedTools` or other configuration), every referenced MCP server **must**
+already be included in the ToolHive catalog. This is a hard requirement and a
+blocker for inclusion.
+
+- The dependency check is performed at submission time.
+- If the required MCP server is not yet in the catalog, the skill submission
+  will be rejected until the server is added.
+- This ensures that every skill in the catalog can be fully resolved and
+  installed from the catalog itself, without requiring external or unvetted
+  server dependencies.
+
+## Specification compliance
+
+- Skills **must** be fully compliant with the
+  [agent skill specification](https://github.com/anthropics/agent-skill-spec).
+- The `thv skills validate` command is used in CI to verify compliance
+  automatically.
+- Skills that fail validation are rejected.
+
+## Distribution and packaging
+
+The official ToolHive catalog requires OCI (Open Container Initiative) images
+as the canonical distribution format for all skills.
+
+- Skills **must** be published as OCI artifacts to be included in the catalog.
+- Git references are supported as a secondary distribution mechanism, but OCI
+  is the authoritative source for the catalog.
+- OCI distribution provides reproducibility, versioning, and supply chain
+  traceability that git references alone cannot guarantee.
+
+## Versioning
+
+- Skills **must** use a versioning scheme (semantic versioning preferred).
+- OCI images provide built-in versioning through container tags, which the
+  catalog leverages.
+- Git-only references without a versioning mechanism are problematic for
+  enterprise consumers and are not sufficient on their own.
+- Versions are used as container tags when the catalog CI builds OCI images.
+
+## Security and supply chain
+
+Security and CI requirements are **relaxed** for skills compared to MCP
+servers. The following items are recommended rather than required:
+
+- Software provenance verification (Sigstore, GitHub Attestations).
+- SLSA compliance level assessment.
+- Pinned dependencies and GitHub Actions pinned to SHAs.
+- Published Software Bill of Materials (SBOM).
+- Automated security scanning.
+- CVE monitoring.
+
+**Rationale**: The skill ecosystem is still emerging. Very few skill authors
+currently publish SBOMs, perform CVE monitoring, or follow SLSA compliance
+practices for skills. Enforcing these requirements today would exclude nearly
+all skill submissions and slow adoption. As the ecosystem matures and tooling
+improves, these requirements will be revisited and tightened.
+
+Skills can ship scripts (executable software), which is one of the motivations
+for requiring OCI distribution -- it provides a clearer supply chain boundary
+than raw git references.
+
+## Skill stability
+
+Skill stability is evaluated differently from MCP server tool stability.
+Skills are more free-form and do not expose the same kind of typed tool
+signatures that MCP servers do, making stability harder to measure
+programmatically.
+
+The primary concern is **skill shadowing** -- a new version of a skill that
+retains the same name and description but behaves in a fundamentally different
+or malicious way. Reviewers should watch for:
+
+- **Name/description consistency** -- a skill update that keeps the same
+  identity but changes its behavior substantially should be flagged for
+  closer review.
+- **Scope changes** -- new versions that request additional MCP server
+  dependencies or new tool permissions beyond the original scope.
+- **Behavioral drift** -- prompt changes that alter the skill's purpose in
+  ways not reflected by its metadata.
+
+## Code quality
+
+- Validation against the agent skill specification via `thv skills validate`.
+- Skill quality metrics are still being developed; both ToolHive and Anthropic
+  have validation tooling that is expected to converge.
+- Reviewers should evaluate the clarity and correctness of skill prompts,
+  proper use of tool references, and overall coherence of the skill's purpose.
+
+## Documentation
+
+- Clear README or description explaining what the skill does and how to use
+  it.
+- Documentation of required MCP server dependencies.
+- Explanation of any scripts or executable components included in the skill.
+- Documentation kept up to date with releases.
+
+## Release process
+
+- Git tags or another versioning mechanism are required.
+- Versions are used as container tags when the catalog CI builds OCI images.
+- Regular release cadence (no releases or meaningful commits in the last
+  6 months is a yellow flag).
+- Semantic versioning compliance is preferred.
+
+## Community health and repository signals
+
+Community health criteria for skills follow the same general framework as
+all registry entries (see
+[community health](registry-criteria.md#community-health)), with additional
+emphasis on repository-level signals that are particularly important for
+evaluating skills:
+
+- **Repository activity** -- regular commits and recent activity are strong
+  positive signals.
+- **Developer activity** -- active issue triage, PR reviews, and responsive
+  maintainers.
+- **Author reputation** -- skills from established organizations or known
+  maintainers carry more weight than submissions from newly created accounts.
+  A GitHub account created the same day as the submission is a red flag.
+- **Stars and community adoption** -- while not a hard requirement, these
+  indicators help gauge community trust.
+
+## Security requirements
+
+Skills share the same security principles as MCP servers for authentication,
+data protection, and security practices, but the enforcement level differs.
+
+### Authentication and authorization
+
+- Skills that interact with authenticated services should document the
+  required credentials clearly.
+- API keys and tokens referenced by the skill must be marked as secret.
+
+### Data protection
+
+- Skills should not embed or expose secrets, tokens, or credentials in their
+  prompts or scripts.
+
+### Security practices
+
+- Security issue reporting mechanisms (`SECURITY.md` or equivalent) are
+  recommended.
+- No known unpatched critical or high CVEs in any scripts or dependencies
+  shipped by the skill.
+
+## Scoring
+
+The following table maps specific requirements to their severity levels for
+skills. Key differences from MCP servers are noted in the rightmost column.
+See the [evaluation framework](registry-criteria.md#evaluation-framework)
+for an explanation of the severity levels.
+
+| Requirement | Severity | Difference from MCP servers |
+|-------------|----------|-----------------------------|
+| Open source with public source code | Required | -- |
+| Permissive license | Required | -- |
+| Agent skill specification compliance | Required | Skills only |
+| MCP server dependencies in catalog | Required | Skills only |
+| OCI distribution | Required | Skills only |
+| Versioning (tags or semantic versioning) | Required | Skills only |
+| No known unpatched critical/high CVEs | Required | -- |
+| Secure auth mechanisms (API keys marked secret) | Required | -- |
+| Sensitive information handling | Required | -- |
+| Repository activity and author reputation | Expected | Higher importance for skills |
+| Documentation of dependencies and usage | Expected | -- |
+| Pinned dependencies / Actions pinned to SHAs | Recommended | Required for MCP servers |
+| Software provenance (Sigstore / GitHub Attestations) | Recommended | Expected for MCP servers |
+| Automated security scanning in CI | Recommended | Expected for MCP servers |
+| CVE monitoring | Recommended | Implicit in MCP server CI requirements |
+| SLSA compliance | Recommended | -- |
+| Published SBOM | Recommended | -- |
+| Security reporting (`SECURITY.md`) | Recommended | -- |
+| Skill quality metrics and validation | Bonus | Skills only |


### PR DESCRIPTION
## Summary

- Splits `docs/registry-criteria.md` into three documents for better readability and navigation:
  - **`registry-criteria.md`** — shared criteria (open source, licenses, community health, evaluation framework, glossary)
  - **`server-criteria.md`** — MCP server-specific criteria with inline severity labels
  - **`skill-criteria.md`** — skill-specific criteria based on team alignment decisions
- Adds a **Key terms glossary** (MCP, OCI, SLSA, SBOM, Sigstore, skill shadowing)
- Documents **skill criteria decisions** from the Apr 15 meeting:
  - MCP server dependencies must be in catalog (Required blocker)
  - OCI distribution required as canonical format
  - Security/CI requirements relaxed to Recommended (ecosystem still maturing)
  - Skill shadowing documented as a review concern
  - Agent skill specification compliance required via `thv skills validate`
- Fixes vague thresholds, defines the proprietary service policy, and updates all cross-references

## Test plan

- [x] `task catalog:validate` passes
- [ ] Verify all internal markdown links resolve correctly
- [ ] Review skill criteria against meeting notes for completeness
- [ ] Confirm mcp-review skill references load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)