### PR TITLE
Add Elasticflow MCP server to catalog

### DIFF
--- a/registries/toolhive/servers/elasticflow/icon.svg
+++ b/registries/toolhive/servers/elasticflow/icon.svg
@@ -1,0 +1,10 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#2563eb"/>
+      <stop offset="100%" style="stop-color:#1d4ed8"/>
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" rx="8" fill="url(#bgGrad)"/>
+  <rect x="10" y="10" width="12" height="12" rx="3" fill="white"/>
+</svg>

--- a/registries/toolhive/servers/elasticflow/server.json
+++ b/registries/toolhive/servers/elasticflow/server.json
@@ -12,7 +12,7 @@
           "metadata": {
             "last_updated": "2026-04-15T00:00:00Z"
           },
-          "overview": "## Elasticflow MCP Server\n\nElasticflow is an AI-native workspace for business — a single place where AI agents and the team work together on structured data, documents, files, and live dashboards.\n\nThis remote MCP server exposes 46 tools across 5 surfaces (workspaces, tables, documents, files, interfaces) so any MCP client can read business data, produce durable artifacts, and publish results that the whole organization sees — not lose them in a chat thread.\n\n**Key capabilities**\n\n- **Durable artifacts, not chat messages.** Every table row, document, and dashboard an agent creates is a first-class object the team can open, edit, and share.\n- **Closed-loop operations.** Agents read live data, take action, produce artifacts, and the org sees results in the same workspace.\n- **Permissioned by design.** Fine-grained OAuth 2.1 scopes (read/write per resource type) let you delegate narrowly and safely.\n- **Modular install.** Use the full `/mcp` endpoint (46 tools) or scoped sub-servers (`/data`, `/content`, `/platform`) to stay under your client's tool limit.\n- **Enterprise-ready.** SOC 2 Type II, GDPR, AES-256 at rest, TLS 1.3, 99.9% uptime SLA.\n\n**Typical use cases**\n\n- Sales — maintain a live pipeline, enrich leads, generate weekly summaries, publish client portals\n- Legal — track contracts, monitor renewals, search NDAs for specific clauses\n- Marketing — run a campaign tracker, calculate CPL/CAC, auto-generate monthly reports\n- Finance — reconcile invoices, flag budget overruns, generate scheduled P&L summaries\n- HR — parse resumes into a candidate table, track hiring stages\n- Operations — manage inventory, suppliers, orders; publish fulfillment dashboards\n\nAuthentication is OAuth 2.1 with PKCE — no API keys or tokens to configure. Sign up at https://www.elasticflow.app.",
+          "overview": "One workspace where your AI agents and your team work together.\n\nConnect your AI assistant to Elasticflow and let it manage tables, write documents, upload files, and publish live dashboards — all within your team's shared workspace. Everything your agents produce is instantly available to the whole organization, not buried in a chat thread.\n\n**What you can do:**\n\n- Build and query structured data — sales pipelines, contract trackers, campaign analytics, inventory logs\n- Create rich documents — reports, proposals, legal summaries, meeting notes\n- Upload and organize files — contracts, NDAs, presentations, compliance docs\n- Publish live dashboards and client portals — no code required\n- Share results across your team — every action is visible, every output is reusable",
           "status": "Active",
           "tags": [
             "remote",
@@ -79,7 +79,7 @@
       }
     }
   },
-  "description": "AI-native workspace for business — tables, documents, files, and live dashboards via remote Streamable HTTP with OAuth 2.1",
+  "description": "AI-native team workspace — tables, documents, workflow automation, live dashboards & analytics",
   "icons": [
     {
       "mimeType": "image/svg+xml",

--- a/registries/toolhive/servers/elasticflow/server.json
+++ b/registries/toolhive/servers/elasticflow/server.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "io.github.stacklok": {
+        "https://mcp.elasticflow.app/mcp": {
+          "custom_metadata": {
+            "author": "Elasticflow",
+            "homepage": "https://www.elasticflow.app",
+            "license": "MIT"
+          },
+          "metadata": {
+            "last_updated": "2026-04-15T00:00:00Z"
+          },
+          "overview": "## Elasticflow MCP Server\n\nElasticflow is an AI-native workspace for business — a single place where AI agents and the team work together on structured data, documents, files, and live dashboards.\n\nThis remote MCP server exposes 46 tools across 5 surfaces (workspaces, tables, documents, files, interfaces) so any MCP client can read business data, produce durable artifacts, and publish results that the whole organization sees — not lose them in a chat thread.\n\n**Key capabilities**\n\n- **Durable artifacts, not chat messages.** Every table row, document, and dashboard an agent creates is a first-class object the team can open, edit, and share.\n- **Closed-loop operations.** Agents read live data, take action, produce artifacts, and the org sees results in the same workspace.\n- **Permissioned by design.** Fine-grained OAuth 2.1 scopes (read/write per resource type) let you delegate narrowly and safely.\n- **Modular install.** Use the full `/mcp` endpoint (46 tools) or scoped sub-servers (`/data`, `/content`, `/platform`) to stay under your client's tool limit.\n- **Enterprise-ready.** SOC 2 Type II, GDPR, AES-256 at rest, TLS 1.3, 99.9% uptime SLA.\n\n**Typical use cases**\n\n- Sales — maintain a live pipeline, enrich leads, generate weekly summaries, publish client portals\n- Legal — track contracts, monitor renewals, search NDAs for specific clauses\n- Marketing — run a campaign tracker, calculate CPL/CAC, auto-generate monthly reports\n- Finance — reconcile invoices, flag budget overruns, generate scheduled P&L summaries\n- HR — parse resumes into a candidate table, track hiring stages\n- Operations — manage inventory, suppliers, orders; publish fulfillment dashboards\n\nAuthentication is OAuth 2.1 with PKCE — no API keys or tokens to configure. Sign up at https://www.elasticflow.app.",
+          "status": "Active",
+          "tags": [
+            "remote",
+            "business",
+            "productivity",
+            "workspace",
+            "tables",
+            "documents",
+            "files",
+            "dashboards",
+            "oauth",
+            "streamable-http"
+          ],
+          "tier": "Community",
+          "tools": [
+            "mcp_workspaces_list",
+            "mcp_workspaces_get",
+            "mcp_workspaces_create",
+            "mcp_workspaces_update",
+            "mcp_tables_list_tables",
+            "mcp_tables_get_table",
+            "mcp_tables_list_column_types",
+            "mcp_tables_create_table",
+            "mcp_tables_update_table",
+            "mcp_tables_delete_table",
+            "mcp_tables_create_column",
+            "mcp_tables_update_column",
+            "mcp_tables_delete_column",
+            "mcp_tables_get_rows",
+            "mcp_tables_create_row",
+            "mcp_tables_update_cells",
+            "mcp_tables_delete_rows",
+            "mcp_tables_link_rows",
+            "mcp_tables_unlink_rows",
+            "mcp_documents_list",
+            "mcp_documents_read",
+            "mcp_documents_create",
+            "mcp_documents_update",
+            "mcp_documents_search",
+            "mcp_documents_patch",
+            "mcp_documents_append",
+            "mcp_documents_insert_image",
+            "mcp_documents_insert_file",
+            "mcp_documents_list_assets",
+            "mcp_documents_remove_asset",
+            "mcp_documents_replace_asset",
+            "mcp_files_list",
+            "mcp_files_get_metadata",
+            "mcp_files_get_content",
+            "mcp_files_upload",
+            "mcp_interfaces_list_projects",
+            "mcp_interfaces_get_project",
+            "mcp_interfaces_get_build_status",
+            "mcp_interfaces_get_build_logs",
+            "mcp_interfaces_discover_schema",
+            "mcp_interfaces_create_project",
+            "mcp_interfaces_update_project",
+            "mcp_interfaces_configure_access",
+            "mcp_interfaces_build",
+            "mcp_interfaces_publish",
+            "mcp_interfaces_rollback"
+          ]
+        }
+      }
+    }
+  },
+  "description": "AI-native workspace for business — tables, documents, files, and live dashboards via remote Streamable HTTP with OAuth 2.1",
+  "icons": [
+    {
+      "mimeType": "image/svg+xml",
+      "sizes": ["any"],
+      "src": "https://raw.githubusercontent.com/stacklok/toolhive-catalog/main/registries/toolhive/servers/elasticflow/icon.svg"
+    }
+  ],
+  "name": "io.github.stacklok/elasticflow",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.elasticflow.app/mcp"
+    }
+  ],
+  "title": "Elasticflow",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
## Summary

Adds **Elasticflow** to the ToolHive catalog as a remote MCP server (Streamable HTTP + OAuth 2.1).

- **Name:** `io.github.stacklok/elasticflow`
- **Title:** Elasticflow
- **Remote URL:** https://mcp.elasticflow.app/mcp
- **Transport:** streamable-http
- **Auth:** OAuth 2.1 with PKCE (no API keys)
- **Tier:** Community
- **Status:** Active
- **License:** MIT
- **Tools:** 46 across 5 surfaces (workspaces, tables, documents, files, interfaces)

## What Elasticflow is

Elasticflow is an AI-native workspace for business — a single place where AI agents and the team work together on structured data, documents, files, and live dashboards. The MCP server exposes that workspace so any MCP-compatible client (Claude, ChatGPT, Cursor, Cline, Copilot Studio, Amazon Q, Gemini, and others) can read business data, produce durable artifacts, and publish results the whole organization sees.

The server is already listed in the **Official MCP Registry** as `app.elasticflow/mcp` (v1.0.0).

## Files added

- `registries/toolhive/servers/elasticflow/server.json` — catalog entry following the upstream MCP `ServerJSON` schema with ToolHive `_meta` extensions (tier, status, tags, tools, custom_metadata)
- `registries/toolhive/servers/elasticflow/icon.svg` — logo

## Checklist

- [x] `server.json` uses the upstream MCP schema (`2025-12-11`)
- [x] `_meta.io.modelcontextprotocol.registry/publisher-provided.io.github.stacklok` extension key matches `remotes[0].url`
- [x] JSON is valid
- [x] Folder name is lowercase-hyphenated
- [x] Icon is provided alongside `server.json`
- [x] Server is public (no auth required to reach — OAuth kicks in on first tool call)

## Links

- Website: https://www.elasticflow.app
- GitHub: https://github.com/elasticflowapp/elasticflow-mcp
- Sign-up: https://p.elasticflow.app/signup-earlybirds
- Official MCP Registry listing: https://registry.modelcontextprotocol.io/v0.1/servers/app.elasticflow%2Fmcp/versions/1.0.0
