### PR TITLE
fix(deps): add regex versioning for toolhive-doc-mcp

### DIFF
--- a/registries/toolhive/servers/toolhive-doc-mcp/server.json
+++ b/registries/toolhive/servers/toolhive-doc-mcp/server.json
@@ -3,7 +3,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.stacklok": {
-        "ghcr.io/stackloklabs/toolhive-doc-mcp:v0.0.11-20260226": {
+        "ghcr.io/stackloklabs/toolhive-doc-mcp:v0.0.12-20260316": {
           "metadata": {
             "last_updated": "2026-04-14T03:03:54Z",
             "stars": 3
@@ -63,7 +63,7 @@
           "name": "OTEL_SERVICE_VERSION"
         }
       ],
-      "identifier": "ghcr.io/stackloklabs/toolhive-doc-mcp:v0.0.11-20260226",
+      "identifier": "ghcr.io/stackloklabs/toolhive-doc-mcp:v0.0.12-20260316",
       "registryType": "oci",
       "transport": {
         "type": "streamable-http",

--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,13 @@
       "automerge": true
     },
     {
+      "description": "Use regex versioning for date-suffixed image tags (semver+YYYYMMDD)",
+      "matchPackageNames": [
+        "ghcr.io/stackloklabs/toolhive-doc-mcp"
+      ],
+      "versioning": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)$"
+    },
+    {
       "description": "MCP Registry dependency updates",
       "matchPackageNames": [
         "github.com/modelcontextprotocol/registry"


### PR DESCRIPTION
## Summary
- Adds a Renovate package rule with regex versioning for `ghcr.io/stackloklabs/toolhive-doc-mcp` so the `vSEMVER-YYYYMMDD` tag format is correctly parsed and ordered
- Bumps toolhive-doc-mcp from `v0.0.11-20260226` to `v0.0.12-20260316`

## Context
Renovate's default Docker versioning treats the `-YYYYMMDD` suffix as a semver compatibility identifier, which prevents it from proposing updates across different date suffixes. The regex versioning rule maps the date to a `build` component so both semver bumps and date-only rebuilds are detected.

The same package rule should also be added to the infra repo's Renovate config.

## Test plan
- [x] `task catalog:validate` passes
- [ ] Verify Renovate picks up the new versioning on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)