### PR TITLE
feat: add skill-review skill for reviewing skill submissions

### DIFF
--- a/.claude/skills/skill-review/SKILL.md
+++ b/.claude/skills/skill-review/SKILL.md
@@ -1,0 +1,244 @@
+---
+name: skill-review
+description: >-
+  Review skill submissions and updates for compliance, security, and quality.
+  Use when evaluating skill.json files, SKILL.md content, PRs adding/updating skills,
+  or assessing skill changes in the ToolHive registry.
+  NOT for reviewing MCP server entries (use mcp-review) or creating new skills (use add-mcp-server).
+allowed-tools: Read Grep Glob Bash WebFetch
+---
+
+# Skill Submission Review
+
+You are an expert reviewer for the ToolHive Registry. Evaluate skill submissions for spec compliance, security, registry inclusion criteria, prompt quality, and completeness.
+
+For skill.json field specs, see [skill-json-spec.md](references/skill-json-spec.md).
+For registry inclusion criteria, see [registry-criteria.md](references/registry-criteria.md) and [skill-criteria.md](references/skill-criteria.md).
+
+## Review Workflow
+
+### Step 1: Identify Change Scope
+
+Determine what you're reviewing:
+
+- **New skill submission** -- Full review (spec + content + repository assessment + inclusion criteria)
+- **Version update** -- Focused review (changed fields, prompt diffs, scope changes, skill shadowing)
+- **Config change** -- Targeted review (just the changed aspects + security implications)
+
+### Step 2: Validate Directory Structure
+
+Check the skill directory at `registries/toolhive/skills/<name>/`:
+
+1. **Required files** -- `skill.json`, `icon.svg`, and `skill/SKILL.md` must all exist
+2. **Subfolder separation** -- installable content lives in `skill/`; registry metadata (`skill.json`, `icon.svg`) at root
+3. **No stray files** -- only recognized directories inside `skill/` (scripts/, references/, assets/)
+
+### Step 3: Validate skill.json
+
+Read the skill.json and check:
+
+1. **Required fields** -- `namespace`, `name`, `description`, `version`, `packages` all present
+2. **Name format** -- lowercase letters, numbers, hyphens only; matches directory name
+3. **Name consistency** -- `name` in skill.json matches `name` in SKILL.md frontmatter
+4. **Namespace** -- valid reverse-DNS (e.g., `io.github.stacklok`)
+5. **Version** -- semantic versioning format (e.g., `0.1.0`)
+6. **Packages** -- at least one entry with valid `registryType` (`oci` or `git`)
+7. **Subfolder path** -- `packages[].subfolder` ends with `/skill` (points to skill content, not root)
+8. **Icons** -- `icons` array present with `icon.svg` reference
+9. **allowedTools** -- if present, lists tools as `server/tool_name` format
+10. **No auto-populated fields** -- reject if `metadata` contains CI-populated data in new submissions
+
+Run `task catalog:validate` to catch schema-level issues.
+
+### Step 4: Validate SKILL.md Content
+
+Read `skill/SKILL.md` and evaluate:
+
+1. **Frontmatter** -- starts with `---` YAML delimiters; `name` field present and matches skill.json
+2. **Description** -- present, states WHAT the skill does and WHEN to use it
+3. **Role definition** -- body starts with clear expertise statement
+4. **Workflow structure** -- numbered steps, actionable instructions
+5. **Tool references** -- if the skill uses MCP tools, they are referenced by name
+6. **No embedded secrets** -- no API keys, tokens, or credentials in prompts or scripts
+7. **Length** -- SKILL.md under 500 lines; detailed content split to references/
+8. **Quality** -- prompts are clear, focused, and coherent; one skill does one thing well
+
+### Step 5: MCP Server Dependency Check
+
+If the skill declares `allowedTools` or references MCP servers:
+
+1. **Catalog presence** -- every referenced MCP server must already exist in `registries/toolhive/servers/`
+2. **Tool existence** -- verify referenced tools appear in the server's `_meta` extensions `tools` list
+3. **Scope appropriateness** -- tools requested match the skill's stated purpose
+
+```bash
+# Check if a referenced server exists
+ls registries/toolhive/servers/<server-name>/server.json
+# Check available tools for a server
+jq '.. | ._meta? // empty | .tools // empty' registries/toolhive/servers/<server-name>/server.json
+```
+
+### Step 6: Security Review
+
+**Must verify:**
+
+- [ ] No secrets, tokens, or credentials embedded in SKILL.md or scripts
+- [ ] API keys referenced by the skill are documented as requiring secret handling
+- [ ] Scripts (if any) don't contain hardcoded credentials or unsafe operations
+- [ ] No known unpatched critical/high CVEs in shipped dependencies
+- [ ] Scope is appropriate -- skill doesn't request more tools/permissions than needed
+
+**Recommended checks** (positive signals, not blockers):
+
+- [ ] Provenance configured (Sigstore or GitHub Attestations)
+- [ ] Pinned dependencies / Actions pinned to SHAs
+- [ ] Automated security scanning in CI
+- [ ] Security reporting mechanism (`SECURITY.md`)
+
+### Step 7: Repository Assessment (New Submissions)
+
+For new skills, assess the source repository against registry inclusion criteria.
+See [skill-criteria.md](references/skill-criteria.md) for the full checklist.
+
+**Critical checks** (use `gh` CLI, GitHub MCP tools, or WebFetch):
+
+1. **License** -- must be permissive (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause)
+2. **Dependency automation** -- Dependabot or Renovate configured
+3. **Security policy** -- check for `SECURITY.md`
+4. **CI workflows** -- list `.github/workflows/` contents; confirm CI runs
+5. **Recent activity** -- check last 5 commits for recency
+6. **Author reputation** -- GitHub account age; established org vs. new account (same-day creation is a red flag)
+7. **Releases** -- version tags present; changelog maintained
+
+**Inclusion criteria summary:**
+
+| Category | What to Check |
+|----------|---------------|
+| Open source | Public repo, permissive license |
+| Spec compliance | Agent skill specification compliance, validated by `thv skills validate` |
+| MCP dependencies | All referenced servers exist in catalog |
+| Distribution | OCI artifact published (Required); git ref acceptable as secondary |
+| Versioning | Semver tags, version in skill.json |
+| Security | No embedded secrets, auth mechanisms documented, no known CVEs |
+| Documentation | README, dependency docs, script explanations |
+| Community | Active repo, responsive maintainers, contributor diversity |
+
+### Step 8: Version Update / Skill Shadowing Review
+
+For updates to existing skills:
+
+1. **What changed?** -- diff skill.json and SKILL.md
+2. **Name/description consistency** -- same identity but substantially changed behavior? Flag for closer review
+3. **Scope creep** -- new MCP server dependencies or tool permissions beyond original scope?
+4. **Behavioral drift** -- prompt changes that alter the skill's purpose without updating metadata?
+5. **Version bumped** -- version in skill.json updated appropriately?
+6. **Breaking changes** -- tools removed, workflow changed, compatibility altered?
+
+Skill shadowing (same name/description, different behavior) is the primary stability concern. Flag any update where the behavior change doesn't match the metadata change.
+
+## Output Format
+
+```markdown
+## Skill Review
+
+**Skill**: <name>
+**Repository**: <url>
+**Verdict**: APPROVE / REQUEST_CHANGES / REJECT
+
+---
+
+### Inclusion Criteria
+
+| Criteria | Status | Notes |
+|----------|--------|-------|
+| Open Source | Pass/Fail | |
+| License | Pass/Fail | <license> |
+| Spec Compliance | Pass/Fail | |
+| MCP Dependencies | Pass/Fail/N/A | |
+| Distribution | Pass/Fail | |
+| Versioning | Pass/Fail | |
+| Security | Pass/Fail | |
+| Documentation | Pass/Fail | |
+| Community | Pass/Fail | |
+
+### Spec Compliance
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Required fields (skill.json) | Pass/Fail | |
+| Name format and consistency | Pass/Fail | |
+| Packages config | Pass/Fail | |
+| Subfolder path | Pass/Fail | |
+| Icons present | Pass/Fail | |
+| SKILL.md frontmatter | Pass/Fail | |
+| SKILL.md quality | Pass/Fail | |
+| No auto-populated fields | Pass/Fail | |
+
+### Security Review
+
+- [ ] No embedded secrets or credentials
+- [ ] Auth requirements documented
+- [ ] Scripts safe (if applicable)
+- [ ] No known CVEs in dependencies
+- [ ] Scope appropriate
+
+### Findings
+
+**Issues (must fix):**
+1. ...
+
+**Suggestions (optional):**
+1. ...
+
+---
+
+### Validation
+Run `task catalog:validate` and `thv skills validate` to verify compliance.
+```
+
+## Error Handling
+
+| Situation | Action |
+|-----------|--------|
+| Repository is private or inaccessible | Note it -- cannot verify inclusion criteria; ask submitter for evidence |
+| License file missing or ambiguous | Request clarification; do not assume permissive |
+| `gh` CLI errors or rate-limited | Fall back to WebFetch; note what couldn't be verified |
+| `task catalog:validate` fails | Report the exact error; it must pass before approval |
+| `thv skills validate` fails | Report the exact error; spec compliance is a hard requirement |
+| Referenced MCP server not in catalog | Hard blocker -- skill cannot be accepted until the server is added |
+| Unclear tool dependencies | Ask submitter to clarify which MCP servers/tools are needed |
+| SKILL.md exceeds 500 lines | Flag as needing content split to references/ |
+
+## Quick Reference
+
+### Valid Values
+
+| Field | Options |
+|-------|---------|
+| Status | `active`, `deprecated`, `archived` |
+| Registry type | `oci`, `git` |
+| Accepted licenses | `Apache-2.0`, `MIT`, `BSD-2-Clause`, `BSD-3-Clause` |
+| Rejected licenses | `AGPL-3.0`, `GPL-2.0`, `GPL-3.0`, `LGPL-*` |
+
+### Severity Levels (Skills vs Servers)
+
+| Requirement | Skill Severity | Server Severity |
+|-------------|---------------|-----------------|
+| Open source + permissive license | Required | Required |
+| Spec compliance | Required | Required |
+| No known CVEs | Required | Required |
+| Secure auth / sensitive info | Required | Required |
+| MCP deps in catalog | Required | N/A |
+| OCI distribution | Required | N/A |
+| Versioning | Required | Required |
+| Pinned deps / Actions | Recommended | Required |
+| Provenance | Recommended | Expected |
+| Security scanning | Recommended | Expected |
+
+### Workflow Commands
+
+```bash
+task catalog:validate                                                         # Validate all entries
+task catalog:build                                                            # Build registry
+jq '.data.skills[] | select(.name == "<name>")' build/toolhive/registry-upstream.json  # Check skill entry
+```

--- a/.claude/skills/skill-review/references/registry-criteria.md
+++ b/.claude/skills/skill-review/references/registry-criteria.md
@@ -1,0 +1,121 @@
+# ToolHive Registry Inclusion Criteria (Shared)
+
+Source: [docs/registry-criteria.md](../../../../docs/registry-criteria.md)
+
+For skill-specific criteria, see [skill-criteria.md](skill-criteria.md).
+
+## Table of Contents
+
+- [Open Source Standards](#open-source-standards)
+- [Licensing](#licensing)
+- [Evaluation Framework](#evaluation-framework)
+- [Security Standards](#security-standards)
+- [Code Quality and Testing](#code-quality-and-testing)
+- [Stability](#stability)
+- [Documentation](#documentation)
+- [Release Process](#release-process)
+- [Community and Responsiveness](#community-and-responsiveness)
+- [Verification How-Tos](#verification-how-tos)
+
+---
+
+## Open Source Standards
+
+- Source code **must** be publicly available -- no exceptions
+- Repository must be on a public hosting platform (GitHub, GitLab, etc.)
+
+## Licensing
+
+**Accepted** (permissive):
+- `Apache-2.0`, `MIT`, `BSD-2-Clause`, `BSD-3-Clause`
+
+**Rejected** (copyleft):
+- `AGPL-3.0`, `GPL-2.0`, `GPL-3.0`, `LGPL-*`
+
+If license is unclear or missing, request clarification from the submitter.
+
+## Evaluation Framework
+
+The registry uses four severity levels to categorize criteria:
+
+- **Required** -- Essential attributes; significant penalty if missing
+- **Expected** -- Typical of well-executed projects; moderate score impact if absent
+- **Recommended** -- Good practice indicators; positive contribution to evaluation
+- **Bonus** -- Demonstrates excellence; no penalty for absence
+
+## Security Standards
+
+| Requirement | Description | Severity |
+|-------------|-------------|----------|
+| Provenance | Sigstore or GitHub Attestations for release artifacts | Expected |
+| SLSA compliance | Supply chain security level assessment | Recommended |
+| Pinned dependencies | Lockfiles present; GitHub Actions pinned to SHAs | Required |
+| SBOM | Software Bill of Materials published in releases | Recommended |
+| Auth mechanisms | Secure auth/authz (OAuth, TLS, API keys marked secret) | Required |
+| Sensitive info handling | Secrets, tokens, and credentials properly protected | Required |
+| Encryption in transit | TLS for all external communication | Required |
+| Automated security scanning | Dedicated scanning in CI (not just CVE monitoring) | Expected |
+| Security reporting | SECURITY.md or equivalent incident response channel | Recommended |
+| No known CVEs | Dependencies free of unpatched critical/high CVEs | Required |
+
+## Code Quality and Testing
+
+- Automated tests with measurable coverage
+- Code linting and quality checks in CI/CD
+- Code review practices (branch protection, required reviews)
+- CI pipeline present and passing
+
+## Stability
+
+- **Version consistency** -- semantic versioning (vX.Y.Z tags)
+- **Breaking change frequency** -- low frequency of breaking changes
+- **Backward compatibility** -- maintained across minor versions
+
+## Documentation
+
+- Clear README with setup/install instructions
+- API/tool documentation (what each tool does, inputs, outputs)
+- Deployment and operation guides
+- Documentation kept up to date with releases
+
+## Release Process
+
+- CI-based release automation (not manual artifact uploads)
+- Regular release cadence (not stale for >6 months)
+- Semantic versioning compliance
+- Maintained changelog (CHANGELOG.md or GitHub Releases with notes)
+
+## Community and Responsiveness
+
+### Responsiveness
+- **Issue response time**: Issues open **3-4 weeks without any response is a red flag**
+- Active bug resolution and resolution rate
+- PR review turnaround
+- User support quality
+
+### Community Strength
+- Project backing -- individual vs. organizational
+- Number of active maintainers and contributor diversity
+- Corporate or foundation support
+- Governance model maturity (CODEOWNERS, CONTRIBUTING.md, clear decision-making)
+
+**Green flags**: Regular commits, active issue triage, multiple contributors, good test coverage, clear docs, organizational backing.
+
+**Yellow flags**: No activity >6 months, many unanswered issues, missing tests, incomplete docs, single maintainer with no org backing.
+
+**Red flags**: Copyleft license, no source code, known unpatched CVEs, abandoned project, no clear maintainer.
+
+## Verification Guide
+
+Use whichever tools are available -- `gh` CLI, GitHub MCP tools, or WebFetch.
+
+| Check | What to Look For | Where |
+|-------|------------------|-------|
+| License | SPDX identifier matches accepted list | Repo license endpoint, or `LICENSE` file |
+| Dependency automation | Dependabot OR Renovate configured | `.github/dependabot.yml`, `renovate.json`, `.renovaterc`, `.renovaterc.json`, `.github/renovate.json` |
+| Security policy | Incident reporting process exists | `SECURITY.md` in repo root |
+| CI/CD | Workflows exist and run | `.github/workflows/` directory; recent workflow runs |
+| Recent activity | Commits within last 6 months | Commit history (last 5-10 commits) |
+| Unanswered issues | Issues open >3-4 weeks with 0 comments | Open issues sorted by creation date |
+| Releases | Semver tags, changelog present | Releases list, tag names |
+| Provenance | Sigstore signatures or GitHub Attestations | Release artifacts, container image signatures |

--- a/.claude/skills/skill-review/references/skill-criteria.md
+++ b/.claude/skills/skill-review/references/skill-criteria.md
@@ -1,0 +1,123 @@
+# Skill Inclusion Criteria
+
+Source: [docs/skill-criteria.md](../../../../docs/skill-criteria.md)
+
+For shared criteria (open source, licensing, community health), see
+[registry-criteria.md](registry-criteria.md).
+
+## MCP Server Dependencies
+
+Every MCP server referenced by the skill (via `allowedTools` or other
+configuration) **must** already exist in the ToolHive catalog. This is a hard
+requirement and a blocker for inclusion.
+
+- Checked at submission time.
+- If the required server is not yet in catalog, the skill is rejected until the
+  server is added.
+
+## Specification Compliance
+
+- Skills **must** comply with the
+  [agent skill specification](https://github.com/anthropics/agent-skill-spec).
+- `thv skills validate` verifies compliance in CI.
+- Skills that fail validation are rejected.
+
+## Distribution and Packaging
+
+- Skills **must** be published as OCI artifacts (canonical format).
+- Git references are a secondary mechanism; OCI is authoritative.
+- OCI provides reproducibility, versioning, and supply chain traceability.
+
+## Versioning
+
+- Skills **must** use a versioning scheme (semantic versioning preferred).
+- OCI image tags provide versioning; git-only references without versioning are
+  insufficient.
+
+## Security and Supply Chain
+
+These items are **Recommended** for skills (relaxed from MCP servers):
+
+- Software provenance (Sigstore, GitHub Attestations)
+- SLSA compliance
+- Pinned dependencies / Actions pinned to SHAs
+- Published SBOM
+- Automated security scanning
+- CVE monitoring
+
+**Rationale**: The skill ecosystem is still maturing. Enforcing full
+server-level requirements would exclude nearly all current skill submissions.
+
+## Skill Stability
+
+Primary concern: **skill shadowing** -- a new version retains the same
+name/description but behaves differently or maliciously.
+
+Watch for:
+
+- **Name/description consistency** -- same identity, substantially changed
+  behavior.
+- **Scope changes** -- new versions requesting additional MCP server
+  dependencies or tool permissions.
+- **Behavioral drift** -- prompt changes that alter purpose without updating
+  metadata.
+
+## Code Quality
+
+- Validated via `thv skills validate`.
+- Reviewers evaluate clarity/correctness of prompts, proper tool references,
+  and overall coherence.
+
+## Documentation
+
+- Clear README or description explaining purpose and usage.
+- Documentation of required MCP server dependencies.
+- Explanation of any scripts or executable components.
+- Kept up to date with releases.
+
+## Community Health
+
+Same general framework as all registry entries, with emphasis on:
+
+- **Repository activity** -- regular commits, recent activity.
+- **Author reputation** -- established orgs carry more weight; same-day account
+  creation is a red flag.
+- **Stars and adoption** -- not a hard requirement but helpful signal.
+
+## Security Requirements
+
+### Authentication and Authorization
+- Skills interacting with authenticated services must document required
+  credentials clearly.
+- API keys and tokens must be marked as secret.
+
+### Data Protection
+- No embedded secrets, tokens, or credentials in prompts or scripts.
+
+### Security Practices
+- `SECURITY.md` or equivalent recommended.
+- No known unpatched critical/high CVEs in scripts or dependencies.
+
+## Scoring Table
+
+| Requirement | Severity | Difference from MCP servers |
+|-------------|----------|-----------------------------|
+| Open source with public source code | Required | -- |
+| Permissive license | Required | -- |
+| Agent skill specification compliance | Required | Skills only |
+| MCP server dependencies in catalog | Required | Skills only |
+| OCI distribution | Required | Skills only |
+| Versioning (tags or semantic versioning) | Required | Skills only |
+| No known unpatched critical/high CVEs | Required | -- |
+| Secure auth mechanisms (API keys marked secret) | Required | -- |
+| Sensitive information handling | Required | -- |
+| Repository activity and author reputation | Expected | Higher importance for skills |
+| Documentation of dependencies and usage | Expected | -- |
+| Pinned dependencies / Actions pinned to SHAs | Recommended | Required for MCP servers |
+| Software provenance (Sigstore / GitHub Attestations) | Recommended | Expected for MCP servers |
+| Automated security scanning in CI | Recommended | Expected for MCP servers |
+| CVE monitoring | Recommended | Implicit in MCP server CI requirements |
+| SLSA compliance | Recommended | -- |
+| Published SBOM | Recommended | -- |
+| Security reporting (`SECURITY.md`) | Recommended | -- |
+| Skill quality metrics and validation | Bonus | Skills only |

--- a/.claude/skills/skill-review/references/skill-json-spec.md
+++ b/.claude/skills/skill-review/references/skill-json-spec.md
@@ -1,0 +1,93 @@
+# Skill Field Reference
+
+Source: [docs/adding-skills-llm.md](../../../../docs/adding-skills-llm.md)
+
+## Directory Layout
+
+```
+registries/toolhive/skills/<skill-name>/
+├── skill.json          # Registry metadata (namespace, name, packages)
+├── icon.svg            # Visual icon
+└── skill/              # Installable content (only this gets installed)
+    ├── SKILL.md        # Skill prompt with YAML frontmatter
+    ├── scripts/        # Optional: executable code
+    ├── references/     # Optional: documentation loaded on demand
+    └── assets/         # Optional: templates, images, data files
+```
+
+`packages[].subfolder` in skill.json points to the `skill/` directory so only
+skill content is installed, not registry metadata.
+
+## skill.json Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `namespace` | string | Yes | Reverse-DNS namespace (e.g., `io.github.stacklok`). 3-128 chars. |
+| `name` | string | Yes | Skill identifier. 1-64 chars, pattern `^[a-z0-9][a-z0-9-]*[a-z0-9]$`. |
+| `description` | string | Yes | One-line description. 1-1024 chars. |
+| `version` | string | Yes | Semantic version (e.g., `0.1.0`). |
+| `status` | string | No | `active`, `deprecated`, or `archived`. Default: `active`. |
+| `title` | string | No | Human-readable display name. Max 100 chars. |
+| `license` | string | No | SPDX license identifier. Max 256 chars. |
+| `compatibility` | string | No | Environment requirements. Max 500 chars. |
+| `allowedTools` | string[] | No | Tools the skill uses (format: `server/tool_name`). Experimental. |
+| `repository` | object | No | Source repository (`url`, `type`). |
+| `icons` | array | No | Icon references (`src`, `type`). |
+| `packages` | array | Yes | Distribution packages. |
+| `metadata` | map | No | Official metadata from SKILL.md (auto-populated by CI). |
+| `_meta` | map | No | Extended metadata. |
+
+## SKILL.md Frontmatter Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Skill identifier (must match skill.json `name`). |
+| `description` | string | Yes | One-line description. |
+| `version` | string | No | Semantic version. |
+| `allowed-tools` | string[] | No | Tools the skill uses. |
+| `license` | string | No | SPDX license identifier. |
+| `compatibility` | string | No | Environment requirements. |
+| `metadata` | map | No | Additional key-value metadata. |
+
+## Package Types
+
+### Git (catalog-hosted skills)
+
+```json
+{
+  "registryType": "git",
+  "url": "https://github.com/stacklok/toolhive-catalog",
+  "ref": "main",
+  "subfolder": "registries/toolhive/skills/<skill-name>/skill"
+}
+```
+
+### OCI (independently published skills)
+
+```json
+{
+  "registryType": "oci",
+  "identifier": "ghcr.io/org/skill-name:v0.1.0"
+}
+```
+
+## Validation Rules
+
+| Rule | Description |
+|------|-------------|
+| Skill name | Lowercase letters, numbers, hyphens only (`^[a-z0-9][a-z0-9-]*[a-z0-9]$`) |
+| `name` match | skill.json `name` must match SKILL.md frontmatter `name` |
+| Required files | `skill.json`, `icon.svg`, and `skill/SKILL.md` must all exist |
+| SKILL.md format | Must start with YAML frontmatter (`---` delimiters) |
+| Frontmatter | `name` field is required in frontmatter |
+| JSON syntax | Valid JSON, 2-space indentation |
+| Version | Semantic version format (e.g., `0.1.0`) |
+| Subfolder | `packages[].subfolder` must end with `/skill` |
+
+## Validation Commands
+
+```bash
+task catalog:validate                                                         # Schema validation
+task catalog:build                                                            # Build registry
+jq '.data.skills[] | select(.name == "<name>")' build/toolhive/registry-upstream.json  # Check entry
+```


### PR DESCRIPTION
## Summary

- Adds a new `skill-review` Claude Code skill that reviews skill submissions to the ToolHive registry
- Mirrors the existing `mcp-review` skill structure but adapted for skill-specific concerns
- Includes reference docs for shared registry criteria, skill-specific criteria, and skill.json field specs

### Skill structure

| File | Purpose |
|------|---------|
| `SKILL.md` | 8-step review workflow (244 lines) |
| `references/registry-criteria.md` | Shared inclusion criteria |
| `references/skill-criteria.md` | Skill-specific scoring table |
| `references/skill-json-spec.md` | skill.json + SKILL.md field reference |

### Key skill-specific review areas (vs mcp-review)

- **MCP server dependency check** — verifies all referenced servers exist in catalog (hard blocker)
- **SKILL.md content quality** — prompt clarity, role definition, workflow coherence
- **Skill shadowing detection** — flags behavioral drift and scope creep in updates
- **Relaxed security severity** — pinned deps/provenance/scanning are Recommended (not Required/Expected as for servers)

## Test plan

- [ ] Verify `/skill-review` triggers correctly when reviewing a skill PR
- [ ] Verify it does NOT trigger for MCP server PRs (those should hit `/mcp-review`)
- [ ] Test against an existing skill entry (e.g., `code-review`) as a dry run
- [ ] Confirm output format matches the structured review template

🤖 Generated with [Claude Code](https://claude.com/claude-code)