### PR TITLE
feat(skills): add claude-api skill entry (OCI distribution)

### DIFF
--- a/registries/toolhive/skills/claude-api/icon.svg
+++ b/registries/toolhive/skills/claude-api/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="8 6 2 12 8 18"/><polyline points="16 6 22 12 16 18"/><line x1="13" y1="4" x2="11" y2="20"/></svg>

--- a/registries/toolhive/skills/claude-api/skill.json
+++ b/registries/toolhive/skills/claude-api/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "claude-api",
+  "title": "Claude API Skill",
+  "description": "Build apps with the Claude API or Anthropic SDK — covers tool use, streaming, batches, and agent SDK patterns. Packaged from the upstream anthropics/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/anthropics/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/claude-api:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/anthropics/skills",
+      "ref": "2c7ec5e78b8e5d43ea02e90bb8826f6b9f147b0c",
+      "subfolder": "skills/claude-api"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the Claude API skill to the ToolHive catalog. This is the first catalog entry to use an OCI package as its canonical distribution.

The skill content lives upstream at [anthropics/skills](https://github.com/anthropics/skills) and is packaged by [dockyard](https://github.com/stacklok/dockyard) to `ghcr.io/stacklok/dockyard/skills/claude-api:0.1.0` with:

- **Sigstore signature** (cosign keyless, `token.actions.githubusercontent.com`)
- **SPDX SBOM attestation** (actions/attest-sbom against skill source)
- **SLSA build provenance attestation** (actions/attest-build-provenance)
- **SCAI v0.3 security-scan attestation** (cisco-ai-skill-scanner, signed via `cosign attest`)

All four attestations are attached to the image digest and are verifiable with standard tools (`cosign verify-attestation`, `gh attestation verify`). This pipeline landed in stacklok/dockyard via PRs #462 and #463.

## Design choices

- **`registryType: oci` is primary.** OCI is the canonical distribution format per `docs/skill-criteria.md` and carries all the supply-chain metadata above.
- **A `registryType: git` package is listed as a commit-pinned fallback**, matching the `ref` that the OCI artifact was built from (`2c7ec5e78b8e5d43ea02e90bb8826f6b9f147b0c`), so consumers that want to pull source directly can do so.
- **No `allowedTools`.** The skill teaches Claude API / Anthropic SDK usage and does not depend on any MCP server tools, so it clears the skill-criteria.md "MCP dependencies in catalog" bar trivially.
- **No `skill/SKILL.md` subfolder.** The content is authoritatively in the OCI artifact; duplicating it here would risk skill shadowing and drift. The schema (`registry/types/data/skill.schema.json`) only requires `namespace`, `name`, `description`, `version` — verified locally.

## Validation

```
$ task catalog:validate
...
  loaded 4 skills
Registry "toolhive": all 112 servers and 4 skills valid (both formats)

$ task catalog:build
...
Built registry "toolhive": 112 entries

$ jq '.data.skills["claude-api"]' build/toolhive/registry-upstream.json
{
  "namespace": "io.github.stacklok",
  "name": "claude-api",
  ...
  "packages": [
    { "registryType": "oci", "identifier": "ghcr.io/stacklok/dockyard/skills/claude-api:0.1.0" },
    { "registryType": "git", "url": "https://github.com/anthropics/skills", "ref": "2c7ec5e...", "subfolder": "skills/claude-api" }
  ]
}

$ npx prettier --check registries/toolhive/skills/claude-api/
All matched files use Prettier code style!
```

OCI artifact confirmed published: `ghcr.io/stacklok/dockyard/skills/claude-api:0.1.0` digest `sha256:92bb79cb30ebdbd4dee92668bfc4ebd4b36ee8273653bc2978c020272d854ec0`.

## Test plan

- [ ] CI: validate + tests pass.
- [ ] `thv skills install ghcr.io/stacklok/dockyard/skills/claude-api:0.1.0` after merge — skill installs from the catalog OCI reference.
- [ ] `cosign verify-attestation --type spdxjson ghcr.io/stacklok/dockyard/skills/claude-api@<digest>` returns the SBOM attestation.
- [ ] `cosign verify-attestation --type https://in-toto.io/attestation/scai/v0.3 ghcr.io/stacklok/dockyard/skills/claude-api@<digest>` returns `SKILL_SECURITY_SCAN_PASSED` with `scanner: cisco-ai-skill-scanner`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)