### PR TITLE
feat(skills): add toolhive-cli-user skill entry (OCI distribution)

### DIFF
--- a/registries/toolhive/skills/toolhive-cli-user/icon.svg
+++ b/registries/toolhive/skills/toolhive-cli-user/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>

--- a/registries/toolhive/skills/toolhive-cli-user/skill.json
+++ b/registries/toolhive/skills/toolhive-cli-user/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "toolhive-cli-user",
+  "title": "ToolHive CLI User Guide",
+  "description": "Guide for using ToolHive CLI (thv) to run and manage MCP servers and skills. Covers server lifecycle, registry browsing, secrets management, client registration, groups, container builds, exports, permissions, network isolation, authentication, and skill management.",
+  "version": "0.3.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/stacklok/toolhive",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/toolhive/skills/toolhive-cli-user:v0.21.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/stacklok/toolhive",
+      "ref": "v0.21.0",
+      "subfolder": "skills/toolhive-cli-user"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Registers the **ToolHive CLI User Guide** skill. Content is packaged by the toolhive repo's own [skills-build-and-publish workflow](https://github.com/stacklok/toolhive/blob/main/.github/workflows/skills-build-and-publish.yml) and is re-tagged on each toolhive release.

| Field | Value |
|---|---|
| OCI | `ghcr.io/stacklok/toolhive/skills/toolhive-cli-user:v0.21.0` |
| Digest | `sha256:277e47f401d09c92f8a22f626d338391651861899d180bc924bb29e26a0f8804` |
| Skill version | `0.3.0` (per SKILL.md frontmatter) |
| Source | `github.com/stacklok/toolhive`, subfolder `skills/toolhive-cli-user` |

## Notes

- **Versioning.** The catalog's `version` field is the skill's own semver (`0.3.0`). The OCI tag (`v0.21.0`) tracks which toolhive release shipped that content. Both are accurate — they answer different questions.
- **Secondary git package** pinned to `v0.21.0` as a fallback for consumers that prefer source.
- **No `allowedTools`** — the skill uses the `thv` CLI, not MCP tools, so the skill-criteria.md "MCP dependencies in catalog" bar doesn't apply.
- **No `skill/SKILL.md` subfolder.** Content lives authoritatively in the OCI artifact; duplicating it here would risk shadowing/drift. The schema (`registry/types/data/skill.schema.json`) only requires `namespace`, `name`, `description`, `version` — verified locally.

## Validation

```
$ task catalog:validate
...
Registry "toolhive": all 112 servers and 4 skills valid (both formats)

$ task catalog:build
...
Built registry "toolhive": 112 entries

$ jq '.data.skills | map(select(.name == "toolhive-cli-user"))[0]' build/toolhive/registry-upstream.json
{
  "namespace": "io.github.stacklok",
  "name": "toolhive-cli-user",
  "version": "0.3.0",
  "packages": [
    { "registryType": "oci", "identifier": "ghcr.io/stacklok/toolhive/skills/toolhive-cli-user:v0.21.0" },
    { "registryType": "git", "url": "https://github.com/stacklok/toolhive", "ref": "v0.21.0", "subfolder": "skills/toolhive-cli-user" }
  ]
}

$ npx prettier --check registries/toolhive/skills/toolhive-cli-user/
All matched files use Prettier code style!
```

## Test plan

- [ ] CI: validate + tests pass.
- [ ] After merge: `thv skills install ghcr.io/stacklok/toolhive/skills/toolhive-cli-user:v0.21.0` installs from the catalog OCI reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)