### PR TITLE
feat(skills): add 15 Trail of Bits skill entries (OCI distribution)

### DIFF
--- a/registries/toolhive/skills/agentic-actions-auditor/icon.svg
+++ b/registries/toolhive/skills/agentic-actions-auditor/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><circle cx="11" cy="11" r="3"/><line x1="13.1" y1="13.1" x2="15.5" y2="15.5"/></svg>

--- a/registries/toolhive/skills/agentic-actions-auditor/skill.json
+++ b/registries/toolhive/skills/agentic-actions-auditor/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "agentic-actions-auditor",
+  "title": "Agentic Actions Auditor",
+  "description": "Audit GitHub Actions workflows for security vulnerabilities in AI agent integrations (Claude Code Action, Gemini CLI, Codex) — detects prompt injection, env-var intermediary patterns, and wildcard user allowlists. Packaged from the upstream trailofbits/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "CC-BY-SA-4.0",
+  "repository": {
+    "url": "https://github.com/trailofbits/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/agentic-actions-auditor:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/trailofbits/skills",
+      "ref": "e8cc5baf9329ccb491bfa200e82eacbac83b1ead",
+      "subfolder": "plugins/agentic-actions-auditor/skills/agentic-actions-auditor"
+    }
+  ]
+}

--- a/registries/toolhive/skills/codeql/icon.svg
+++ b/registries/toolhive/skills/codeql/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><circle cx="11" cy="11" r="3"/><line x1="13.1" y1="13.1" x2="15.5" y2="15.5"/></svg>

--- a/registries/toolhive/skills/codeql/skill.json
+++ b/registries/toolhive/skills/codeql/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "codeql",
+  "title": "CodeQL",
+  "description": "Scan a codebase for security vulnerabilities using CodeQL's interprocedural data flow and taint tracking — supports security-and-quality suites or high-precision findings, plus SARIF output handling. Packaged from the upstream trailofbits/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "CC-BY-SA-4.0",
+  "repository": {
+    "url": "https://github.com/trailofbits/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/codeql:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/trailofbits/skills",
+      "ref": "e8cc5baf9329ccb491bfa200e82eacbac83b1ead",
+      "subfolder": "plugins/static-analysis/skills/codeql"
+    }
+  ]
+}

--- a/registries/toolhive/skills/constant-time-analysis/icon.svg
+++ b/registries/toolhive/skills/constant-time-analysis/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><circle cx="11" cy="11" r="3"/><line x1="13.1" y1="13.1" x2="15.5" y2="15.5"/></svg>

--- a/registries/toolhive/skills/constant-time-analysis/skill.json
+++ b/registries/toolhive/skills/constant-time-analysis/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "constant-time-analysis",
+  "title": "Constant-Time Analysis",
+  "description": "Detect timing side-channels in cryptographic code — covers C, C++, Go, Rust, Swift, Java, Kotlin, C#, PHP, JS/TS, Python, and Ruby; flags division on secrets and secret-dependent branches. Packaged from the upstream trailofbits/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "CC-BY-SA-4.0",
+  "repository": {
+    "url": "https://github.com/trailofbits/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/constant-time-analysis:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/trailofbits/skills",
+      "ref": "e8cc5baf9329ccb491bfa200e82eacbac83b1ead",
+      "subfolder": "plugins/constant-time-analysis/skills/constant-time-analysis"
+    }
+  ]
+}

--- a/registries/toolhive/skills/differential-review/icon.svg
+++ b/registries/toolhive/skills/differential-review/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><circle cx="11" cy="11" r="3"/><line x1="13.1" y1="13.1" x2="15.5" y2="15.5"/></svg>

--- a/registries/toolhive/skills/differential-review/skill.json
+++ b/registries/toolhive/skills/differential-review/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "differential-review",
+  "title": "Differential Review",
+  "description": "Security-focused differential review of PRs, commits, and diffs — uses git history for context, calculates blast radius, checks test coverage, and flags security regressions. Packaged from the upstream trailofbits/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "CC-BY-SA-4.0",
+  "repository": {
+    "url": "https://github.com/trailofbits/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/differential-review:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/trailofbits/skills",
+      "ref": "e8cc5baf9329ccb491bfa200e82eacbac83b1ead",
+      "subfolder": "plugins/differential-review/skills/differential-review"
+    }
+  ]
+}

--- a/registries/toolhive/skills/fp-check/icon.svg
+++ b/registries/toolhive/skills/fp-check/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><circle cx="11" cy="11" r="3"/><line x1="13.1" y1="13.1" x2="15.5" y2="15.5"/></svg>

--- a/registries/toolhive/skills/fp-check/skill.json
+++ b/registries/toolhive/skills/fp-check/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "fp-check",
+  "title": "False Positive Check",
+  "description": "Systematically verify suspected security bugs to eliminate false positives — produces TRUE POSITIVE or FALSE POSITIVE verdicts with documented evidence per bug, with mandatory gate reviews. Packaged from the upstream trailofbits/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "CC-BY-SA-4.0",
+  "repository": {
+    "url": "https://github.com/trailofbits/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/fp-check:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/trailofbits/skills",
+      "ref": "e8cc5baf9329ccb491bfa200e82eacbac83b1ead",
+      "subfolder": "plugins/fp-check/skills/fp-check"
+    }
+  ]
+}

--- a/registries/toolhive/skills/insecure-defaults/icon.svg
+++ b/registries/toolhive/skills/insecure-defaults/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><circle cx="11" cy="11" r="3"/><line x1="13.1" y1="13.1" x2="15.5" y2="15.5"/></svg>

--- a/registries/toolhive/skills/insecure-defaults/skill.json
+++ b/registries/toolhive/skills/insecure-defaults/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "insecure-defaults",
+  "title": "Insecure Defaults Detector",
+  "description": "Detect fail-open insecure defaults — hardcoded secrets, weak auth, permissive security settings, and misconfigured environment variable handling that let apps run insecurely in production. Packaged from the upstream trailofbits/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "CC-BY-SA-4.0",
+  "repository": {
+    "url": "https://github.com/trailofbits/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/insecure-defaults:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/trailofbits/skills",
+      "ref": "e8cc5baf9329ccb491bfa200e82eacbac83b1ead",
+      "subfolder": "plugins/insecure-defaults/skills/insecure-defaults"
+    }
+  ]
+}

--- a/registries/toolhive/skills/property-based-testing/icon.svg
+++ b/registries/toolhive/skills/property-based-testing/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><circle cx="11" cy="11" r="3"/><line x1="13.1" y1="13.1" x2="15.5" y2="15.5"/></svg>

--- a/registries/toolhive/skills/property-based-testing/skill.json
+++ b/registries/toolhive/skills/property-based-testing/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "property-based-testing",
+  "title": "Property-Based Testing",
+  "description": "Property-based testing guidance across multiple languages and smart contracts — use when writing tests, designing features with serialization/validation/parsing, or when stronger coverage than example-based tests is needed. Packaged from the upstream trailofbits/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "CC-BY-SA-4.0",
+  "repository": {
+    "url": "https://github.com/trailofbits/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/property-based-testing:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/trailofbits/skills",
+      "ref": "e8cc5baf9329ccb491bfa200e82eacbac83b1ead",
+      "subfolder": "plugins/property-based-testing/skills/property-based-testing"
+    }
+  ]
+}

--- a/registries/toolhive/skills/sarif-parsing/icon.svg
+++ b/registries/toolhive/skills/sarif-parsing/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><circle cx="11" cy="11" r="3"/><line x1="13.1" y1="13.1" x2="15.5" y2="15.5"/></svg>

--- a/registries/toolhive/skills/sarif-parsing/skill.json
+++ b/registries/toolhive/skills/sarif-parsing/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "sarif-parsing",
+  "title": "SARIF Parsing",
+  "description": "Parse, filter, deduplicate, and convert SARIF files from CodeQL, Semgrep, and other scanners — for CI/CD integration and findings aggregation (does not run scans — pair with the codeql or semgrep skills for that). Packaged from the upstream trailofbits/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "CC-BY-SA-4.0",
+  "repository": {
+    "url": "https://github.com/trailofbits/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/sarif-parsing:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/trailofbits/skills",
+      "ref": "e8cc5baf9329ccb491bfa200e82eacbac83b1ead",
+      "subfolder": "plugins/static-analysis/skills/sarif-parsing"
+    }
+  ]
+}

--- a/registries/toolhive/skills/semgrep-rule-creator/icon.svg
+++ b/registries/toolhive/skills/semgrep-rule-creator/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><circle cx="11" cy="11" r="3"/><line x1="13.1" y1="13.1" x2="15.5" y2="15.5"/></svg>

--- a/registries/toolhive/skills/semgrep-rule-creator/skill.json
+++ b/registries/toolhive/skills/semgrep-rule-creator/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "semgrep-rule-creator",
+  "title": "Semgrep Rule Creator",
+  "description": "Create custom Semgrep rules for detecting security vulnerabilities, bug patterns, and code patterns — use when writing Semgrep rules or building tailored static analysis detections. Packaged from the upstream trailofbits/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "CC-BY-SA-4.0",
+  "repository": {
+    "url": "https://github.com/trailofbits/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/semgrep-rule-creator:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/trailofbits/skills",
+      "ref": "e8cc5baf9329ccb491bfa200e82eacbac83b1ead",
+      "subfolder": "plugins/semgrep-rule-creator/skills/semgrep-rule-creator"
+    }
+  ]
+}

--- a/registries/toolhive/skills/semgrep-rule-variant-creator/icon.svg
+++ b/registries/toolhive/skills/semgrep-rule-variant-creator/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><circle cx="11" cy="11" r="3"/><line x1="13.1" y1="13.1" x2="15.5" y2="15.5"/></svg>

--- a/registries/toolhive/skills/semgrep-rule-variant-creator/skill.json
+++ b/registries/toolhive/skills/semgrep-rule-variant-creator/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "semgrep-rule-variant-creator",
+  "title": "Semgrep Rule Variant Creator",
+  "description": "Port existing Semgrep rules to new target languages with test-driven validation — produces independent rule and test directories for each target language. Packaged from the upstream trailofbits/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "CC-BY-SA-4.0",
+  "repository": {
+    "url": "https://github.com/trailofbits/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/semgrep-rule-variant-creator:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/trailofbits/skills",
+      "ref": "e8cc5baf9329ccb491bfa200e82eacbac83b1ead",
+      "subfolder": "plugins/semgrep-rule-variant-creator/skills/semgrep-rule-variant-creator"
+    }
+  ]
+}

--- a/registries/toolhive/skills/semgrep/icon.svg
+++ b/registries/toolhive/skills/semgrep/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><circle cx="11" cy="11" r="3"/><line x1="13.1" y1="13.1" x2="15.5" y2="15.5"/></svg>

--- a/registries/toolhive/skills/semgrep/skill.json
+++ b/registries/toolhive/skills/semgrep/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "semgrep",
+  "title": "Semgrep",
+  "description": "Run Semgrep static analysis with parallel subagents — full ruleset or high-confidence security findings only; auto-detects Semgrep Pro for cross-file taint analysis across multi-language codebases. Packaged from the upstream trailofbits/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "CC-BY-SA-4.0",
+  "repository": {
+    "url": "https://github.com/trailofbits/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/semgrep:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/trailofbits/skills",
+      "ref": "e8cc5baf9329ccb491bfa200e82eacbac83b1ead",
+      "subfolder": "plugins/static-analysis/skills/semgrep"
+    }
+  ]
+}

--- a/registries/toolhive/skills/sharp-edges/icon.svg
+++ b/registries/toolhive/skills/sharp-edges/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><circle cx="11" cy="11" r="3"/><line x1="13.1" y1="13.1" x2="15.5" y2="15.5"/></svg>

--- a/registries/toolhive/skills/sharp-edges/skill.json
+++ b/registries/toolhive/skills/sharp-edges/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "sharp-edges",
+  "title": "Sharp Edges",
+  "description": "Identify error-prone APIs, dangerous configurations, and footgun designs — evaluates whether code follows 'secure by default' and 'pit of success' principles for API usability and crypto library ergonomics. Packaged from the upstream trailofbits/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "CC-BY-SA-4.0",
+  "repository": {
+    "url": "https://github.com/trailofbits/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/sharp-edges:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/trailofbits/skills",
+      "ref": "e8cc5baf9329ccb491bfa200e82eacbac83b1ead",
+      "subfolder": "plugins/sharp-edges/skills/sharp-edges"
+    }
+  ]
+}

--- a/registries/toolhive/skills/supply-chain-risk-auditor/icon.svg
+++ b/registries/toolhive/skills/supply-chain-risk-auditor/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><circle cx="11" cy="11" r="3"/><line x1="13.1" y1="13.1" x2="15.5" y2="15.5"/></svg>

--- a/registries/toolhive/skills/supply-chain-risk-auditor/skill.json
+++ b/registries/toolhive/skills/supply-chain-risk-auditor/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "supply-chain-risk-auditor",
+  "title": "Supply Chain Risk Auditor",
+  "description": "Audit a project's dependencies for supply-chain attack surface — flags libraries at heightened risk of exploitation or takeover based on health, maintainership, and activity signals. Packaged from the upstream trailofbits/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "CC-BY-SA-4.0",
+  "repository": {
+    "url": "https://github.com/trailofbits/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/supply-chain-risk-auditor:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/trailofbits/skills",
+      "ref": "e8cc5baf9329ccb491bfa200e82eacbac83b1ead",
+      "subfolder": "plugins/supply-chain-risk-auditor/skills/supply-chain-risk-auditor"
+    }
+  ]
+}

--- a/registries/toolhive/skills/variant-analysis/icon.svg
+++ b/registries/toolhive/skills/variant-analysis/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><circle cx="11" cy="11" r="3"/><line x1="13.1" y1="13.1" x2="15.5" y2="15.5"/></svg>

--- a/registries/toolhive/skills/variant-analysis/skill.json
+++ b/registries/toolhive/skills/variant-analysis/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "variant-analysis",
+  "title": "Variant Analysis",
+  "description": "Find similar vulnerabilities and bugs across a codebase after an initial finding — pattern-based analysis for hunting variants, building CodeQL/Semgrep queries, and systematic code audits. Packaged from the upstream trailofbits/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "CC-BY-SA-4.0",
+  "repository": {
+    "url": "https://github.com/trailofbits/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/variant-analysis:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/trailofbits/skills",
+      "ref": "e8cc5baf9329ccb491bfa200e82eacbac83b1ead",
+      "subfolder": "plugins/variant-analysis/skills/variant-analysis"
+    }
+  ]
+}

--- a/registries/toolhive/skills/yara-rule-authoring/icon.svg
+++ b/registries/toolhive/skills/yara-rule-authoring/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><circle cx="11" cy="11" r="3"/><line x1="13.1" y1="13.1" x2="15.5" y2="15.5"/></svg>

--- a/registries/toolhive/skills/yara-rule-authoring/skill.json
+++ b/registries/toolhive/skills/yara-rule-authoring/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "yara-rule-authoring",
+  "title": "YARA Rule Authoring",
+  "description": "Author high-quality YARA-X detection rules for malware identification — covers naming conventions, string selection, performance optimization, migration from legacy YARA, and false-positive reduction. Packaged from the upstream trailofbits/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "CC-BY-SA-4.0",
+  "repository": {
+    "url": "https://github.com/trailofbits/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/yara-rule-authoring:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/trailofbits/skills",
+      "ref": "e8cc5baf9329ccb491bfa200e82eacbac83b1ead",
+      "subfolder": "plugins/yara-authoring/skills/yara-rule-authoring"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds 15 security-focused agent skills from [`trailofbits/skills`](https://github.com/trailofbits/skills) to the ToolHive catalog. Content is CC-BY-SA-4.0, pinned upstream to commit [`e8cc5ba`](https://github.com/trailofbits/skills/commit/e8cc5baf9329ccb491bfa200e82eacbac83b1ead) and packaged by Dockyard (see [stacklok/dockyard#466](https://github.com/stacklok/dockyard/pull/466)) to `ghcr.io/stacklok/dockyard/skills/<name>:0.1.0` with Sigstore signatures, SPDX SBOM, SLSA build provenance, and a Cisco AI Defense skill-scanner SCAI v0.3 security-scan attestation on each artifact.

Follows the OCI-distribution pattern established by [PR #1093 (claude-api)](https://github.com/stacklok/toolhive-catalog/pull/1093) and [PR #1094 (toolhive-cli-user)](https://github.com/stacklok/toolhive-catalog/pull/1094).

### Skills added

**Security analysis**
- `agentic-actions-auditor` — audits GitHub Actions workflows for AI-agent security holes (prompt injection, env-var intermediary, wildcard allowlists)
- `codeql`, `semgrep`, `sarif-parsing` — classic SAST tooling from the upstream `static-analysis` plugin
- `semgrep-rule-creator`, `semgrep-rule-variant-creator` — authoring/porting custom Semgrep rules

**Supply chain and defensive review**
- `supply-chain-risk-auditor` — dependency takeover/exploitation risk
- `insecure-defaults` — fail-open configurations and hardcoded secrets
- `sharp-edges` — footgun APIs and dangerous defaults
- `fp-check` — false-positive verification with mandatory gate reviews
- `differential-review` — security-focused PR/commit review
- `variant-analysis` — finding bug variants across a codebase

**Cryptographic verification**
- `constant-time-analysis` — timing side-channels across 12 languages
- `property-based-testing` — PBT guidance across multiple languages

**Malware analysis**
- `yara-rule-authoring` — YARA-X detection rule authoring

### Notes for review

- **License: `CC-BY-SA-4.0`.** Upstream picked CC-BY-SA because `SKILL.md` files are prose, not code. Not one of the permissive licenses explicitly listed in [`docs/skill-criteria.md`](docs/skill-criteria.md) (Apache/MIT/BSD), but also not on the excluded list (GPL/AGPL/LGPL). Flagging for reviewer judgment — happy to revisit scope if the call is that CC-BY-SA is a blocker.
- **`zeroize-audit` intentionally excluded.** The 16th skill in the dockyard batch requires `mcp__serena__*` tools, and Serena is not yet in the catalog. Per skill-criteria.md that's a hard blocker; Serena-as-a-server is a separate thread (upstream container is SSE-only, experimental, and `:latest`-tagged; the PyPI route has an executable-name mismatch with dockhand). Will revisit.
- **No `allowedTools`.** Every included skill uses only Claude Code built-in tools (Read, Grep, Glob, Bash, Task, AskUserQuestion, etc.), which are out of scope for the "MCP dependencies in catalog" bar.
- **No `skill/SKILL.md` subfolder.** Following the `claude-api` / `toolhive-cli-user` precedent — OCI is authoritative, duplicating SKILL.md risks shadowing and drift. Git fallback package is commit-pinned.
- **Icons.** All 15 use the same shield+magnifier SVG (thematic for security audit). Happy to differentiate if reviewers prefer per-skill iconography.

## Test plan

- [x] `task catalog:validate` — 20 skills total, all valid
- [x] `task catalog:build` — all 15 present under `data.skills` in `build/toolhive/registry-upstream.json`
- [x] `npx prettier --check` on all new `skill.json` files — passes
- [ ] `task catalog:validate` in CI
- [ ] Post-merge: skills appear in the published `registry-upstream.json` feed

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)