### PR TITLE
feat(server): add Pinecone MCP server

### DIFF
--- a/registries/official/servers/pinecone/icon.svg
+++ b/registries/official/servers/pinecone/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none"><path d="M16 3L8 11L16 19L24 11L16 3Z" fill="#030303"/><path d="M16 13L10 19L16 25L22 19L16 13Z" fill="#030303"/><path d="M16 22L12 26L16 30L20 26L16 22Z" fill="#030303"/></svg>

--- a/registries/official/servers/pinecone/server.json
+++ b/registries/official/servers/pinecone/server.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "io.github.stacklok": {
+        "ghcr.io/stacklok/dockyard/npx/pinecone-mcp:0.2.1": {
+          "custom_metadata": {
+            "author": "Pinecone",
+            "homepage": "https://docs.pinecone.io/guides/operations/mcp-server"
+          },
+          "overview": "## Pinecone MCP Server\n\nThe Pinecone MCP server enables AI assistants and agents to interact with Pinecone — the managed vector database — for semantic search, retrieval-augmented generation, and document Q&A workflows. It exposes tools to list and describe indexes, provision new integrated-embedding indexes, upsert records with automatic embedding, perform text-based semantic search with filtering and reranking, run cross-index cascading searches with deduplication, and query the official Pinecone documentation. The server supports integrated indexes (Pinecone-hosted embedding models); for standard indexes with external embeddings, use the Pinecone CLI instead.",
+          "permissions": {
+            "network": {
+              "outbound": {
+                "allow_host": [
+                  ".pinecone.io"
+                ],
+                "allow_port": [
+                  443
+                ]
+              }
+            }
+          },
+          "provenance": {
+            "cert_issuer": "https://token.actions.githubusercontent.com",
+            "repository_uri": "https://github.com/stacklok/dockyard",
+            "runner_environment": "github-hosted",
+            "signer_identity": "/.github/workflows/build-containers.yml",
+            "sigstore_url": "tuf-repo-cdn.sigstore.dev"
+          },
+          "status": "Active",
+          "tags": [
+            "vector-database",
+            "pinecone",
+            "semantic-search",
+            "rag",
+            "embeddings",
+            "ai"
+          ],
+          "tier": "Official",
+          "tools": [
+            "search-docs",
+            "list-indexes",
+            "describe-index",
+            "describe-index-stats",
+            "create-index-for-model",
+            "upsert-records",
+            "search-records",
+            "cascading-search",
+            "rerank-documents"
+          ]
+        }
+      }
+    }
+  },
+  "description": "Model Context Protocol server for Pinecone vector database and documentation search",
+  "icons": [
+    {
+      "mimeType": "image/svg+xml",
+      "sizes": [
+        "any"
+      ],
+      "src": "https://raw.githubusercontent.com/stacklok/toolhive-registry/main/registries/toolhive/servers/pinecone/icon.svg"
+    }
+  ],
+  "name": "io.github.stacklok/pinecone",
+  "packages": [
+    {
+      "environmentVariables": [
+        {
+          "description": "Pinecone API key for authentication. Without it, only the search-docs tool is available; with a valid key the server exposes all nine index and search tools.",
+          "isRequired": false,
+          "isSecret": true,
+          "name": "PINECONE_API_KEY"
+        }
+      ],
+      "identifier": "ghcr.io/stacklok/dockyard/npx/pinecone-mcp:0.2.1",
+      "registryType": "oci",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ],
+  "repository": {
+    "source": "github",
+    "url": "https://github.com/pinecone-io/pinecone-mcp"
+  },
+  "title": "Pinecone",
+  "version": "1.0.0"
+}

--- a/registries/toolhive/servers/pinecone/icon.svg
+++ b/registries/toolhive/servers/pinecone/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none"><path d="M16 3L8 11L16 19L24 11L16 3Z" fill="#030303"/><path d="M16 13L10 19L16 25L22 19L16 13Z" fill="#030303"/><path d="M16 22L12 26L16 30L20 26L16 22Z" fill="#030303"/></svg>

--- a/registries/toolhive/servers/pinecone/server.json
+++ b/registries/toolhive/servers/pinecone/server.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "io.github.stacklok": {
+        "ghcr.io/stacklok/dockyard/npx/pinecone-mcp:0.2.1": {
+          "custom_metadata": {
+            "author": "Pinecone",
+            "homepage": "https://docs.pinecone.io/guides/operations/mcp-server"
+          },
+          "overview": "## Pinecone MCP Server\n\nThe Pinecone MCP server enables AI assistants and agents to interact with Pinecone — the managed vector database — for semantic search, retrieval-augmented generation, and document Q&A workflows. It exposes tools to list and describe indexes, provision new integrated-embedding indexes, upsert records with automatic embedding, perform text-based semantic search with filtering and reranking, run cross-index cascading searches with deduplication, and query the official Pinecone documentation. The server supports integrated indexes (Pinecone-hosted embedding models); for standard indexes with external embeddings, use the Pinecone CLI instead.",
+          "permissions": {
+            "network": {
+              "outbound": {
+                "allow_host": [
+                  ".pinecone.io"
+                ],
+                "allow_port": [
+                  443
+                ]
+              }
+            }
+          },
+          "provenance": {
+            "cert_issuer": "https://token.actions.githubusercontent.com",
+            "repository_uri": "https://github.com/stacklok/dockyard",
+            "runner_environment": "github-hosted",
+            "signer_identity": "/.github/workflows/build-containers.yml",
+            "sigstore_url": "tuf-repo-cdn.sigstore.dev"
+          },
+          "status": "Active",
+          "tags": [
+            "vector-database",
+            "pinecone",
+            "semantic-search",
+            "rag",
+            "embeddings",
+            "ai"
+          ],
+          "tier": "Official",
+          "tools": [
+            "search-docs",
+            "list-indexes",
+            "describe-index",
+            "describe-index-stats",
+            "create-index-for-model",
+            "upsert-records",
+            "search-records",
+            "cascading-search",
+            "rerank-documents"
+          ]
+        }
+      }
+    }
+  },
+  "description": "Model Context Protocol server for Pinecone vector database and documentation search",
+  "icons": [
+    {
+      "mimeType": "image/svg+xml",
+      "sizes": [
+        "any"
+      ],
+      "src": "https://raw.githubusercontent.com/stacklok/toolhive-registry/main/registries/toolhive/servers/pinecone/icon.svg"
+    }
+  ],
+  "name": "io.github.stacklok/pinecone",
+  "packages": [
+    {
+      "environmentVariables": [
+        {
+          "description": "Pinecone API key for authentication. Without it, only the search-docs tool is available; with a valid key the server exposes all nine index and search tools.",
+          "isRequired": false,
+          "isSecret": true,
+          "name": "PINECONE_API_KEY"
+        }
+      ],
+      "identifier": "ghcr.io/stacklok/dockyard/npx/pinecone-mcp:0.2.1",
+      "registryType": "oci",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ],
+  "repository": {
+    "source": "github",
+    "url": "https://github.com/pinecone-io/pinecone-mcp"
+  },
+  "title": "Pinecone",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
Adds the Pinecone MCP server (`@pinecone-database/mcp` v0.2.1) to both the **Official** and **ToolHive** tiers. Pinecone publishes the server themselves, qualifying for Official tier.

### Tools exposed (9)
- `search-docs` — query official Pinecone docs (works without auth)
- `list-indexes`, `describe-index`, `describe-index-stats`
- `create-index-for-model` — provision integrated-embedding indexes
- `upsert-records`, `search-records`
- `cascading-search` — cross-index dedup + rerank
- `rerank-documents` — standalone reranking

Without `PINECONE_API_KEY` only `search-docs` is exposed; with a valid key the server exposes all nine tools.

### Links
- Package: https://www.npmjs.com/package/@pinecone-database/mcp
- Source: https://github.com/pinecone-io/pinecone-mcp
- Docs: https://docs.pinecone.io/guides/operations/mcp-server
- Dockyard packaging PR: [stacklok/dockyard#509](https://github.com/stacklok/dockyard/pull/509)
  - Published container will be `ghcr.io/stacklok/dockyard/npx/pinecone-mcp:0.2.1`

### Unblocks

With Pinecone MCP in the catalog, three Pinecone skills from [`pinecone-io/skills`](https://github.com/pinecone-io/skills) that hard-depend on it (`pinecone-mcp`, `pinecone-query`, `pinecone-quickstart`) become eligible for packaging into dockyard skills per [`skill-criteria.md`](docs/skill-criteria.md#mcp-server-dependencies).

### Test plan
- [x] `task catalog:validate` passes (both `toolhive` and `official` registries, both formats)
- [ ] CI validation passes