### PR TITLE
feat(skills): add 4 Google Gemini skill entries (OCI distribution)

### DIFF
--- a/registries/toolhive/skills/gemini-api-dev/icon.svg
+++ b/registries/toolhive/skills/gemini-api-dev/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2 L14 10 L22 12 L14 14 L12 22 L10 14 L2 12 L10 10 Z"/></svg>

--- a/registries/toolhive/skills/gemini-api-dev/skill.json
+++ b/registries/toolhive/skills/gemini-api-dev/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "gemini-api-dev",
+  "title": "Gemini API Development Skill",
+  "description": "Build applications with Gemini models and the Gemini API — covers multimodal content, function calling, structured outputs, and current model and SDK guidance. Packaged from the upstream google-gemini/gemini-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/google-gemini/gemini-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/gemini-api-dev:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/google-gemini/gemini-skills",
+      "ref": "5b655a47ac6d03a2d96d6e64ca051b6a7fe62296",
+      "subfolder": "skills/gemini-api-dev"
+    }
+  ]
+}

--- a/registries/toolhive/skills/gemini-interactions-api/icon.svg
+++ b/registries/toolhive/skills/gemini-interactions-api/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2 L14 10 L22 12 L14 14 L12 22 L10 14 L2 12 L10 10 Z"/></svg>

--- a/registries/toolhive/skills/gemini-interactions-api/skill.json
+++ b/registries/toolhive/skills/gemini-interactions-api/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "gemini-interactions-api",
+  "title": "Gemini Interactions API Skill",
+  "description": "Call the Gemini Interactions API for text, chat, multimodal understanding, image generation, streaming, background research, function calling, and structured output — the recommended way to use Gemini models and agents. Packaged from the upstream google-gemini/gemini-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/google-gemini/gemini-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/gemini-interactions-api:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/google-gemini/gemini-skills",
+      "ref": "5b655a47ac6d03a2d96d6e64ca051b6a7fe62296",
+      "subfolder": "skills/gemini-interactions-api"
+    }
+  ]
+}

--- a/registries/toolhive/skills/gemini-live-api-dev/icon.svg
+++ b/registries/toolhive/skills/gemini-live-api-dev/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2 L14 10 L22 12 L14 14 L12 22 L10 14 L2 12 L10 10 Z"/></svg>

--- a/registries/toolhive/skills/gemini-live-api-dev/skill.json
+++ b/registries/toolhive/skills/gemini-live-api-dev/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "gemini-live-api-dev",
+  "title": "Gemini Live API Development Skill",
+  "description": "Build real-time, bidirectional streaming applications with the Gemini Live API — WebSocket audio/video/text streaming, voice activity detection, native audio, function calling, session management, and ephemeral tokens for client-side auth. Packaged from the upstream google-gemini/gemini-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/google-gemini/gemini-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/gemini-live-api-dev:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/google-gemini/gemini-skills",
+      "ref": "5b655a47ac6d03a2d96d6e64ca051b6a7fe62296",
+      "subfolder": "skills/gemini-live-api-dev"
+    }
+  ]
+}

--- a/registries/toolhive/skills/vertex-ai-api-dev/icon.svg
+++ b/registries/toolhive/skills/vertex-ai-api-dev/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2 L14 10 L22 12 L14 14 L12 22 L10 14 L2 12 L10 10 Z"/></svg>

--- a/registries/toolhive/skills/vertex-ai-api-dev/skill.json
+++ b/registries/toolhive/skills/vertex-ai-api-dev/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "vertex-ai-api-dev",
+  "title": "Vertex AI API Development Skill",
+  "description": "Use the Gemini API on Google Cloud Vertex AI with the unified Gen AI SDK — Live API, function calling, structured output, context caching, embeddings, and batch prediction for enterprise workloads. Packaged from the upstream google-gemini/gemini-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/google-gemini/gemini-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/vertex-ai-api-dev:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/google-gemini/gemini-skills",
+      "ref": "5b655a47ac6d03a2d96d6e64ca051b6a7fe62296",
+      "subfolder": "skills/vertex-ai-api-dev"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the 4-skill Google Gemini pack from [`google-gemini/gemini-skills`](https://github.com/google-gemini/gemini-skills) to the ToolHive catalog. Content is Apache-2.0, pinned upstream to commit [`5b655a4`](https://github.com/google-gemini/gemini-skills/commit/5b655a47ac6d03a2d96d6e64ca051b6a7fe62296) and packaged by Dockyard to `ghcr.io/stacklok/dockyard/skills/<name>:0.1.0`.

Follows the OCI-distribution pattern established by [PR #1093 (claude-api)](https://github.com/stacklok/toolhive-catalog/pull/1093), [PR #1094 (toolhive-cli-user)](https://github.com/stacklok/toolhive-catalog/pull/1094), and [PR #1095 (trailofbits security skills)](https://github.com/stacklok/toolhive-catalog/pull/1095).

### Skills added

- `gemini-api-dev` — build apps with Gemini models and the Gemini API (multimodal, function calling, structured outputs, current model/SDK guidance)
- `gemini-interactions-api` — unified Interactions API for models and agents (text, chat, streaming, background research, tool orchestration)
- `gemini-live-api-dev` — real-time, bidirectional streaming over WebSocket (audio/video/text, VAD, native audio, ephemeral tokens)
- `vertex-ai-api-dev` — Gemini API on Google Cloud Vertex AI for enterprise workloads (Live API, context caching, embeddings, batch prediction)

### Notes for review

- **License: `Apache-2.0`.** Confirmed at the `google-gemini/gemini-skills` repo root; upstream does not embed an SPDX identifier in per-skill SKILL.md frontmatter, which is tracked as an allowed Dockyard manifest issue.
- **No `allowedTools`.** None of the 4 skills declare `mcp__*` tools — they only use Claude Code built-ins.
- **No `skill/SKILL.md` subfolder.** Following the `claude-api` / `toolhive-cli-user` precedent — OCI is authoritative, and a commit-pinned git package is included as a fallback.
- **Icons.** All 4 skills share the same monochrome 4-point sparkle SVG (thematic for Gemini). Happy to differentiate per-skill if reviewers prefer.

## Test plan

- [x] `task catalog:validate` — 24 skills total, all valid (both upstream and toolhive formats)
- [x] `task catalog:build` — all 4 new skills present under `data.skills` in `build/toolhive/registry-upstream.json`
- [ ] `task catalog:validate` in CI
- [ ] Post-merge: skills appear in the published `registry-upstream.json` feed

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)