### PR TITLE
feat(skills): add 3 Stripe skill entries (OCI distribution)

### DIFF
--- a/registries/toolhive/skills/stripe-best-practices/icon.svg
+++ b/registries/toolhive/skills/stripe-best-practices/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="5" width="20" height="14" rx="2"/><line x1="2" y1="10" x2="22" y2="10"/></svg>

--- a/registries/toolhive/skills/stripe-best-practices/skill.json
+++ b/registries/toolhive/skills/stripe-best-practices/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "stripe-best-practices",
+  "title": "Stripe Best Practices Skill",
+  "description": "Guides Stripe integration decisions — API selection (Checkout Sessions vs PaymentIntents), Connect platform, Billing, Treasury, integration surfaces, migrations from deprecated APIs, and security best practices. Packaged from the upstream stripe/agent-toolkit repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "MIT",
+  "repository": {
+    "url": "https://github.com/stripe/agent-toolkit",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/stripe-best-practices:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/stripe/agent-toolkit",
+      "ref": "dd6deb03137908d0102ffde97e60c90cf79bf929",
+      "subfolder": "skills/stripe-best-practices"
+    }
+  ]
+}

--- a/registries/toolhive/skills/stripe-projects/icon.svg
+++ b/registries/toolhive/skills/stripe-projects/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="5" width="20" height="14" rx="2"/><line x1="2" y1="10" x2="22" y2="10"/></svg>

--- a/registries/toolhive/skills/stripe-projects/skill.json
+++ b/registries/toolhive/skills/stripe-projects/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "stripe-projects",
+  "title": "Stripe Projects Skill",
+  "description": "Set up a new app or local repo with Stripe Projects — CLI-driven software-stack provisioning (stripe projects init) for bootstrapping Stripe integrations from a coding agent. Packaged from the upstream stripe/agent-toolkit repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "MIT",
+  "repository": {
+    "url": "https://github.com/stripe/agent-toolkit",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/stripe-projects:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/stripe/agent-toolkit",
+      "ref": "dd6deb03137908d0102ffde97e60c90cf79bf929",
+      "subfolder": "skills/stripe-projects"
+    }
+  ]
+}

--- a/registries/toolhive/skills/upgrade-stripe/icon.svg
+++ b/registries/toolhive/skills/upgrade-stripe/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="5" width="20" height="14" rx="2"/><line x1="2" y1="10" x2="22" y2="10"/></svg>

--- a/registries/toolhive/skills/upgrade-stripe/skill.json
+++ b/registries/toolhive/skills/upgrade-stripe/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "upgrade-stripe",
+  "title": "Upgrade Stripe Skill",
+  "description": "Upgrade Stripe API versions and SDKs — server-side SDK version management, Stripe.js versioning, mobile SDK migration, API Changelog review, and staged adoption via the Stripe-Version header. Packaged from the upstream stripe/agent-toolkit repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "MIT",
+  "repository": {
+    "url": "https://github.com/stripe/agent-toolkit",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/upgrade-stripe:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/stripe/agent-toolkit",
+      "ref": "dd6deb03137908d0102ffde97e60c90cf79bf929",
+      "subfolder": "skills/upgrade-stripe"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the 3-skill Stripe pack from [`stripe/agent-toolkit`](https://github.com/stripe/agent-toolkit) to the ToolHive catalog. Content is MIT-licensed, pinned upstream to commit [`dd6deb0`](https://github.com/stripe/agent-toolkit/commit/dd6deb03137908d0102ffde97e60c90cf79bf929) and packaged by Dockyard to `ghcr.io/stacklok/dockyard/skills/<name>:0.1.0` (see companion [dockyard PR #505](https://github.com/stacklok/dockyard/pull/505)).

Follows the OCI-distribution pattern established by [PR #1093 (claude-api)](https://github.com/stacklok/toolhive-catalog/pull/1093), [PR #1094 (toolhive-cli-user)](https://github.com/stacklok/toolhive-catalog/pull/1094), [PR #1095 (trailofbits security skills)](https://github.com/stacklok/toolhive-catalog/pull/1095), and [PR #1109 (google-gemini pack)](https://github.com/stacklok/toolhive-catalog/pull/1109).

### Skills added

- `stripe-best-practices` — guides Stripe integration decisions (API selection, Connect, Billing, Treasury, integration surfaces, migrations from deprecated APIs, and security best practices)
- `stripe-projects` — bootstrap a new app or local repo with the Stripe Projects CLI (`stripe projects init`) for software-stack provisioning
- `upgrade-stripe` — upgrade Stripe API versions and SDKs (server-side SDKs, Stripe.js, mobile SDKs, staged adoption via the `Stripe-Version` header)

### Notes for review

- **License: `MIT`.** Confirmed at the `stripe/agent-toolkit` repo root; upstream does not embed an SPDX identifier in per-skill SKILL.md frontmatter, which is tracked as an allowed Dockyard manifest issue.
- **No `allowedTools`.** None of the 3 skills declare `mcp__*` tools — they only use Claude Code built-ins.
- **No `skill/SKILL.md` subfolder.** Following the `claude-api` / `toolhive-cli-user` / `gemini` precedent — OCI is authoritative, and a commit-pinned git package is included as a fallback.
- **Icons.** All 3 skills share the same monochrome card-with-stripe SVG (thematic for Stripe / payments). Happy to differentiate per-skill if reviewers prefer.

## Test plan

- [x] `task catalog:validate` — all entries valid (both upstream and toolhive formats)
- [x] `task catalog:build` — all 3 new skills present under `data.skills` in `build/toolhive/registry-upstream.json`
- [ ] `task catalog:validate` in CI
- [ ] Post-merge: skills appear in the published `registry-upstream.json` feed

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)