### PR TITLE
feat(skills): add 3 Neon skill entries (OCI distribution)

### DIFF
--- a/registries/toolhive/skills/claimable-postgres/icon.svg
+++ b/registries/toolhive/skills/claimable-postgres/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="8" ry="3"/><path d="M4 5v6c0 1.66 3.58 3 8 3s8-1.34 8-3V5"/><path d="M4 11v6c0 1.66 3.58 3 8 3s8-1.34 8-3v-6"/></svg>

--- a/registries/toolhive/skills/claimable-postgres/skill.json
+++ b/registries/toolhive/skills/claimable-postgres/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "claimable-postgres",
+  "title": "Claimable Postgres Skill",
+  "description": "Provision instant temporary Postgres databases via Claimable Postgres by Neon (neon.new) — no signup, REST API/CLI/SDK, ideal for prototyping and tests with a 72-hour claim window. Packaged from the upstream neondatabase/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/neondatabase/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/claimable-postgres:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/neondatabase/agent-skills",
+      "ref": "38c7da85db656c8c9efd1e6433c200212926fd2d",
+      "subfolder": "skills/claimable-postgres"
+    }
+  ]
+}

--- a/registries/toolhive/skills/neon-postgres-egress-optimizer/icon.svg
+++ b/registries/toolhive/skills/neon-postgres-egress-optimizer/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="8" ry="3"/><path d="M4 5v6c0 1.66 3.58 3 8 3s8-1.34 8-3V5"/><path d="M4 11v6c0 1.66 3.58 3 8 3s8-1.34 8-3v-6"/></svg>

--- a/registries/toolhive/skills/neon-postgres-egress-optimizer/skill.json
+++ b/registries/toolhive/skills/neon-postgres-egress-optimizer/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "neon-postgres-egress-optimizer",
+  "title": "Neon Postgres Egress Optimizer Skill",
+  "description": "Diagnose and fix excessive Postgres egress — identify top offenders with pg_stat_statements, spot SELECT *, missing pagination, and overfetching patterns, then apply concrete SQL refactors to cut data-transfer costs. Packaged from the upstream neondatabase/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/neondatabase/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/neon-postgres-egress-optimizer:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/neondatabase/agent-skills",
+      "ref": "38c7da85db656c8c9efd1e6433c200212926fd2d",
+      "subfolder": "skills/neon-postgres-egress-optimizer"
+    }
+  ]
+}

--- a/registries/toolhive/skills/neon-postgres/icon.svg
+++ b/registries/toolhive/skills/neon-postgres/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="8" ry="3"/><path d="M4 5v6c0 1.66 3.58 3 8 3s8-1.34 8-3V5"/><path d="M4 11v6c0 1.66 3.58 3 8 3s8-1.34 8-3v-6"/></svg>

--- a/registries/toolhive/skills/neon-postgres/skill.json
+++ b/registries/toolhive/skills/neon-postgres/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "neon-postgres",
+  "title": "Neon Serverless Postgres Skill",
+  "description": "Guides and best practices for Neon Serverless Postgres — connection methods, Neon CLI, MCP server setup, branching, autoscaling, scale-to-zero, instant restore, read replicas, and the Platform API/SDKs. Packaged from the upstream neondatabase/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/neondatabase/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/neon-postgres:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/neondatabase/agent-skills",
+      "ref": "38c7da85db656c8c9efd1e6433c200212926fd2d",
+      "subfolder": "skills/neon-postgres"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the 3-skill Neon pack from [`neondatabase/agent-skills`](https://github.com/neondatabase/agent-skills) to the ToolHive catalog. Content is Apache-2.0, pinned upstream to commit [`38c7da8`](https://github.com/neondatabase/agent-skills/commit/38c7da85db656c8c9efd1e6433c200212926fd2d) and packaged by Dockyard ([Dockyard PR #506](https://github.com/stacklok/dockyard/pull/506)) to `ghcr.io/stacklok/dockyard/skills/<name>:0.1.0`.

Follows the OCI-distribution pattern established by [PR #1093 (claude-api)](https://github.com/stacklok/toolhive-catalog/pull/1093), [PR #1094 (toolhive-cli-user)](https://github.com/stacklok/toolhive-catalog/pull/1094), [PR #1095 (trailofbits security skills)](https://github.com/stacklok/toolhive-catalog/pull/1095), and [PR #1109 (gemini pack)](https://github.com/stacklok/toolhive-catalog/pull/1109).

### Skills added

- `claimable-postgres` — instant temporary Postgres databases via Claimable Postgres by Neon (neon.new); no login/signup/credit card, REST API/CLI/SDK, 72-hour claim window, ideal for prototyping and tests
- `neon-postgres` — guides and best practices for Neon Serverless Postgres (connection methods, Neon CLI, MCP server setup, branching, autoscaling, scale-to-zero, instant restore, read replicas, Platform API/SDKs)
- `neon-postgres-egress-optimizer` — diagnose and fix excessive Postgres egress (identify top offenders with `pg_stat_statements`, spot `SELECT *`, missing pagination, overfetching; concrete SQL refactors)

### Notes for review

- **License: `Apache-2.0`.** Confirmed at the `neondatabase/agent-skills` repo root; upstream does not embed an SPDX identifier in per-skill SKILL.md frontmatter, which is tracked as an allowed Dockyard manifest issue.
- **No `allowedTools`.** None of the 3 skills declare `mcp__*` tools — they only use Claude Code built-ins.
- **No `skill/SKILL.md` subfolder.** Following the `claude-api` / `toolhive-cli-user` / `gemini` precedent — OCI is authoritative, and a commit-pinned git package is included as a fallback.
- **Icons.** All 3 skills share the same monochrome database/stack SVG (thematic for Neon serverless Postgres). Happy to differentiate per-skill if reviewers prefer.

## Test plan

- [x] `task catalog:validate` — 23 skills total (20 existing + 3 new), all valid (both upstream and toolhive formats)
- [x] `task catalog:build` — all 3 new skills present under `data.skills` in `build/toolhive/registry-upstream.json`
- [ ] `task catalog:validate` in CI
- [ ] Post-merge: skills appear in the published `registry-upstream.json` feed

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>