### PR TITLE
feat(skills): add 2 LlamaIndex skill entries (OCI distribution)

### DIFF
--- a/registries/toolhive/skills/liteparse/icon.svg
+++ b/registries/toolhive/skills/liteparse/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 2 H14 L18 6 V22 H6 Z"/><path d="M14 2 V6 H18"/><line x1="9" y1="11" x2="15" y2="11"/><line x1="9" y1="15" x2="15" y2="15"/><line x1="9" y1="19" x2="13" y2="19"/></svg>

--- a/registries/toolhive/skills/liteparse/skill.json
+++ b/registries/toolhive/skills/liteparse/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "liteparse",
+  "title": "LlamaIndex LiteParse Skill",
+  "description": "Use LlamaIndex's lightweight liteparse document parser — extract text and structure from PDFs and other documents without the full LlamaParse cloud dependency. Packaged from the upstream run-llama/llamaparse-agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "MIT",
+  "repository": {
+    "url": "https://github.com/run-llama/llamaparse-agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/liteparse:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/run-llama/llamaparse-agent-skills",
+      "ref": "1f10f60a9eba0dbb490724c8104b0a865365f136",
+      "subfolder": "skills/liteparse"
+    }
+  ]
+}

--- a/registries/toolhive/skills/llamaparse/icon.svg
+++ b/registries/toolhive/skills/llamaparse/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 2 H14 L18 6 V22 H6 Z"/><path d="M14 2 V6 H18"/><line x1="9" y1="11" x2="15" y2="11"/><line x1="9" y1="15" x2="15" y2="15"/><line x1="9" y1="19" x2="13" y2="19"/></svg>

--- a/registries/toolhive/skills/llamaparse/skill.json
+++ b/registries/toolhive/skills/llamaparse/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "llamaparse",
+  "title": "LlamaIndex LlamaParse Skill",
+  "description": "Parse complex documents with LlamaParse — PDFs, tables, images, and multimodal content via LlamaIndex's managed parsing service; API usage, parse modes, and structured-output schemas. Packaged from the upstream run-llama/llamaparse-agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "MIT",
+  "repository": {
+    "url": "https://github.com/run-llama/llamaparse-agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/llamaparse:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/run-llama/llamaparse-agent-skills",
+      "ref": "1f10f60a9eba0dbb490724c8104b0a865365f136",
+      "subfolder": "skills/llamaparse"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the 2-skill LlamaIndex document-parsing pack from [`run-llama/llamaparse-agent-skills`](https://github.com/run-llama/llamaparse-agent-skills) to the ToolHive catalog. Content is MIT-licensed, pinned upstream to commit [`1f10f60`](https://github.com/run-llama/llamaparse-agent-skills/commit/1f10f60a9eba0dbb490724c8104b0a865365f136) and packaged by Dockyard to `ghcr.io/stacklok/dockyard/skills/<name>:0.1.0` (Dockyard PR #511).

Follows the OCI-distribution pattern established by [PR #1093 (claude-api)](https://github.com/stacklok/toolhive-catalog/pull/1093), [PR #1094 (toolhive-cli-user)](https://github.com/stacklok/toolhive-catalog/pull/1094), [PR #1095 (trailofbits security skills)](https://github.com/stacklok/toolhive-catalog/pull/1095), and [PR #1109 (gemini skills)](https://github.com/stacklok/toolhive-catalog/pull/1109).

### Skills added

- `liteparse` — LlamaIndex's lightweight local document parser; extracts text and structure from PDFs, DOCX, PPTX, XLSX, and images with no cloud dependencies or LLM required
- `llamaparse` — managed parsing service for complex documents (PDFs, tables, images, multimodal content) via the LlamaIndex LlamaCloud API

### Notes for review

- **License: `MIT`.** Confirmed at the `run-llama/llamaparse-agent-skills` repo root; upstream does not embed an SPDX identifier in per-skill SKILL.md frontmatter, which is tracked as an allowed Dockyard manifest issue.
- **Runtime environment (not MCP-server dependencies).**
  - `llamaparse` requires a `LLAMA_CLOUD_API_KEY` environment variable at runtime (documented in the upstream SKILL.md).
  - `liteparse` is local-only and needs `@llamaindex/liteparse` installed via npm.
  - These are end-user runtime expectations for the skill, not MCP-server secrets.
- **No `allowedTools`.** Neither skill declares `mcp__*` tools; they rely on Claude Code built-ins.
- **No `skill/SKILL.md` subfolder.** Following the `claude-api` / `toolhive-cli-user` / `gemini-*` precedent — OCI is authoritative, and a commit-pinned git package is included as a fallback.
- **Icons.** Both skills share a monochrome document-with-text-lines SVG (thematic for document parsing).

## Test plan

- [x] `task catalog:validate` — all 22 toolhive skills valid (both upstream and toolhive formats)
- [x] `task catalog:build` — both new skills present under `data.skills` in `build/toolhive/registry-upstream.json`
- [ ] `task catalog:validate` in CI
- [ ] Post-merge: skills appear in the published `registry-upstream.json` feed

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>

Generated with [Claude Code](https://claude.com/claude-code)