### PR TITLE
feat(skills): add 3 Atlassian Forge skill entries (OCI distribution)

### DIFF
--- a/registries/toolhive/skills/forge-app-builder/icon.svg
+++ b/registries/toolhive/skills/forge-app-builder/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9 L15 9 L17 7 L21 7 L21 11 L17 11 L15 13 L11 13 L11 17 L14 17 L14 20 L6 20 L6 17 L9 17 L9 13 L7 13 Z"/></svg>

--- a/registries/toolhive/skills/forge-app-builder/skill.json
+++ b/registries/toolhive/skills/forge-app-builder/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "forge-app-builder",
+  "title": "Atlassian Forge App Builder Skill",
+  "description": "Build Atlassian Forge apps end-to-end — app scaffolding via Forge CLI, manifest config, UI components (UI Kit, Custom UI, Forge React), backend resolvers and functions, triggers, scheduled triggers, permissions, and deployment. Packaged from the upstream atlassian/forge-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/atlassian/forge-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/forge-app-builder:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/atlassian/forge-skills",
+      "ref": "0d60ac5436dcb63af0869e110728f40e61274924",
+      "subfolder": "skills/forge-app-builder"
+    }
+  ]
+}

--- a/registries/toolhive/skills/forge-app-review/icon.svg
+++ b/registries/toolhive/skills/forge-app-review/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9 L15 9 L17 7 L21 7 L21 11 L17 11 L15 13 L11 13 L11 17 L14 17 L14 20 L6 20 L6 17 L9 17 L9 13 L7 13 Z"/></svg>

--- a/registries/toolhive/skills/forge-app-review/skill.json
+++ b/registries/toolhive/skills/forge-app-review/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "forge-app-review",
+  "title": "Atlassian Forge App Review Skill",
+  "description": "Review Atlassian Forge apps for quality, security, and marketplace readiness — manifest and permission audit, resolver security, UI patterns, error handling, and Marketplace submission checklist. Packaged from the upstream atlassian/forge-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/atlassian/forge-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/forge-app-review:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/atlassian/forge-skills",
+      "ref": "0d60ac5436dcb63af0869e110728f40e61274924",
+      "subfolder": "skills/forge-app-review"
+    }
+  ]
+}

--- a/registries/toolhive/skills/forge-debugger/icon.svg
+++ b/registries/toolhive/skills/forge-debugger/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9 L15 9 L17 7 L21 7 L21 11 L17 11 L15 13 L11 13 L11 17 L14 17 L14 20 L6 20 L6 17 L9 17 L9 13 L7 13 Z"/></svg>

--- a/registries/toolhive/skills/forge-debugger/skill.json
+++ b/registries/toolhive/skills/forge-debugger/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "forge-debugger",
+  "title": "Atlassian Forge Debugger Skill",
+  "description": "Debug Atlassian Forge apps — inspect logs, tunnel to local dev, trace resolver errors, reproduce webhook/trigger failures, verify manifest and permission scopes. Packaged from the upstream atlassian/forge-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/atlassian/forge-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/forge-debugger:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/atlassian/forge-skills",
+      "ref": "0d60ac5436dcb63af0869e110728f40e61274924",
+      "subfolder": "skills/forge-debugger"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the 3-skill Atlassian Forge pack from [`atlassian/forge-skills`](https://github.com/atlassian/forge-skills) to the ToolHive catalog. Content is Apache-2.0, pinned upstream to commit [`0d60ac5`](https://github.com/atlassian/forge-skills/commit/0d60ac5436dcb63af0869e110728f40e61274924) and packaged by Dockyard to `ghcr.io/stacklok/dockyard/skills/<name>:0.1.0`.

Follows the OCI-distribution pattern established by [PR #1093 (claude-api)](https://github.com/stacklok/toolhive-catalog/pull/1093), [PR #1094 (toolhive-cli-user)](https://github.com/stacklok/toolhive-catalog/pull/1094), [PR #1095 (trailofbits security skills)](https://github.com/stacklok/toolhive-catalog/pull/1095), and [PR #1109 (gemini skills)](https://github.com/stacklok/toolhive-catalog/pull/1109).

Dockyard packaging PR: [dockyard#510](https://github.com/stacklok/dockyard/pull/510).

### Skills added

- `forge-app-builder` — build Atlassian Forge apps end-to-end (scaffolding via Forge CLI, manifest config, UI Kit / Custom UI / Forge React components, backend resolvers and functions, triggers, scheduled triggers, permissions, deployment)
- `forge-app-review` — review Forge apps for quality, security, and marketplace readiness (manifest and permission audit, resolver security, UI patterns, error handling, Marketplace submission checklist)
- `forge-debugger` — debug Forge apps (inspect logs, tunnel to local dev, trace resolver errors, reproduce webhook/trigger failures, verify manifest and permission scopes)

### Notes for review

- **License: `Apache-2.0`.** Confirmed at the `atlassian/forge-skills` repo root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter, which is tracked as an allowed Dockyard manifest issue (`MANIFEST_MISSING_LICENSE`).
- **No `allowedTools`.** None of the 3 skills declare `mcp__*` tools — they use Claude Code built-ins.
- **No `skill/SKILL.md` subfolder.** Following the `claude-api` / `toolhive-cli-user` / `gemini-*` precedent — OCI is authoritative, and a commit-pinned git package is included as a fallback.
- **Icons.** All 3 skills share the same monochrome anvil SVG (thematic for Forge). Happy to differentiate per-skill if reviewers prefer.
- **`forge-app-builder` network access.** The skill bundles `scripts/list_templates.py` which fetches the official Atlassian Forge template index via `urllib.request.urlopen()`. This is a documented scaffolding step; tracked in Dockyard as allowed `DATA_EXFIL_NETWORK_REQUESTS` / `TOOL_ABUSE_UNDECLARED_NETWORK` exceptions to a trusted destination.

## Test plan

- [x] `task catalog:validate` — 23 skills total (20 existing + 3 Forge), all valid (both upstream and toolhive formats)
- [x] `task catalog:build` — all 3 new skills present under `data.skills` in `build/toolhive/registry-upstream.json`
- [ ] `task catalog:validate` in CI
- [ ] Post-merge: skills appear in the published `registry-upstream.json` feed

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>