### PR TITLE
feat(skills): add 2 Supabase skill entries (OCI distribution)

### DIFF
--- a/registries/toolhive/skills/supabase-postgres-best-practices/icon.svg
+++ b/registries/toolhive/skills/supabase-postgres-best-practices/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2 L4 14 L12 14 L11 22 L20 10 L12 10 Z"/></svg>

--- a/registries/toolhive/skills/supabase-postgres-best-practices/skill.json
+++ b/registries/toolhive/skills/supabase-postgres-best-practices/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "supabase-postgres-best-practices",
+  "title": "Supabase Postgres Best Practices Skill",
+  "description": "Postgres performance optimization and best practices from Supabase — rules across query performance, connection management, security/RLS, schema design, concurrency/locking, data access patterns, monitoring, and advanced features. Packaged from the upstream supabase/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "MIT",
+  "repository": {
+    "url": "https://github.com/supabase/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/supabase-postgres-best-practices:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/supabase/agent-skills",
+      "ref": "3e7fd16bf8cab06d3c24dc775a331e6effcba29a",
+      "subfolder": "skills/supabase-postgres-best-practices"
+    }
+  ]
+}

--- a/registries/toolhive/skills/supabase/icon.svg
+++ b/registries/toolhive/skills/supabase/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2 L4 14 L12 14 L11 22 L20 10 L12 10 Z"/></svg>

--- a/registries/toolhive/skills/supabase/skill.json
+++ b/registries/toolhive/skills/supabase/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "supabase",
+  "title": "Supabase Skill",
+  "description": "Use for any Supabase task — Database, Auth, Edge Functions, Realtime, Storage, Vectors, Cron, Queues; supabase-js and @supabase/ssr SSR integrations; RLS-by-default security checklist, schema changes, migrations, Postgres extensions, CLI, MCP server troubleshooting. Packaged from the upstream supabase/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "MIT",
+  "repository": {
+    "url": "https://github.com/supabase/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/supabase:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/supabase/agent-skills",
+      "ref": "3e7fd16bf8cab06d3c24dc775a331e6effcba29a",
+      "subfolder": "skills/supabase"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the 2-skill Supabase pack from [`supabase/agent-skills`](https://github.com/supabase/agent-skills) to the ToolHive catalog. Content is MIT, pinned upstream to commit [`3e7fd16`](https://github.com/supabase/agent-skills/commit/3e7fd16bf8cab06d3c24dc775a331e6effcba29a) and packaged by Dockyard to `ghcr.io/stacklok/dockyard/skills/<name>:0.1.0` (see stacklok/dockyard#503).

Follows the OCI-distribution pattern established by PR #1093 (claude-api), PR #1094 (toolhive-cli-user), PR #1095 (trailofbits), and PR #1109 (gemini-skills).

### Skills added

- `supabase` — full product skill (Database, Auth, Edge Functions, Realtime, Storage, Vectors, Cron, Queues); `supabase-js` / `@supabase/ssr` SSR integrations; RLS-by-default security checklist, migrations workflow, CLI and MCP server troubleshooting
- `supabase-postgres-best-practices` — Postgres performance and schema rules across 8 categories (query performance, connection management, security/RLS, schema design, concurrency/locking, data access patterns, monitoring, advanced features)

### Notes for review

- **License: `MIT`.** Confirmed at the `supabase/agent-skills` repo root. The `supabase-postgres-best-practices` skill embeds `license: MIT` in frontmatter; `supabase` does not — tracked as an allowed Dockyard manifest issue (`MANIFEST_MISSING_LICENSE`, INFO).
- **MCP dependency.** The `supabase` skill references the Supabase MCP server for optional tool calls (with documented fetch-URL / CLI fallbacks). The Supabase MCP server is already packaged in this catalog under `registries/*/servers/supabase`, so the dependency is satisfied per `skill-criteria.md`.
- **No `allowedTools`.** Neither skill declares `mcp__*` tools — calls into the Supabase MCP are documented narratively and gated by graceful fallbacks.
- **No `skill/SKILL.md` subfolder.** Following the `claude-api` / `toolhive-cli-user` / `gemini-skills` precedent — OCI is authoritative, and a commit-pinned git package is included as a fallback.
- **Icons.** Both skills share the same monochrome bolt SVG (thematic for Supabase, not the copyrighted logo). Happy to differentiate per-skill if reviewers prefer.

## Test plan

- [x] `task catalog:validate` — 22 skills total, all valid (both upstream and toolhive formats)
- [x] `task catalog:build` — both new skills present under `data.skills` in `build/toolhive/registry-upstream.json`
- [ ] `task catalog:validate` in CI
- [ ] Post-merge: skills appear in the published `registry-upstream.json` feed

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>

Generated with [Claude Code](https://claude.com/claude-code)