### PR TITLE
feat(skills): add 8 Cloudflare skill entries (OCI distribution)

### DIFF
--- a/registries/toolhive/skills/agents-sdk/icon.svg
+++ b/registries/toolhive/skills/agents-sdk/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 18 C3.7 18 2 15.8 2 13.5 C2 11.2 3.8 9.3 6.2 9.1 C6.9 6.7 9.2 5 12 5 C15 5 17.5 7 18.2 9.6 C20.3 10 22 11.7 22 14 C22 16.2 20.2 18 18 18 Z"/></svg>

--- a/registries/toolhive/skills/agents-sdk/skill.json
+++ b/registries/toolhive/skills/agents-sdk/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "agents-sdk",
+  "title": "Cloudflare Agents SDK Skill",
+  "description": "Build AI agents on Cloudflare Workers with the Agents SDK — Agent class, persistent state, callable RPC, Workflows, durable execution, queues, retries, MCP client/server, chat agents, WebSockets, scheduling, observability, and React client hooks. Packaged from the upstream cloudflare/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/cloudflare/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/agents-sdk:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/cloudflare/skills",
+      "ref": "0397d7d88fa6ac7517a88389622eb0799e86ded2",
+      "subfolder": "skills/agents-sdk"
+    }
+  ]
+}

--- a/registries/toolhive/skills/cloudflare-email-service/icon.svg
+++ b/registries/toolhive/skills/cloudflare-email-service/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 18 C3.7 18 2 15.8 2 13.5 C2 11.2 3.8 9.3 6.2 9.1 C6.9 6.7 9.2 5 12 5 C15 5 17.5 7 18.2 9.6 C20.3 10 22 11.7 22 14 C22 16.2 20.2 18 18 18 Z"/></svg>

--- a/registries/toolhive/skills/cloudflare-email-service/skill.json
+++ b/registries/toolhive/skills/cloudflare-email-service/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "cloudflare-email-service",
+  "title": "Cloudflare Email Service Skill",
+  "description": "Send and receive transactional email with Cloudflare Email Service (Email Sending + Email Routing) — Workers bindings, REST API, Agents SDK onEmail/replyToEmail, SPF/DKIM/DMARC, wrangler setup, deliverability. Packaged from the upstream cloudflare/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/cloudflare/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/cloudflare-email-service:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/cloudflare/skills",
+      "ref": "0397d7d88fa6ac7517a88389622eb0799e86ded2",
+      "subfolder": "skills/cloudflare-email-service"
+    }
+  ]
+}

--- a/registries/toolhive/skills/cloudflare/icon.svg
+++ b/registries/toolhive/skills/cloudflare/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 18 C3.7 18 2 15.8 2 13.5 C2 11.2 3.8 9.3 6.2 9.1 C6.9 6.7 9.2 5 12 5 C15 5 17.5 7 18.2 9.6 C20.3 10 22 11.7 22 14 C22 16.2 20.2 18 18 18 Z"/></svg>

--- a/registries/toolhive/skills/cloudflare/skill.json
+++ b/registries/toolhive/skills/cloudflare/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "cloudflare",
+  "title": "Cloudflare Platform Skill",
+  "description": "Comprehensive Cloudflare platform skill — Workers, Pages, storage (KV/D1/R2/Artifacts/Queues), AI (Workers AI, Vectorize, Agents SDK, AI Gateway), networking (Tunnel, Spectrum), security (WAF, DDoS, Turnstile), and IaC (Terraform, Pulumi); decision trees for product selection. Packaged from the upstream cloudflare/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/cloudflare/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/cloudflare:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/cloudflare/skills",
+      "ref": "0397d7d88fa6ac7517a88389622eb0799e86ded2",
+      "subfolder": "skills/cloudflare"
+    }
+  ]
+}

--- a/registries/toolhive/skills/durable-objects/icon.svg
+++ b/registries/toolhive/skills/durable-objects/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 18 C3.7 18 2 15.8 2 13.5 C2 11.2 3.8 9.3 6.2 9.1 C6.9 6.7 9.2 5 12 5 C15 5 17.5 7 18.2 9.6 C20.3 10 22 11.7 22 14 C22 16.2 20.2 18 18 18 Z"/></svg>

--- a/registries/toolhive/skills/durable-objects/skill.json
+++ b/registries/toolhive/skills/durable-objects/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "durable-objects",
+  "title": "Cloudflare Durable Objects Skill",
+  "description": "Create and review Cloudflare Durable Objects — stateful coordination (chat rooms, multiplayer, booking), RPC methods, SQLite storage, alarms, WebSockets, wrangler config, Vitest testing. Packaged from the upstream cloudflare/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/cloudflare/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/durable-objects:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/cloudflare/skills",
+      "ref": "0397d7d88fa6ac7517a88389622eb0799e86ded2",
+      "subfolder": "skills/durable-objects"
+    }
+  ]
+}

--- a/registries/toolhive/skills/sandbox-sdk/icon.svg
+++ b/registries/toolhive/skills/sandbox-sdk/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 18 C3.7 18 2 15.8 2 13.5 C2 11.2 3.8 9.3 6.2 9.1 C6.9 6.7 9.2 5 12 5 C15 5 17.5 7 18.2 9.6 C20.3 10 22 11.7 22 14 C22 16.2 20.2 18 18 18 Z"/></svg>

--- a/registries/toolhive/skills/sandbox-sdk/skill.json
+++ b/registries/toolhive/skills/sandbox-sdk/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "sandbox-sdk",
+  "title": "Cloudflare Sandbox SDK Skill",
+  "description": "Build sandboxed apps for secure code execution — AI code interpreters, CI sandboxes, interactive dev environments; Sandbox SDK lifecycle, exec/runCode, file ops, preview URLs, OpenAI Agents SDK integration. Packaged from the upstream cloudflare/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/cloudflare/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/sandbox-sdk:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/cloudflare/skills",
+      "ref": "0397d7d88fa6ac7517a88389622eb0799e86ded2",
+      "subfolder": "skills/sandbox-sdk"
+    }
+  ]
+}

--- a/registries/toolhive/skills/web-perf/icon.svg
+++ b/registries/toolhive/skills/web-perf/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 18 C3.7 18 2 15.8 2 13.5 C2 11.2 3.8 9.3 6.2 9.1 C6.9 6.7 9.2 5 12 5 C15 5 17.5 7 18.2 9.6 C20.3 10 22 11.7 22 14 C22 16.2 20.2 18 18 18 Z"/></svg>

--- a/registries/toolhive/skills/web-perf/skill.json
+++ b/registries/toolhive/skills/web-perf/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "web-perf",
+  "title": "Web Performance Audit Skill",
+  "description": "Web performance audit via Chrome DevTools MCP — measures Core Web Vitals (LCP, INP, CLS) and supplementary metrics, identifies render-blocking resources and request chains, detects caching gaps and accessibility issues. Packaged from the upstream cloudflare/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/cloudflare/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/web-perf:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/cloudflare/skills",
+      "ref": "0397d7d88fa6ac7517a88389622eb0799e86ded2",
+      "subfolder": "skills/web-perf"
+    }
+  ]
+}

--- a/registries/toolhive/skills/workers-best-practices/icon.svg
+++ b/registries/toolhive/skills/workers-best-practices/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 18 C3.7 18 2 15.8 2 13.5 C2 11.2 3.8 9.3 6.2 9.1 C6.9 6.7 9.2 5 12 5 C15 5 17.5 7 18.2 9.6 C20.3 10 22 11.7 22 14 C22 16.2 20.2 18 18 18 Z"/></svg>

--- a/registries/toolhive/skills/workers-best-practices/skill.json
+++ b/registries/toolhive/skills/workers-best-practices/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "workers-best-practices",
+  "title": "Cloudflare Workers Best Practices Skill",
+  "description": "Review and author Cloudflare Workers code against production best practices — streaming, floating promises, global state, secrets, bindings, observability, cryptographic randomness, type safety, wrangler config. Packaged from the upstream cloudflare/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/cloudflare/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/workers-best-practices:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/cloudflare/skills",
+      "ref": "0397d7d88fa6ac7517a88389622eb0799e86ded2",
+      "subfolder": "skills/workers-best-practices"
+    }
+  ]
+}

--- a/registries/toolhive/skills/wrangler/icon.svg
+++ b/registries/toolhive/skills/wrangler/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 18 C3.7 18 2 15.8 2 13.5 C2 11.2 3.8 9.3 6.2 9.1 C6.9 6.7 9.2 5 12 5 C15 5 17.5 7 18.2 9.6 C20.3 10 22 11.7 22 14 C22 16.2 20.2 18 18 18 Z"/></svg>

--- a/registries/toolhive/skills/wrangler/skill.json
+++ b/registries/toolhive/skills/wrangler/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "wrangler",
+  "title": "Wrangler CLI Skill",
+  "description": "Cloudflare Workers CLI — deploy, dev, and manage Workers, KV, R2, D1, Vectorize, Hyperdrive, Workers AI, Containers, Queues, Workflows, Pipelines, and Secrets Store; wrangler.jsonc config patterns and binding shapes. Packaged from the upstream cloudflare/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/cloudflare/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/wrangler:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/cloudflare/skills",
+      "ref": "0397d7d88fa6ac7517a88389622eb0799e86ded2",
+      "subfolder": "skills/wrangler"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the 8-skill Cloudflare pack from [`cloudflare/skills`](https://github.com/cloudflare/skills) to the ToolHive catalog. Content is Apache-2.0, pinned upstream to commit [`0397d7d`](https://github.com/cloudflare/skills/commit/0397d7d88fa6ac7517a88389622eb0799e86ded2) and packaged by Dockyard to `ghcr.io/stacklok/dockyard/skills/<name>:0.1.0` (see Dockyard PR [#500](https://github.com/stacklok/dockyard/pull/500)).

Follows the OCI-distribution pattern established by [PR #1093 (claude-api)](https://github.com/stacklok/toolhive-catalog/pull/1093), [PR #1094 (toolhive-cli-user)](https://github.com/stacklok/toolhive-catalog/pull/1094), [PR #1095 (trailofbits security skills)](https://github.com/stacklok/toolhive-catalog/pull/1095), and [PR #1109 (Gemini skills)](https://github.com/stacklok/toolhive-catalog/pull/1109).

### Skills added

- `agents-sdk` — build AI agents on Cloudflare Workers with the Agents SDK (Agent class, Workflows, MCP client/server, chat agents, WebSockets, scheduling, React hooks)
- `cloudflare` — umbrella Cloudflare platform skill with decision trees for Workers, Pages, storage, AI, networking, security, and IaC
- `cloudflare-email-service` — send and receive transactional email via Email Sending + Email Routing (Workers bindings, REST API, Agents SDK onEmail/replyToEmail, SPF/DKIM/DMARC)
- `durable-objects` — create and review Durable Objects (stateful coordination, RPC, SQLite storage, alarms, WebSockets, Vitest testing)
- `sandbox-sdk` — build sandboxed apps for secure code execution (AI code interpreters, CI sandboxes, interactive dev environments, OpenAI Agents SDK integration)
- `web-perf` — web performance audit via Chrome DevTools MCP (Core Web Vitals, render-blocking resources, caching gaps, accessibility)
- `workers-best-practices` — review and author Workers code against production best practices (streaming, floating promises, global state, secrets, bindings, observability)
- `wrangler` — Cloudflare Workers CLI for deploying and managing Workers, KV, R2, D1, Vectorize, Hyperdrive, Workers AI, Containers, Queues, Workflows, Pipelines, and Secrets Store

### Notes for review

- **License: `Apache-2.0`.** Confirmed at the `cloudflare/skills` repo root; upstream does not embed an SPDX identifier in per-skill SKILL.md frontmatter, which is tracked as an allowed Dockyard manifest issue.
- **No `allowedTools`.** None of the 8 skills declare `mcp__*` tools — they only use Claude Code built-ins.
- **No `skill/SKILL.md` subfolder.** Following the `claude-api` / `toolhive-cli-user` / `gemini-api-dev` precedent — OCI is authoritative, and a commit-pinned git package is included as a fallback.
- **Icons.** All 8 skills share the same monochrome stylized-cloud SVG (thematic for Cloudflare). Happy to differentiate per-skill if reviewers prefer.

## Test plan

- [x] `task catalog:validate` — 28 skills total, all valid (both upstream and toolhive formats)
- [x] `task catalog:build` — all 8 new skills present under `data.skills` in `build/toolhive/registry-upstream.json`
- [ ] `task catalog:validate` in CI
- [ ] Post-merge: skills appear in the published `registry-upstream.json` feed

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>

Generated with [Claude Code](https://claude.com/claude-code)