### PR TITLE
feat(skills): add 6 ClickHouse skill entries (OCI distribution)

### DIFF
--- a/registries/toolhive/skills/chdb-datastore/icon.svg
+++ b/registries/toolhive/skills/chdb-datastore/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#181717"><rect x="3" y="10" width="4" height="11"/><rect x="10" y="5" width="4" height="16"/><rect x="17" y="13" width="4" height="8"/></svg>

--- a/registries/toolhive/skills/chdb-datastore/skill.json
+++ b/registries/toolhive/skills/chdb-datastore/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "chdb-datastore",
+  "title": "chDB Datastore Skill",
+  "description": "Use chDB as an in-process ClickHouse datastore — embed the ClickHouse engine in Python, Go, Node.js, or Rust apps for local analytics, columnar storage, and fast aggregation without running a server. Packaged from the upstream ClickHouse/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/ClickHouse/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/chdb-datastore:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/ClickHouse/agent-skills",
+      "ref": "d28416142e5634ce288602cd0c8f3457e68177ff",
+      "subfolder": "skills/chdb-datastore"
+    }
+  ]
+}

--- a/registries/toolhive/skills/chdb-sql/icon.svg
+++ b/registries/toolhive/skills/chdb-sql/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#181717"><rect x="3" y="10" width="4" height="11"/><rect x="10" y="5" width="4" height="16"/><rect x="17" y="13" width="4" height="8"/></svg>

--- a/registries/toolhive/skills/chdb-sql/skill.json
+++ b/registries/toolhive/skills/chdb-sql/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "chdb-sql",
+  "title": "chDB SQL Skill",
+  "description": "Write SQL queries against chDB — ClickHouse dialect syntax, aggregations, window functions, JSON handling, working with files (Parquet, CSV, JSON) directly from SQL, and common analytics patterns. Packaged from the upstream ClickHouse/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/ClickHouse/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/chdb-sql:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/ClickHouse/agent-skills",
+      "ref": "d28416142e5634ce288602cd0c8f3457e68177ff",
+      "subfolder": "skills/chdb-sql"
+    }
+  ]
+}

--- a/registries/toolhive/skills/clickhouse-architecture-advisor/icon.svg
+++ b/registries/toolhive/skills/clickhouse-architecture-advisor/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#181717"><rect x="3" y="10" width="4" height="11"/><rect x="10" y="5" width="4" height="16"/><rect x="17" y="13" width="4" height="8"/></svg>

--- a/registries/toolhive/skills/clickhouse-architecture-advisor/skill.json
+++ b/registries/toolhive/skills/clickhouse-architecture-advisor/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "clickhouse-architecture-advisor",
+  "title": "ClickHouse Architecture Advisor Skill",
+  "description": "Advise on ClickHouse architecture — deployment topology (self-hosted vs Cloud), replication/sharding, storage tiers, materialized views, table engines (MergeTree family), and capacity planning. Packaged from the upstream ClickHouse/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/ClickHouse/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/clickhouse-architecture-advisor:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/ClickHouse/agent-skills",
+      "ref": "d28416142e5634ce288602cd0c8f3457e68177ff",
+      "subfolder": "skills/clickhouse-architecture-advisor"
+    }
+  ]
+}

--- a/registries/toolhive/skills/clickhouse-best-practices/icon.svg
+++ b/registries/toolhive/skills/clickhouse-best-practices/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#181717"><rect x="3" y="10" width="4" height="11"/><rect x="10" y="5" width="4" height="16"/><rect x="17" y="13" width="4" height="8"/></svg>

--- a/registries/toolhive/skills/clickhouse-best-practices/skill.json
+++ b/registries/toolhive/skills/clickhouse-best-practices/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "clickhouse-best-practices",
+  "title": "ClickHouse Best Practices Skill",
+  "description": "ClickHouse best practices across 34 rules — schema (sort keys, codecs, skipping indexes), ingestion, query patterns, agent connect/discover/plan/verify/execute workflow with MCP, CLI, and HTTP paths. Packaged from the upstream ClickHouse/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/ClickHouse/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/clickhouse-best-practices:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/ClickHouse/agent-skills",
+      "ref": "d28416142e5634ce288602cd0c8f3457e68177ff",
+      "subfolder": "skills/clickhouse-best-practices"
+    }
+  ]
+}

--- a/registries/toolhive/skills/clickhousectl-cloud-deploy/icon.svg
+++ b/registries/toolhive/skills/clickhousectl-cloud-deploy/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#181717"><rect x="3" y="10" width="4" height="11"/><rect x="10" y="5" width="4" height="16"/><rect x="17" y="13" width="4" height="8"/></svg>

--- a/registries/toolhive/skills/clickhousectl-cloud-deploy/skill.json
+++ b/registries/toolhive/skills/clickhousectl-cloud-deploy/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "clickhousectl-cloud-deploy",
+  "title": "clickhousectl Cloud Deploy Skill",
+  "description": "Deploy and manage ClickHouse Cloud with the clickhousectl CLI — authenticate, create services, manage credentials, connection strings, and common administrative workflows. Packaged from the upstream ClickHouse/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/ClickHouse/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/clickhousectl-cloud-deploy:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/ClickHouse/agent-skills",
+      "ref": "d28416142e5634ce288602cd0c8f3457e68177ff",
+      "subfolder": "skills/clickhousectl-cloud-deploy"
+    }
+  ]
+}

--- a/registries/toolhive/skills/clickhousectl-local-dev/icon.svg
+++ b/registries/toolhive/skills/clickhousectl-local-dev/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#181717"><rect x="3" y="10" width="4" height="11"/><rect x="10" y="5" width="4" height="16"/><rect x="17" y="13" width="4" height="8"/></svg>

--- a/registries/toolhive/skills/clickhousectl-local-dev/skill.json
+++ b/registries/toolhive/skills/clickhousectl-local-dev/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "clickhousectl-local-dev",
+  "title": "clickhousectl Local Dev Skill",
+  "description": "Run and develop against ClickHouse locally with clickhousectl — Docker-based local server, quick setup, schema/data bootstrap, and connection patterns for local-first development. Packaged from the upstream ClickHouse/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/ClickHouse/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/clickhousectl-local-dev:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/ClickHouse/agent-skills",
+      "ref": "d28416142e5634ce288602cd0c8f3457e68177ff",
+      "subfolder": "skills/clickhousectl-local-dev"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the 6-skill ClickHouse pack from [`ClickHouse/agent-skills`](https://github.com/ClickHouse/agent-skills) to the ToolHive catalog. Content is Apache-2.0, pinned upstream to commit [`d284161`](https://github.com/ClickHouse/agent-skills/commit/d28416142e5634ce288602cd0c8f3457e68177ff) and packaged by Dockyard to `ghcr.io/stacklok/dockyard/skills/<name>:0.1.0`.

Dockyard-side reference: stacklok/dockyard#512.

Follows the OCI-distribution pattern established by [PR #1093 (claude-api)](https://github.com/stacklok/toolhive-catalog/pull/1093), [PR #1094 (toolhive-cli-user)](https://github.com/stacklok/toolhive-catalog/pull/1094), [PR #1095 (trailofbits security skills)](https://github.com/stacklok/toolhive-catalog/pull/1095), and [PR #1109 (google-gemini skills)](https://github.com/stacklok/toolhive-catalog/pull/1109).

### Skills added

- `chdb-datastore` — in-process ClickHouse datastore embedded in Python/Go/Node.js/Rust apps for local analytics without running a server
- `chdb-sql` — ClickHouse SQL dialect against chDB (aggregations, window functions, JSON, direct file access for Parquet/CSV/JSON)
- `clickhouse-architecture-advisor` — deployment topology, replication/sharding, storage tiers, materialized views, MergeTree table engines, capacity planning
- `clickhouse-best-practices` — 34 rules across schema, ingestion, query patterns, and the connect/discover/plan/verify/execute agent workflow (MCP, CLI, HTTP)
- `clickhousectl-cloud-deploy` — deploy and manage ClickHouse Cloud with the `clickhousectl` CLI (auth, service creation, credentials, connection strings)
- `clickhousectl-local-dev` — local ClickHouse development with `clickhousectl` (Docker-based local server, schema/data bootstrap, connection patterns)

### Notes for review

- **License: `Apache-2.0`.** Confirmed at the `ClickHouse/agent-skills` repo root; upstream does not embed an SPDX identifier in per-skill SKILL.md frontmatter (tracked as an allowed Dockyard manifest issue, same as the google-gemini pack).
- **No `allowedTools`.** None of the 6 skills declare `mcp__*` tools today. The catalog already ships the `mcp-clickhouse` MCP server, and `clickhouse-architecture-advisor` / `clickhouse-best-practices` reference the agent connect/query workflow (including an MCP path) in their content — but they do not currently declare `mcp__*` tools in their SKILL.md frontmatter, so no `allowedTools` entries are added here.
- **No `skill/SKILL.md` subfolder.** Following the `claude-api` / `toolhive-cli-user` / `google-gemini` precedent — OCI is authoritative, and a commit-pinned git package is included as a fallback.
- **Icons.** All 6 skills share a single monochrome columnar-DB SVG (three vertical bars, thematic for ClickHouse's columnar storage). Happy to differentiate per-skill if reviewers prefer.

## Test plan

- [x] `task catalog:validate` — 26 skills total, all valid (both upstream and toolhive formats)
- [x] `task catalog:build` — all 6 new skills present under `data.skills` in `build/toolhive/registry-upstream.json`
- [ ] `task catalog:validate` in CI
- [ ] Post-merge: skills appear in the published `registry-upstream.json` feed

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)