### PR TITLE
feat(skills): add 8 Socket skill entries (OCI distribution)

### DIFF
--- a/registries/toolhive/skills/socket-dep-cleanup/icon.svg
+++ b/registries/toolhive/skills/socket-dep-cleanup/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.07 0l3-3a5 5 0 0 0-7.07-7.07l-1.5 1.5"/><path d="M14 11a5 5 0 0 0-7.07 0l-3 3a5 5 0 0 0 7.07 7.07l1.5-1.5"/></svg>

--- a/registries/toolhive/skills/socket-dep-cleanup/skill.json
+++ b/registries/toolhive/skills/socket-dep-cleanup/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "socket-dep-cleanup",
+  "title": "Socket Dep Cleanup Skill",
+  "description": "Evaluate and remove a single unused dependency — searches the entire codebase for direct imports, indirect references (types packages, plugins, CLI scripts, peer deps, bundler plugins), reports findings, removes with build/test verification. Packaged from the upstream SocketDev/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "MIT",
+  "repository": {
+    "url": "https://github.com/SocketDev/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/socket-dep-cleanup:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/SocketDev/skills",
+      "ref": "25879b0c8d69cffff9ed895cfb57c12b669f76b2",
+      "subfolder": "skills/socket-fix/socket-dep-cleanup"
+    }
+  ]
+}

--- a/registries/toolhive/skills/socket-dep-patch/icon.svg
+++ b/registries/toolhive/skills/socket-dep-patch/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.07 0l3-3a5 5 0 0 0-7.07-7.07l-1.5 1.5"/><path d="M14 11a5 5 0 0 0-7.07 0l-3 3a5 5 0 0 0 7.07 7.07l1.5-1.5"/></svg>

--- a/registries/toolhive/skills/socket-dep-patch/skill.json
+++ b/registries/toolhive/skills/socket-dep-patch/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "socket-dep-patch",
+  "title": "Socket Dep Patch Skill",
+  "description": "Apply Socket's binary-level security patches with socket-patch apply — fixes vulnerabilities in-place without version changes, then verifies automated patching is configured so patches persist across installs. Packaged from the upstream SocketDev/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "MIT",
+  "repository": {
+    "url": "https://github.com/SocketDev/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/socket-dep-patch:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/SocketDev/skills",
+      "ref": "25879b0c8d69cffff9ed895cfb57c12b669f76b2",
+      "subfolder": "skills/socket-fix/socket-dep-patch"
+    }
+  ]
+}

--- a/registries/toolhive/skills/socket-dep-replace/icon.svg
+++ b/registries/toolhive/skills/socket-dep-replace/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.07 0l3-3a5 5 0 0 0-7.07-7.07l-1.5 1.5"/><path d="M14 11a5 5 0 0 0-7.07 0l-3 3a5 5 0 0 0 7.07 7.07l1.5-1.5"/></svg>

--- a/registries/toolhive/skills/socket-dep-replace/skill.json
+++ b/registries/toolhive/skills/socket-dep-replace/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "socket-dep-replace",
+  "title": "Socket Dep Replace Skill",
+  "description": "Replace a dependency — swap with an alternative, eliminate via code rewrite, or use socket-optimize for optimized replacements; builds a full API usage map and executes migration with build/test verification. Packaged from the upstream SocketDev/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "MIT",
+  "repository": {
+    "url": "https://github.com/SocketDev/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/socket-dep-replace:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/SocketDev/skills",
+      "ref": "25879b0c8d69cffff9ed895cfb57c12b669f76b2",
+      "subfolder": "skills/socket-fix/socket-dep-replace"
+    }
+  ]
+}

--- a/registries/toolhive/skills/socket-dep-upgrade/icon.svg
+++ b/registries/toolhive/skills/socket-dep-upgrade/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.07 0l3-3a5 5 0 0 0-7.07-7.07l-1.5 1.5"/><path d="M14 11a5 5 0 0 0-7.07 0l-3 3a5 5 0 0 0 7.07 7.07l1.5-1.5"/></svg>

--- a/registries/toolhive/skills/socket-dep-upgrade/skill.json
+++ b/registries/toolhive/skills/socket-dep-upgrade/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "socket-dep-upgrade",
+  "title": "Socket Dep Upgrade Skill",
+  "description": "Upgrade vulnerable dependencies with socket fix — discovers fixable CVEs via Coana analysis, applies one fix at a time via subagents (conservative no-major-updates first, escalate if needed), fixes breaking changes, bails on failure. Packaged from the upstream SocketDev/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "MIT",
+  "repository": {
+    "url": "https://github.com/SocketDev/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/socket-dep-upgrade:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/SocketDev/skills",
+      "ref": "25879b0c8d69cffff9ed895cfb57c12b669f76b2",
+      "subfolder": "skills/socket-fix/socket-dep-upgrade"
+    }
+  ]
+}

--- a/registries/toolhive/skills/socket-fix/icon.svg
+++ b/registries/toolhive/skills/socket-fix/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.07 0l3-3a5 5 0 0 0-7.07-7.07l-1.5 1.5"/><path d="M14 11a5 5 0 0 0-7.07 0l-3 3a5 5 0 0 0 7.07 7.07l1.5-1.5"/></svg>

--- a/registries/toolhive/skills/socket-fix/skill.json
+++ b/registries/toolhive/skills/socket-fix/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "socket-fix",
+  "title": "Socket Fix Skill",
+  "description": "Orchestrate dependency security fixes — Fix All (full scan, tiered aggressiveness: conservative/cautious/full) or Fix Package (single named package); delegates to socket-dep-cleanup, socket-dep-patch, socket-dep-replace, socket-dep-upgrade. Packaged from the upstream SocketDev/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "MIT",
+  "repository": {
+    "url": "https://github.com/SocketDev/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/socket-fix:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/SocketDev/skills",
+      "ref": "25879b0c8d69cffff9ed895cfb57c12b669f76b2",
+      "subfolder": "skills/socket-fix"
+    }
+  ]
+}

--- a/registries/toolhive/skills/socket-inspect/icon.svg
+++ b/registries/toolhive/skills/socket-inspect/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.07 0l3-3a5 5 0 0 0-7.07-7.07l-1.5 1.5"/><path d="M14 11a5 5 0 0 0-7.07 0l-3 3a5 5 0 0 0 7.07 7.07l1.5-1.5"/></svg>

--- a/registries/toolhive/skills/socket-inspect/skill.json
+++ b/registries/toolhive/skills/socket-inspect/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "socket-inspect",
+  "title": "Socket Inspect Skill",
+  "description": "Research a package before depending on it — pulls Socket scores, alerts, malware verdicts, CVEs, dependency tree, maintainer trust; evaluates alternatives and surfaces Socket patches. Packaged from the upstream SocketDev/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "MIT",
+  "repository": {
+    "url": "https://github.com/SocketDev/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/socket-inspect:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/SocketDev/skills",
+      "ref": "25879b0c8d69cffff9ed895cfb57c12b669f76b2",
+      "subfolder": "skills/socket-inspect"
+    }
+  ]
+}

--- a/registries/toolhive/skills/socket-scan/icon.svg
+++ b/registries/toolhive/skills/socket-scan/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.07 0l3-3a5 5 0 0 0-7.07-7.07l-1.5 1.5"/><path d="M14 11a5 5 0 0 0-7.07 0l-3 3a5 5 0 0 0 7.07 7.07l1.5-1.5"/></svg>

--- a/registries/toolhive/skills/socket-scan/skill.json
+++ b/registries/toolhive/skills/socket-scan/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "socket-scan",
+  "title": "Socket Scan Skill",
+  "description": "Run a Socket CLI dependency scan — SBOM generation, vulnerability and malware detection, license auditing, and (for enterprise accounts) reachability analysis; cdxgen fallback for unauthenticated users. Packaged from the upstream SocketDev/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "MIT",
+  "repository": {
+    "url": "https://github.com/SocketDev/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/socket-scan:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/SocketDev/skills",
+      "ref": "25879b0c8d69cffff9ed895cfb57c12b669f76b2",
+      "subfolder": "skills/socket-scan"
+    }
+  ]
+}

--- a/registries/toolhive/skills/socket-setup/icon.svg
+++ b/registries/toolhive/skills/socket-setup/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.07 0l3-3a5 5 0 0 0-7.07-7.07l-1.5 1.5"/><path d="M14 11a5 5 0 0 0-7.07 0l-3 3a5 5 0 0 0 7.07 7.07l1.5-1.5"/></svg>

--- a/registries/toolhive/skills/socket-setup/skill.json
+++ b/registries/toolhive/skills/socket-setup/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "socket-setup",
+  "title": "Socket Setup Skill",
+  "description": "Set up Socket end-to-end — prompts for account tier, installs CLI/sfw/socket-patch, authenticates, configures firewall and patch modes across GitHub, GitLab, Bitbucket, and Dockerfiles. Packaged from the upstream SocketDev/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "MIT",
+  "repository": {
+    "url": "https://github.com/SocketDev/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/socket-setup:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/SocketDev/skills",
+      "ref": "25879b0c8d69cffff9ed895cfb57c12b669f76b2",
+      "subfolder": "skills/socket-setup"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the 8-skill Socket pack from [`SocketDev/skills`](https://github.com/SocketDev/skills) to the ToolHive catalog. Content is MIT, pinned upstream to commit [`25879b0`](https://github.com/SocketDev/skills/commit/25879b0c8d69cffff9ed895cfb57c12b669f76b2) and packaged by Dockyard to `ghcr.io/stacklok/dockyard/skills/<name>:0.1.0` (Dockyard PR [#499](https://github.com/stacklok/dockyard/pull/499)).

Follows the OCI-distribution pattern established by [PR #1093 (claude-api)](https://github.com/stacklok/toolhive-catalog/pull/1093), [PR #1094 (toolhive-cli-user)](https://github.com/stacklok/toolhive-catalog/pull/1094), [PR #1095 (trailofbits)](https://github.com/stacklok/toolhive-catalog/pull/1095), and [PR #1109 (gemini)](https://github.com/stacklok/toolhive-catalog/pull/1109).

### Skills added

- `socket-fix` — **umbrella orchestrator**: Fix All (full scan, tiered aggressiveness) or Fix Package (single named); delegates to the dep-* skills
- `socket-dep-cleanup` — subagent: evaluate and remove a single unused dependency with build/test verification
- `socket-dep-patch` — subagent: apply Socket's binary-level security patches in-place (no version change) via `socket-patch apply`
- `socket-dep-replace` — subagent: swap a dependency with an alternative, inline it, or use `socket-optimize`
- `socket-dep-upgrade` — subagent: discover fixable CVEs via `socket fix` / Coana, apply one fix at a time, fix breaking changes
- `socket-inspect` — research a package before depending on it (Socket scores, alerts, CVEs, alternatives)
- `socket-scan` — Socket CLI dependency scan (SBOM, vulns, malware, license, reachability; cdxgen fallback)
- `socket-setup` — install CLI/sfw/socket-patch, authenticate, configure firewall/patch across GitHub/GitLab/Bitbucket/Dockerfiles

### Architecture

`socket-fix` is the **umbrella orchestrator skill**; the four `socket-dep-*` skills are **subagent-style delegations** invoked by `socket-fix` during Fix All / Fix Package flows. Upstream these subagent skills live under `skills/socket-fix/<name>/` — the skill.json `subfolder` path reflects that layout.

All 8 skills use the **Socket CLI (shell tool)** — none of them use or ship an MCP server.

### Notes for review

- **License: `MIT`** (confirmed at the `SocketDev/skills` repo root; upstream does not embed SPDX identifiers in per-skill SKILL.md frontmatter — tracked as an allowed Dockyard manifest issue). `socket-setup` additionally has an allowed `PIPELINE_TAINT_FLOW` scanner finding for the official `nvm` installer URL cited as documentation.
- **No `allowedTools`** — the skills rely on Claude Code built-ins plus the Socket CLI.
- **No `skill/SKILL.md` subfolder** — following the OCI-authoritative precedent; a commit-pinned git package is included as a fallback.
- **Icons** — all 8 skills share the same monochrome chain-links SVG (supply-chain theme). Happy to differentiate per-skill if reviewers prefer.

## Test plan

- [x] `task catalog:validate` — 28 skills total, all valid (both upstream and toolhive formats)
- [x] `task catalog:build` — all 8 new skills present under `data.skills` in `build/toolhive/registry-upstream.json`
- [ ] `task catalog:validate` in CI
- [ ] Post-merge: skills appear in the published `registry-upstream.json` feed

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>

Generated with [Claude Code](https://claude.com/claude-code)