### PR TITLE
feat(skills): add 8 Pulumi skill entries (OCI distribution)

### DIFF
--- a/registries/toolhive/skills/package-usage/icon.svg
+++ b/registries/toolhive/skills/package-usage/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="14" width="16" height="5" rx="1"/><rect x="4" y="8" width="16" height="5" rx="1"/><rect x="4" y="2" width="16" height="5" rx="1"/></svg>

--- a/registries/toolhive/skills/package-usage/skill.json
+++ b/registries/toolhive/skills/package-usage/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "package-usage",
+  "title": "Pulumi Package Usage Audit Skill",
+  "description": "Audit Pulumi package usage across stacks — cross-stack inventory of provider/component packages, detect unused or outdated dependencies (hand off to provider-upgrade for version bumps). Packaged from the upstream pulumi/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/pulumi/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/package-usage:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/pulumi/agent-skills",
+      "ref": "fbeac07327a601b954ba82e7f7e1c24cf3b1fa71",
+      "subfolder": "authoring/skills/package-usage"
+    }
+  ]
+}

--- a/registries/toolhive/skills/provider-upgrade/icon.svg
+++ b/registries/toolhive/skills/provider-upgrade/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="14" width="16" height="5" rx="1"/><rect x="4" y="8" width="16" height="5" rx="1"/><rect x="4" y="2" width="16" height="5" rx="1"/></svg>

--- a/registries/toolhive/skills/provider-upgrade/skill.json
+++ b/registries/toolhive/skills/provider-upgrade/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "provider-upgrade",
+  "title": "Pulumi Provider Upgrade Skill",
+  "description": "Upgrade Pulumi provider packages safely — npm/pip/go package bumps, post-upgrade resource-breakage diagnosis, cross-stack upgrade planning. Packaged from the upstream pulumi/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/pulumi/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/provider-upgrade:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/pulumi/agent-skills",
+      "ref": "fbeac07327a601b954ba82e7f7e1c24cf3b1fa71",
+      "subfolder": "authoring/skills/provider-upgrade"
+    }
+  ]
+}

--- a/registries/toolhive/skills/pulumi-automation-api/icon.svg
+++ b/registries/toolhive/skills/pulumi-automation-api/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="14" width="16" height="5" rx="1"/><rect x="4" y="8" width="16" height="5" rx="1"/><rect x="4" y="2" width="16" height="5" rx="1"/></svg>

--- a/registries/toolhive/skills/pulumi-automation-api/skill.json
+++ b/registries/toolhive/skills/pulumi-automation-api/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "pulumi-automation-api",
+  "title": "Pulumi Automation API Skill",
+  "description": "Drive Pulumi programmatically with the Automation API — embed up/destroy/preview operations, manage stacks from code (TypeScript, Python, Go, .NET), event streaming, and workspace configuration. Packaged from the upstream pulumi/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/pulumi/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/pulumi-automation-api:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/pulumi/agent-skills",
+      "ref": "fbeac07327a601b954ba82e7f7e1c24cf3b1fa71",
+      "subfolder": "authoring/skills/pulumi-automation-api"
+    }
+  ]
+}

--- a/registries/toolhive/skills/pulumi-best-practices/icon.svg
+++ b/registries/toolhive/skills/pulumi-best-practices/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="14" width="16" height="5" rx="1"/><rect x="4" y="8" width="16" height="5" rx="1"/><rect x="4" y="2" width="16" height="5" rx="1"/></svg>

--- a/registries/toolhive/skills/pulumi-best-practices/skill.json
+++ b/registries/toolhive/skills/pulumi-best-practices/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "pulumi-best-practices",
+  "title": "Pulumi Best Practices Skill",
+  "description": "Pulumi best practices across IaC projects — project and stack organization, config/secret management, resource naming, output handling, provider selection, and common anti-patterns. Packaged from the upstream pulumi/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/pulumi/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/pulumi-best-practices:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/pulumi/agent-skills",
+      "ref": "fbeac07327a601b954ba82e7f7e1c24cf3b1fa71",
+      "subfolder": "authoring/skills/pulumi-best-practices"
+    }
+  ]
+}

--- a/registries/toolhive/skills/pulumi-component/icon.svg
+++ b/registries/toolhive/skills/pulumi-component/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="14" width="16" height="5" rx="1"/><rect x="4" y="8" width="16" height="5" rx="1"/><rect x="4" y="2" width="16" height="5" rx="1"/></svg>

--- a/registries/toolhive/skills/pulumi-component/skill.json
+++ b/registries/toolhive/skills/pulumi-component/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "pulumi-component",
+  "title": "Pulumi Component Authoring Skill",
+  "description": "Build reusable Pulumi Components — author multi-language components via ComponentResource, package for Pulumi Registry, handle inputs/outputs, schema, and versioning. Packaged from the upstream pulumi/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/pulumi/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/pulumi-component:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/pulumi/agent-skills",
+      "ref": "fbeac07327a601b954ba82e7f7e1c24cf3b1fa71",
+      "subfolder": "authoring/skills/pulumi-component"
+    }
+  ]
+}

--- a/registries/toolhive/skills/pulumi-esc/icon.svg
+++ b/registries/toolhive/skills/pulumi-esc/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="14" width="16" height="5" rx="1"/><rect x="4" y="8" width="16" height="5" rx="1"/><rect x="4" y="2" width="16" height="5" rx="1"/></svg>

--- a/registries/toolhive/skills/pulumi-esc/skill.json
+++ b/registries/toolhive/skills/pulumi-esc/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "pulumi-esc",
+  "title": "Pulumi ESC (Environments, Secrets, Configurations) Skill",
+  "description": "Pulumi ESC (Environments, Secrets, Configurations) — centralize and share config/secrets across stacks, integrate with CI/CD, resolve at runtime from cloud providers or static sources. Packaged from the upstream pulumi/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/pulumi/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/pulumi-esc:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/pulumi/agent-skills",
+      "ref": "fbeac07327a601b954ba82e7f7e1c24cf3b1fa71",
+      "subfolder": "authoring/skills/pulumi-esc"
+    }
+  ]
+}

--- a/registries/toolhive/skills/pulumi-upgrade-provider/icon.svg
+++ b/registries/toolhive/skills/pulumi-upgrade-provider/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="14" width="16" height="5" rx="1"/><rect x="4" y="8" width="16" height="5" rx="1"/><rect x="4" y="2" width="16" height="5" rx="1"/></svg>

--- a/registries/toolhive/skills/pulumi-upgrade-provider/skill.json
+++ b/registries/toolhive/skills/pulumi-upgrade-provider/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "pulumi-upgrade-provider",
+  "title": "Pulumi Bridged Provider Upgrade Skill",
+  "description": "Upgrade a Pulumi bridged provider to a new upstream Terraform-provider version — pulumi-terraform-bridge integration, schema diffing, generated SDK regeneration, and release checklist. Packaged from the upstream pulumi/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/pulumi/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/pulumi-upgrade-provider:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/pulumi/agent-skills",
+      "ref": "fbeac07327a601b954ba82e7f7e1c24cf3b1fa71",
+      "subfolder": "authoring/skills/pulumi-upgrade-provider"
+    }
+  ]
+}

--- a/registries/toolhive/skills/upstream-patches/icon.svg
+++ b/registries/toolhive/skills/upstream-patches/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="14" width="16" height="5" rx="1"/><rect x="4" y="8" width="16" height="5" rx="1"/><rect x="4" y="2" width="16" height="5" rx="1"/></svg>

--- a/registries/toolhive/skills/upstream-patches/skill.json
+++ b/registries/toolhive/skills/upstream-patches/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "upstream-patches",
+  "title": "Pulumi Upstream Patches Skill",
+  "description": "Manage upstream patches for bridged Pulumi providers — apply, refresh, and rebase patches against upstream Terraform providers; common workflows for provider maintainers. Packaged from the upstream pulumi/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/pulumi/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/upstream-patches:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/pulumi/agent-skills",
+      "ref": "fbeac07327a601b954ba82e7f7e1c24cf3b1fa71",
+      "subfolder": "authoring/skills/upstream-patches"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the 8-skill Pulumi pack from [`pulumi/agent-skills`](https://github.com/pulumi/agent-skills) to the ToolHive catalog. Content is Apache-2.0, pinned upstream to commit [`fbeac07`](https://github.com/pulumi/agent-skills/commit/fbeac07327a601b954ba82e7f7e1c24cf3b1fa71) and packaged by Dockyard ([stacklok/dockyard#514](https://github.com/stacklok/dockyard/pull/514)) to `ghcr.io/stacklok/dockyard/skills/<name>:0.1.0`.

Follows the OCI-distribution pattern established by [PR #1093 (claude-api)](https://github.com/stacklok/toolhive-catalog/pull/1093), [PR #1094 (toolhive-cli-user)](https://github.com/stacklok/toolhive-catalog/pull/1094), [PR #1095 (trailofbits security skills)](https://github.com/stacklok/toolhive-catalog/pull/1095), and [PR #1109 (gemini skills)](https://github.com/stacklok/toolhive-catalog/pull/1109).

### Skills added

- `package-usage` — cross-stack Pulumi package inventory and audits; detects unused or outdated provider/component dependencies before coordinated upgrades
- `provider-upgrade` — safe Pulumi provider package bumps (npm/pip/go), post-upgrade resource-breakage diagnosis, cross-stack upgrade planning
- `pulumi-automation-api` — drive Pulumi programmatically (embed up/destroy/preview in TypeScript, Python, Go, .NET; event streaming; workspace configuration)
- `pulumi-best-practices` — project/stack organization, config/secret management, output handling, resource naming, common anti-patterns
- `pulumi-component` — author reusable multi-language `ComponentResource`s with schema, inputs/outputs, and versioning for the Pulumi Registry
- `pulumi-esc` — Environments, Secrets, and Configurations: centralize config across stacks, integrate with CI/CD, resolve secrets at runtime from cloud providers
- `pulumi-upgrade-provider` — upgrade bridged Pulumi providers to new upstream Terraform-provider versions (pulumi-terraform-bridge, schema diffing, SDK regen)
- `upstream-patches` — manage patches for bridged Pulumi providers (apply, refresh, rebase against upstream Terraform providers)

### Notes for review

- **License: `Apache-2.0`.** Confirmed at the `pulumi/agent-skills` repo root; upstream does not embed an SPDX identifier in per-skill `SKILL.md` frontmatter, which is tracked as an allowed Dockyard manifest issue.
- **No `allowedTools`.** None of the 8 skills declare `mcp__*` tools — they only use Claude Code built-ins.
- **No `skill/SKILL.md` subfolder.** Following the `claude-api` / `toolhive-cli-user` precedent — OCI is authoritative, and a commit-pinned git package is included as a fallback. The git package `subfolder` uses the upstream `authoring/skills/<name>/` path verbatim.
- **Icons.** All 8 skills share the same monochrome 24x24 stacked-tiles IaC icon. Happy to differentiate per-skill if reviewers prefer.

## Test plan

- [x] `task catalog:validate` — 28 toolhive skills total, all valid (both upstream and toolhive formats)
- [x] `task catalog:build` — all 8 new skills present under `data.skills` in `build/toolhive/registry-upstream.json`
- [ ] `task catalog:validate` in CI
- [ ] Post-merge: skills appear in the published `registry-upstream.json` feed

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)