### PR TITLE
feat(skills): add 6 Datadog skill entries (OCI distribution)

### DIFF
--- a/registries/toolhive/skills/dd-apm/icon.svg
+++ b/registries/toolhive/skills/dd-apm/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3 L3 21 L21 21"/><rect x="6" y="13" width="3" height="6"/><rect x="11" y="8" width="3" height="11"/><rect x="16" y="4" width="3" height="15"/></svg>

--- a/registries/toolhive/skills/dd-apm/skill.json
+++ b/registries/toolhive/skills/dd-apm/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "dd-apm",
+  "title": "Datadog APM Skill",
+  "description": "Datadog APM via the `pup` CLI — search traces, inspect services, surface slow endpoints and error patterns; analyze latency/throughput and trace-to-log correlation. Packaged from the upstream datadog-labs/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "MIT",
+  "repository": {
+    "url": "https://github.com/datadog-labs/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/dd-apm:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/datadog-labs/agent-skills",
+      "ref": "a04611e9d3c402859f7d973be451c16cd5982ca5",
+      "subfolder": "dd-apm"
+    }
+  ]
+}

--- a/registries/toolhive/skills/dd-docs/icon.svg
+++ b/registries/toolhive/skills/dd-docs/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3 L3 21 L21 21"/><rect x="6" y="13" width="3" height="6"/><rect x="11" y="8" width="3" height="11"/><rect x="16" y="4" width="3" height="15"/></svg>

--- a/registries/toolhive/skills/dd-docs/skill.json
+++ b/registries/toolhive/skills/dd-docs/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "dd-docs",
+  "title": "Datadog Docs Skill",
+  "description": "Search Datadog documentation via the `pup` CLI — look up product docs, integrations, and API references for grounding Datadog-related agent work. Packaged from the upstream datadog-labs/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "MIT",
+  "repository": {
+    "url": "https://github.com/datadog-labs/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/dd-docs:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/datadog-labs/agent-skills",
+      "ref": "a04611e9d3c402859f7d973be451c16cd5982ca5",
+      "subfolder": "dd-docs"
+    }
+  ]
+}

--- a/registries/toolhive/skills/dd-llmo-eval-session-classify/icon.svg
+++ b/registries/toolhive/skills/dd-llmo-eval-session-classify/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3 L3 21 L21 21"/><rect x="6" y="13" width="3" height="6"/><rect x="11" y="8" width="3" height="11"/><rect x="16" y="4" width="3" height="15"/></svg>

--- a/registries/toolhive/skills/dd-llmo-eval-session-classify/skill.json
+++ b/registries/toolhive/skills/dd-llmo-eval-session-classify/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "dd-llmo-eval-session-classify",
+  "title": "Datadog LLM Observability Eval Session Classify Skill",
+  "description": "Classify LLM evaluation sessions in Datadog LLM Observability — group sessions by outcome, taxonomy, or failure mode for regression detection and reporting. Packaged from the upstream datadog-labs/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "MIT",
+  "repository": {
+    "url": "https://github.com/datadog-labs/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/dd-llmo-eval-session-classify:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/datadog-labs/agent-skills",
+      "ref": "a04611e9d3c402859f7d973be451c16cd5982ca5",
+      "subfolder": "dd-llmo/eval-session-classify"
+    }
+  ]
+}

--- a/registries/toolhive/skills/dd-logs/icon.svg
+++ b/registries/toolhive/skills/dd-logs/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3 L3 21 L21 21"/><rect x="6" y="13" width="3" height="6"/><rect x="11" y="8" width="3" height="11"/><rect x="16" y="4" width="3" height="15"/></svg>

--- a/registries/toolhive/skills/dd-logs/skill.json
+++ b/registries/toolhive/skills/dd-logs/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "dd-logs",
+  "title": "Datadog Logs Skill",
+  "description": "Search Datadog logs and manage pipelines and archives via the `pup` CLI — query syntax, time-range filtering, facets/tags, and log-to-metric or log-to-trace correlation. Packaged from the upstream datadog-labs/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "MIT",
+  "repository": {
+    "url": "https://github.com/datadog-labs/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/dd-logs:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/datadog-labs/agent-skills",
+      "ref": "a04611e9d3c402859f7d973be451c16cd5982ca5",
+      "subfolder": "dd-logs"
+    }
+  ]
+}

--- a/registries/toolhive/skills/dd-monitors/icon.svg
+++ b/registries/toolhive/skills/dd-monitors/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3 L3 21 L21 21"/><rect x="6" y="13" width="3" height="6"/><rect x="11" y="8" width="3" height="11"/><rect x="16" y="4" width="3" height="15"/></svg>

--- a/registries/toolhive/skills/dd-monitors/skill.json
+++ b/registries/toolhive/skills/dd-monitors/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "dd-monitors",
+  "title": "Datadog Monitors Skill",
+  "description": "Create, manage, and mute Datadog monitors and alerts via the `pup` CLI — monitor types, query syntax, thresholds, downtimes, and alert-routing configuration. Packaged from the upstream datadog-labs/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "MIT",
+  "repository": {
+    "url": "https://github.com/datadog-labs/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/dd-monitors:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/datadog-labs/agent-skills",
+      "ref": "a04611e9d3c402859f7d973be451c16cd5982ca5",
+      "subfolder": "dd-monitors"
+    }
+  ]
+}

--- a/registries/toolhive/skills/dd-pup/icon.svg
+++ b/registries/toolhive/skills/dd-pup/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3 L3 21 L21 21"/><rect x="6" y="13" width="3" height="6"/><rect x="11" y="8" width="3" height="11"/><rect x="16" y="4" width="3" height="15"/></svg>

--- a/registries/toolhive/skills/dd-pup/skill.json
+++ b/registries/toolhive/skills/dd-pup/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "dd-pup",
+  "title": "Datadog pup CLI Skill",
+  "description": "Primary `pup` CLI for Datadog agent workflows — authentication, PATH setup, command reference across monitors, logs, APM, metrics, and docs. Packaged from the upstream datadog-labs/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "MIT",
+  "repository": {
+    "url": "https://github.com/datadog-labs/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/dd-pup:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/datadog-labs/agent-skills",
+      "ref": "a04611e9d3c402859f7d973be451c16cd5982ca5",
+      "subfolder": "dd-pup"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the Datadog pack from [`datadog-labs/agent-skills`](https://github.com/datadog-labs/agent-skills) to the ToolHive catalog. Content is MIT-licensed, pinned upstream to commit [`a04611e`](https://github.com/datadog-labs/agent-skills/commit/a04611e9d3c402859f7d973be451c16cd5982ca5) and packaged by Dockyard (see [stacklok/dockyard#515](https://github.com/stacklok/dockyard/pull/515)) to `ghcr.io/stacklok/dockyard/skills/<name>:0.1.0`.

Follows the OCI-distribution pattern established by [PR #1093 (claude-api)](https://github.com/stacklok/toolhive-catalog/pull/1093), [PR #1094 (toolhive-cli-user)](https://github.com/stacklok/toolhive-catalog/pull/1094), [PR #1095 (trailofbits security skills)](https://github.com/stacklok/toolhive-catalog/pull/1095), and [PR #1109 (Gemini skills)](https://github.com/stacklok/toolhive-catalog/pull/1109).

### Skills added

- `dd-apm` — Datadog APM via the `pup` CLI (search traces, inspect services, slow endpoints, error patterns, latency/throughput, trace-to-log correlation)
- `dd-docs` — search Datadog documentation via the `pup` CLI (product docs, integrations, API references)
- `dd-logs` — search Datadog logs and manage pipelines/archives via the `pup` CLI (query syntax, facets/tags, log-to-metric/trace correlation)
- `dd-monitors` — create, manage, and mute Datadog monitors and alerts via the `pup` CLI (monitor types, thresholds, downtimes, alert routing)
- `dd-pup` — primary `pup` CLI skill (authentication, PATH setup, command reference across monitors, logs, APM, metrics, docs)
- `dd-llmo-eval-session-classify` — classify LLM evaluation sessions in Datadog LLM Observability (group by outcome, taxonomy, or failure mode)

### Skills NOT added

The upstream `datadog-labs/agent-skills` repo ships 9 skills; 3 are intentionally excluded because they reference MCP tools (`mcp__datadog-mcp-core__*` and `mcp__datadog-llmo-mcp__*`) whose servers are not in the ToolHive catalog. Per [`docs/skill-criteria.md` — MCP server dependencies](docs/skill-criteria.md#mcp-server-dependencies), that is a hard blocker.

- `dd-llmo-eval-bootstrap` — requires `mcp__datadog-mcp-core__*` and `mcp__datadog-llmo-mcp__*`
- `dd-llmo-eval-trace-rca` — requires `mcp__datadog-mcp-core__*` and `mcp__datadog-llmo-mcp__*`
- `dd-llmo-experiment-analyzer` — requires `mcp__datadog-mcp-core__*` and `mcp__datadog-llmo-mcp__*`

**Missing MCP servers:** `datadog-mcp-core` and `datadog-llmo-mcp`. The catalog currently only has `datadog-remote`, which is **not** sufficient — those 3 skills specifically reference the `datadog-mcp-core` and `datadog-llmo-mcp` tool namespaces, not the remote HTTP entry. Following the precedent of [PR #1095](https://github.com/stacklok/toolhive-catalog/pull/1095), where `zeroize-audit` was skipped for an analogous missing-server reason (Serena). Will revisit once those servers land in the catalog.

### Notes for review

- **License: `MIT`.** Confirmed at the `datadog-labs/agent-skills` repo root; upstream does not embed an SPDX license identifier in per-skill `SKILL.md` frontmatter, which is tracked as an allowed Dockyard manifest issue.
- **No `allowedTools`.** The 6 included skills use the `pup` CLI via Bash and Claude Code built-ins; none declare `mcp__*` tools.
- **No `skill/SKILL.md` subfolder.** Following the `claude-api` / `toolhive-cli-user` precedent — OCI is authoritative; a commit-pinned git package is included as a fallback.
- **Icons.** All 6 skills share the same monochrome bar-chart SVG (thematic for observability). Happy to differentiate per-skill if reviewers prefer.

## Test plan

- [x] `task catalog:validate` — 26 skills total, all valid (both upstream and toolhive formats)
- [x] `task catalog:build` — all 6 new skills present under `data.skills` in `build/toolhive/registry-upstream.json`
- [ ] `task catalog:validate` in CI
- [ ] Post-merge: skills appear in the published `registry-upstream.json` feed

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>