### PR TITLE
feat(skills): add 12 Firebase skill entries (OCI distribution)

### DIFF
--- a/registries/toolhive/skills/developing-genkit-dart/icon.svg
+++ b/registries/toolhive/skills/developing-genkit-dart/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2c0 3-4 5-4 9a4 4 0 0 0 3 3.9"/><path d="M15 7c0 2 3 4 3 8a6 6 0 1 1-12 0c0-3 2-5 3-7 1 2 2 3 3 3 1-2 2-3 3-4z"/></svg>

--- a/registries/toolhive/skills/developing-genkit-dart/skill.json
+++ b/registries/toolhive/skills/developing-genkit-dart/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "developing-genkit-dart",
+  "title": "Developing with Genkit (Dart)",
+  "description": "Build AI features with Firebase Genkit in Dart/Flutter — Genkit core concepts (flows, models, tools, indexing, prompts), plugin setup, and common AI workflows (RAG, agents) for Dart apps. Packaged from the upstream firebase/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/firebase/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/developing-genkit-dart:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/firebase/agent-skills",
+      "ref": "4679fc8dd31f77f068301eb4796ec37904da53aa",
+      "subfolder": "skills/developing-genkit-dart"
+    }
+  ]
+}

--- a/registries/toolhive/skills/developing-genkit-go/icon.svg
+++ b/registries/toolhive/skills/developing-genkit-go/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2c0 3-4 5-4 9a4 4 0 0 0 3 3.9"/><path d="M15 7c0 2 3 4 3 8a6 6 0 1 1-12 0c0-3 2-5 3-7 1 2 2 3 3 3 1-2 2-3 3-4z"/></svg>

--- a/registries/toolhive/skills/developing-genkit-go/skill.json
+++ b/registries/toolhive/skills/developing-genkit-go/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "developing-genkit-go",
+  "title": "Developing with Genkit (Go)",
+  "description": "Build AI features with Firebase Genkit in Go — flows, models, tool calling, indexing and retrieval, observability, and deployment patterns for Go services. Packaged from the upstream firebase/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/firebase/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/developing-genkit-go:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/firebase/agent-skills",
+      "ref": "4679fc8dd31f77f068301eb4796ec37904da53aa",
+      "subfolder": "skills/developing-genkit-go"
+    }
+  ]
+}

--- a/registries/toolhive/skills/developing-genkit-js/icon.svg
+++ b/registries/toolhive/skills/developing-genkit-js/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2c0 3-4 5-4 9a4 4 0 0 0 3 3.9"/><path d="M15 7c0 2 3 4 3 8a6 6 0 1 1-12 0c0-3 2-5 3-7 1 2 2 3 3 3 1-2 2-3 3-4z"/></svg>

--- a/registries/toolhive/skills/developing-genkit-js/skill.json
+++ b/registries/toolhive/skills/developing-genkit-js/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "developing-genkit-js",
+  "title": "Developing with Genkit (JavaScript/TypeScript)",
+  "description": "Build AI features with Firebase Genkit in JavaScript/TypeScript — flows, models, tools, plugins, observability, and deployment patterns for Node.js and Next.js apps. Packaged from the upstream firebase/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/firebase/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/developing-genkit-js:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/firebase/agent-skills",
+      "ref": "4679fc8dd31f77f068301eb4796ec37904da53aa",
+      "subfolder": "skills/developing-genkit-js"
+    }
+  ]
+}

--- a/registries/toolhive/skills/firebase-ai-logic-basics/icon.svg
+++ b/registries/toolhive/skills/firebase-ai-logic-basics/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2c0 3-4 5-4 9a4 4 0 0 0 3 3.9"/><path d="M15 7c0 2 3 4 3 8a6 6 0 1 1-12 0c0-3 2-5 3-7 1 2 2 3 3 3 1-2 2-3 3-4z"/></svg>

--- a/registries/toolhive/skills/firebase-ai-logic-basics/skill.json
+++ b/registries/toolhive/skills/firebase-ai-logic-basics/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "firebase-ai-logic-basics",
+  "title": "Firebase AI Logic Basics",
+  "description": "Use Firebase AI Logic — secure client-side access to Gemini and Imagen models from mobile/web apps with App Check, prompt and schema management, and per-user rate controls. Packaged from the upstream firebase/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/firebase/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/firebase-ai-logic-basics:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/firebase/agent-skills",
+      "ref": "4679fc8dd31f77f068301eb4796ec37904da53aa",
+      "subfolder": "skills/firebase-ai-logic-basics"
+    }
+  ]
+}

--- a/registries/toolhive/skills/firebase-app-hosting-basics/icon.svg
+++ b/registries/toolhive/skills/firebase-app-hosting-basics/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2c0 3-4 5-4 9a4 4 0 0 0 3 3.9"/><path d="M15 7c0 2 3 4 3 8a6 6 0 1 1-12 0c0-3 2-5 3-7 1 2 2 3 3 3 1-2 2-3 3-4z"/></svg>

--- a/registries/toolhive/skills/firebase-app-hosting-basics/skill.json
+++ b/registries/toolhive/skills/firebase-app-hosting-basics/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "firebase-app-hosting-basics",
+  "title": "Firebase App Hosting Basics",
+  "description": "Deploy full-stack web apps with Firebase App Hosting — Next.js and Angular framework support, GitHub integration, rollouts, backends, and environment configuration. Packaged from the upstream firebase/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/firebase/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/firebase-app-hosting-basics:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/firebase/agent-skills",
+      "ref": "4679fc8dd31f77f068301eb4796ec37904da53aa",
+      "subfolder": "skills/firebase-app-hosting-basics"
+    }
+  ]
+}

--- a/registries/toolhive/skills/firebase-auth-basics/icon.svg
+++ b/registries/toolhive/skills/firebase-auth-basics/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2c0 3-4 5-4 9a4 4 0 0 0 3 3.9"/><path d="M15 7c0 2 3 4 3 8a6 6 0 1 1-12 0c0-3 2-5 3-7 1 2 2 3 3 3 1-2 2-3 3-4z"/></svg>

--- a/registries/toolhive/skills/firebase-auth-basics/skill.json
+++ b/registries/toolhive/skills/firebase-auth-basics/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "firebase-auth-basics",
+  "title": "Firebase Authentication Basics",
+  "description": "Add authentication with Firebase Authentication — sign-in methods (email/password, phone, OAuth providers, anonymous), session management, custom claims, and integration patterns across platforms. Packaged from the upstream firebase/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/firebase/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/firebase-auth-basics:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/firebase/agent-skills",
+      "ref": "4679fc8dd31f77f068301eb4796ec37904da53aa",
+      "subfolder": "skills/firebase-auth-basics"
+    }
+  ]
+}

--- a/registries/toolhive/skills/firebase-basics/icon.svg
+++ b/registries/toolhive/skills/firebase-basics/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2c0 3-4 5-4 9a4 4 0 0 0 3 3.9"/><path d="M15 7c0 2 3 4 3 8a6 6 0 1 1-12 0c0-3 2-5 3-7 1 2 2 3 3 3 1-2 2-3 3-4z"/></svg>

--- a/registries/toolhive/skills/firebase-basics/skill.json
+++ b/registries/toolhive/skills/firebase-basics/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "firebase-basics",
+  "title": "Firebase Basics",
+  "description": "Firebase fundamentals — project setup, SDK install across platforms, Firebase CLI, local emulators, environment config, and common product selection guidance. Packaged from the upstream firebase/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/firebase/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/firebase-basics:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/firebase/agent-skills",
+      "ref": "4679fc8dd31f77f068301eb4796ec37904da53aa",
+      "subfolder": "skills/firebase-basics"
+    }
+  ]
+}

--- a/registries/toolhive/skills/firebase-data-connect-basics/icon.svg
+++ b/registries/toolhive/skills/firebase-data-connect-basics/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2c0 3-4 5-4 9a4 4 0 0 0 3 3.9"/><path d="M15 7c0 2 3 4 3 8a6 6 0 1 1-12 0c0-3 2-5 3-7 1 2 2 3 3 3 1-2 2-3 3-4z"/></svg>

--- a/registries/toolhive/skills/firebase-data-connect-basics/skill.json
+++ b/registries/toolhive/skills/firebase-data-connect-basics/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "firebase-data-connect-basics",
+  "title": "Firebase Data Connect Basics",
+  "description": "Firebase SQL Connect (formerly Data Connect) — managed Postgres with auto-generated GraphQL APIs, typed client SDKs, and Firebase Auth integration. Packaged from the upstream firebase/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/firebase/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/firebase-data-connect-basics:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/firebase/agent-skills",
+      "ref": "4679fc8dd31f77f068301eb4796ec37904da53aa",
+      "subfolder": "skills/firebase-data-connect-basics"
+    }
+  ]
+}

--- a/registries/toolhive/skills/firebase-firestore-enterprise-native-mode/icon.svg
+++ b/registries/toolhive/skills/firebase-firestore-enterprise-native-mode/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2c0 3-4 5-4 9a4 4 0 0 0 3 3.9"/><path d="M15 7c0 2 3 4 3 8a6 6 0 1 1-12 0c0-3 2-5 3-7 1 2 2 3 3 3 1-2 2-3 3-4z"/></svg>

--- a/registries/toolhive/skills/firebase-firestore-enterprise-native-mode/skill.json
+++ b/registries/toolhive/skills/firebase-firestore-enterprise-native-mode/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "firebase-firestore-enterprise-native-mode",
+  "title": "Firestore Enterprise Native Mode",
+  "description": "Firestore in Enterprise Native Mode for Google Cloud — backend-only operations, advanced transaction semantics, multi-region replication, and migration guidance. Packaged from the upstream firebase/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/firebase/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/firebase-firestore-enterprise-native-mode:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/firebase/agent-skills",
+      "ref": "4679fc8dd31f77f068301eb4796ec37904da53aa",
+      "subfolder": "skills/firebase-firestore-enterprise-native-mode"
+    }
+  ]
+}

--- a/registries/toolhive/skills/firebase-firestore-standard/icon.svg
+++ b/registries/toolhive/skills/firebase-firestore-standard/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2c0 3-4 5-4 9a4 4 0 0 0 3 3.9"/><path d="M15 7c0 2 3 4 3 8a6 6 0 1 1-12 0c0-3 2-5 3-7 1 2 2 3 3 3 1-2 2-3 3-4z"/></svg>

--- a/registries/toolhive/skills/firebase-firestore-standard/skill.json
+++ b/registries/toolhive/skills/firebase-firestore-standard/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "firebase-firestore-standard",
+  "title": "Firestore Standard",
+  "description": "Firestore Standard — document database for mobile/web apps with offline support, realtime sync, security rules, indexes, and data modeling patterns. Packaged from the upstream firebase/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/firebase/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/firebase-firestore-standard:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/firebase/agent-skills",
+      "ref": "4679fc8dd31f77f068301eb4796ec37904da53aa",
+      "subfolder": "skills/firebase-firestore-standard"
+    }
+  ]
+}

--- a/registries/toolhive/skills/firebase-hosting-basics/icon.svg
+++ b/registries/toolhive/skills/firebase-hosting-basics/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2c0 3-4 5-4 9a4 4 0 0 0 3 3.9"/><path d="M15 7c0 2 3 4 3 8a6 6 0 1 1-12 0c0-3 2-5 3-7 1 2 2 3 3 3 1-2 2-3 3-4z"/></svg>

--- a/registries/toolhive/skills/firebase-hosting-basics/skill.json
+++ b/registries/toolhive/skills/firebase-hosting-basics/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "firebase-hosting-basics",
+  "title": "Firebase Hosting Basics",
+  "description": "Firebase Hosting — static and dynamic site hosting with global CDN; rewrite/redirect rules, preview channels, GitHub Actions integration, and custom domains. Packaged from the upstream firebase/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/firebase/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/firebase-hosting-basics:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/firebase/agent-skills",
+      "ref": "4679fc8dd31f77f068301eb4796ec37904da53aa",
+      "subfolder": "skills/firebase-hosting-basics"
+    }
+  ]
+}

--- a/registries/toolhive/skills/firebase-security-rules-auditor/icon.svg
+++ b/registries/toolhive/skills/firebase-security-rules-auditor/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2c0 3-4 5-4 9a4 4 0 0 0 3 3.9"/><path d="M15 7c0 2 3 4 3 8a6 6 0 1 1-12 0c0-3 2-5 3-7 1 2 2 3 3 3 1-2 2-3 3-4z"/></svg>

--- a/registries/toolhive/skills/firebase-security-rules-auditor/skill.json
+++ b/registries/toolhive/skills/firebase-security-rules-auditor/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "firebase-security-rules-auditor",
+  "title": "Firebase Security Rules Auditor",
+  "description": "Audit Firebase Security Rules for Firestore, Realtime Database, and Cloud Storage — common bypass patterns, authorization gaps, path-traversal issues, and rule-test recommendations. Packaged from the upstream firebase/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/firebase/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/firebase-security-rules-auditor:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/firebase/agent-skills",
+      "ref": "4679fc8dd31f77f068301eb4796ec37904da53aa",
+      "subfolder": "skills/firebase-security-rules-auditor"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the 12-skill Firebase pack from [`firebase/agent-skills`](https://github.com/firebase/agent-skills) to the ToolHive catalog. Content is Apache-2.0, pinned upstream to commit [`4679fc8`](https://github.com/firebase/agent-skills/commit/4679fc8dd31f77f068301eb4796ec37904da53aa) and packaged by Dockyard (see [stacklok/dockyard#513](https://github.com/stacklok/dockyard/pull/513)) to `ghcr.io/stacklok/dockyard/skills/<name>:0.1.0`.

Follows the OCI-distribution pattern established by [PR #1093 (claude-api)](https://github.com/stacklok/toolhive-catalog/pull/1093), [PR #1094 (toolhive-cli-user)](https://github.com/stacklok/toolhive-catalog/pull/1094), [PR #1095 (trailofbits security skills)](https://github.com/stacklok/toolhive-catalog/pull/1095), and [PR #1109 (gemini)](https://github.com/stacklok/toolhive-catalog/pull/1109).

### Skills added

**Firebase fundamentals**
- `firebase-basics` — project setup, SDK install, Firebase CLI, emulators, product selection
- `firebase-auth-basics` — sign-in methods, session management, custom claims across platforms

**AI with Firebase**
- `firebase-ai-logic-basics` — client-side Gemini/Imagen access with App Check and per-user rate controls
- `developing-genkit-dart` — Genkit flows, models, tools, prompts for Dart/Flutter apps
- `developing-genkit-go` — Genkit flows, tool calling, retrieval, observability for Go services
- `developing-genkit-js` — Genkit flows, plugins, observability for Node.js and Next.js apps

**Data**
- `firebase-data-connect-basics` — Firebase SQL Connect (managed Postgres + GraphQL, typed SDKs, Auth integration)
- `firebase-firestore-standard` — document DB for mobile/web with offline sync, rules, indexes
- `firebase-firestore-enterprise-native-mode` — Firestore on GCP for backend workloads, multi-region, migrations

**Hosting**
- `firebase-hosting-basics` — static/dynamic site hosting, preview channels, GitHub Actions integration
- `firebase-app-hosting-basics` — full-stack Next.js/Angular deploys with rollouts and backends

**Security**
- `firebase-security-rules-auditor` — audits Firestore/RTDB/Cloud Storage rules for bypass patterns and authorization gaps

### Notes for review

- **License: `Apache-2.0`.** Confirmed at the `firebase/agent-skills` repo root; upstream does not embed an SPDX identifier in per-skill SKILL.md frontmatter, which is tracked as an allowed Dockyard manifest issue.
- **Upstream `name` drift (3 skills).** Three skills have upstream SKILL.md `name:` frontmatter that differs from the dockyard `metadata.name` / OCI tag:
  - `firebase-ai-logic-basics` — upstream frontmatter name is `firebase-ai-logic`
  - `firebase-data-connect-basics` — upstream frontmatter name is `firebase-data-connect`
  - `firebase-security-rules-auditor` — upstream frontmatter name is `firestore-security-rules-auditor`

  The catalog `name` and directory match the dockyard manifest name (which is what the OCI tag uses: `ghcr.io/stacklok/dockyard/skills/<name>:0.1.0`). This keeps the catalog entry aligned with the OCI identifier users will actually install; flagging it here for reviewer visibility.
- **No `allowedTools`.** None of the 12 skills declare `mcp__*` tools — they use Claude Code built-ins and the Firebase CLI (`npx -y firebase-tools@latest`).
- **No `skill/SKILL.md` subfolder.** Following the `claude-api` / `toolhive-cli-user` precedent — OCI is authoritative, and a commit-pinned git package is included as a fallback.
- **Icons.** All 12 skills share the same monochrome stylized-flame SVG (thematic for Firebase). Happy to differentiate per-skill if reviewers prefer.

## Test plan

- [x] `task catalog:validate` — 32 skills total, all valid (both upstream and toolhive formats)
- [x] `task catalog:build` — all 12 new skills present under `data.skills` in `build/toolhive/registry-upstream.json`
- [ ] `task catalog:validate` in CI
- [ ] Post-merge: skills appear in the published `registry-upstream.json` feed

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>