### PR TITLE
feat(skills): add 7 MongoDB skill entries (OCI distribution)

### DIFF
--- a/registries/toolhive/skills/atlas-stream-processing/icon.svg
+++ b/registries/toolhive/skills/atlas-stream-processing/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 2 h8 l4 4 v12 a2 2 0 0 1 -2 2 H8 a2 2 0 0 1 -2 -2 V4 a2 2 0 0 1 2 -2 z"/><polyline points="16 2 16 6 20 6"/><line x1="2" y1="8" x2="2" y2="20"/><line x1="4" y1="10" x2="4" y2="22"/></svg>

--- a/registries/toolhive/skills/atlas-stream-processing/skill.json
+++ b/registries/toolhive/skills/atlas-stream-processing/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "atlas-stream-processing",
+  "title": "MongoDB Atlas Stream Processing Skill",
+  "description": "Build real-time stream processing pipelines with MongoDB Atlas Stream Processing — continuous queries over Kafka and MongoDB sources, windowing, aggregations, and enrichment. Packaged from the upstream mongodb/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/mongodb/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/atlas-stream-processing:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/mongodb/agent-skills",
+      "ref": "eba6ae3f673baecb38d8ecd9df3ea4ce1f254443",
+      "subfolder": "skills/atlas-stream-processing"
+    }
+  ]
+}

--- a/registries/toolhive/skills/mongodb-connection/icon.svg
+++ b/registries/toolhive/skills/mongodb-connection/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 2 h8 l4 4 v12 a2 2 0 0 1 -2 2 H8 a2 2 0 0 1 -2 -2 V4 a2 2 0 0 1 2 -2 z"/><polyline points="16 2 16 6 20 6"/><line x1="2" y1="8" x2="2" y2="20"/><line x1="4" y1="10" x2="4" y2="22"/></svg>

--- a/registries/toolhive/skills/mongodb-connection/skill.json
+++ b/registries/toolhive/skills/mongodb-connection/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "mongodb-connection",
+  "title": "MongoDB Connection Skill",
+  "description": "Configure MongoDB connections across drivers and deployment targets — connection strings, TLS, auth (SCRAM, X.509, AWS IAM), replica sets, pooling, serverless, and troubleshooting patterns. Packaged from the upstream mongodb/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/mongodb/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/mongodb-connection:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/mongodb/agent-skills",
+      "ref": "eba6ae3f673baecb38d8ecd9df3ea4ce1f254443",
+      "subfolder": "skills/mongodb-connection"
+    }
+  ]
+}

--- a/registries/toolhive/skills/mongodb-mcp-setup/icon.svg
+++ b/registries/toolhive/skills/mongodb-mcp-setup/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 2 h8 l4 4 v12 a2 2 0 0 1 -2 2 H8 a2 2 0 0 1 -2 -2 V4 a2 2 0 0 1 2 -2 z"/><polyline points="16 2 16 6 20 6"/><line x1="2" y1="8" x2="2" y2="20"/><line x1="4" y1="10" x2="4" y2="22"/></svg>

--- a/registries/toolhive/skills/mongodb-mcp-setup/skill.json
+++ b/registries/toolhive/skills/mongodb-mcp-setup/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "mongodb-mcp-setup",
+  "title": "MongoDB MCP Setup Skill",
+  "description": "Set up the MongoDB MCP server — install, authenticate, configure tools and scopes; guided integration with Claude Code, Cursor, and other MCP-compatible agents. Packaged from the upstream mongodb/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/mongodb/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/mongodb-mcp-setup:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/mongodb/agent-skills",
+      "ref": "eba6ae3f673baecb38d8ecd9df3ea4ce1f254443",
+      "subfolder": "skills/mongodb-mcp-setup"
+    }
+  ]
+}

--- a/registries/toolhive/skills/mongodb-natural-language-querying/icon.svg
+++ b/registries/toolhive/skills/mongodb-natural-language-querying/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 2 h8 l4 4 v12 a2 2 0 0 1 -2 2 H8 a2 2 0 0 1 -2 -2 V4 a2 2 0 0 1 2 -2 z"/><polyline points="16 2 16 6 20 6"/><line x1="2" y1="8" x2="2" y2="20"/><line x1="4" y1="10" x2="4" y2="22"/></svg>

--- a/registries/toolhive/skills/mongodb-natural-language-querying/skill.json
+++ b/registries/toolhive/skills/mongodb-natural-language-querying/skill.json
@@ -1,0 +1,38 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "mongodb-natural-language-querying",
+  "title": "MongoDB Natural Language Querying Skill",
+  "description": "Translate natural-language requests into MongoDB queries and aggregations — schema-aware query generation, aggregation pipeline stages, and index-aware plan hints. Packaged from the upstream mongodb/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "allowedTools": [
+    "mongodb/collection-indexes",
+    "mongodb/collection-schema",
+    "mongodb/find",
+    "mongodb/list-collections",
+    "mongodb/list-databases"
+  ],
+  "repository": {
+    "url": "https://github.com/mongodb/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/mongodb-natural-language-querying:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/mongodb/agent-skills",
+      "ref": "eba6ae3f673baecb38d8ecd9df3ea4ce1f254443",
+      "subfolder": "skills/mongodb-natural-language-querying"
+    }
+  ]
+}

--- a/registries/toolhive/skills/mongodb-query-optimizer/icon.svg
+++ b/registries/toolhive/skills/mongodb-query-optimizer/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 2 h8 l4 4 v12 a2 2 0 0 1 -2 2 H8 a2 2 0 0 1 -2 -2 V4 a2 2 0 0 1 2 -2 z"/><polyline points="16 2 16 6 20 6"/><line x1="2" y1="8" x2="2" y2="20"/><line x1="4" y1="10" x2="4" y2="22"/></svg>

--- a/registries/toolhive/skills/mongodb-query-optimizer/skill.json
+++ b/registries/toolhive/skills/mongodb-query-optimizer/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "mongodb-query-optimizer",
+  "title": "MongoDB Query Optimizer Skill",
+  "description": "Analyze and optimize MongoDB queries and aggregation pipelines — explain plans, index design, stage ordering, covered queries, and performance anti-patterns. Packaged from the upstream mongodb/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/mongodb/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/mongodb-query-optimizer:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/mongodb/agent-skills",
+      "ref": "eba6ae3f673baecb38d8ecd9df3ea4ce1f254443",
+      "subfolder": "skills/mongodb-query-optimizer"
+    }
+  ]
+}

--- a/registries/toolhive/skills/mongodb-schema-design/icon.svg
+++ b/registries/toolhive/skills/mongodb-schema-design/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 2 h8 l4 4 v12 a2 2 0 0 1 -2 2 H8 a2 2 0 0 1 -2 -2 V4 a2 2 0 0 1 2 -2 z"/><polyline points="16 2 16 6 20 6"/><line x1="2" y1="8" x2="2" y2="20"/><line x1="4" y1="10" x2="4" y2="22"/></svg>

--- a/registries/toolhive/skills/mongodb-schema-design/skill.json
+++ b/registries/toolhive/skills/mongodb-schema-design/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "mongodb-schema-design",
+  "title": "MongoDB Schema Design Skill",
+  "description": "Design effective MongoDB schemas — document modeling patterns (embedding, referencing, bucketing, polymorphism, extended reference), cardinality trade-offs, and index strategy. Packaged from the upstream mongodb/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/mongodb/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/mongodb-schema-design:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/mongodb/agent-skills",
+      "ref": "eba6ae3f673baecb38d8ecd9df3ea4ce1f254443",
+      "subfolder": "skills/mongodb-schema-design"
+    }
+  ]
+}

--- a/registries/toolhive/skills/mongodb-search-and-ai/icon.svg
+++ b/registries/toolhive/skills/mongodb-search-and-ai/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 2 h8 l4 4 v12 a2 2 0 0 1 -2 2 H8 a2 2 0 0 1 -2 -2 V4 a2 2 0 0 1 2 -2 z"/><polyline points="16 2 16 6 20 6"/><line x1="2" y1="8" x2="2" y2="20"/><line x1="4" y1="10" x2="4" y2="22"/></svg>

--- a/registries/toolhive/skills/mongodb-search-and-ai/skill.json
+++ b/registries/toolhive/skills/mongodb-search-and-ai/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "mongodb-search-and-ai",
+  "title": "MongoDB Search and AI Skill",
+  "description": "Build Atlas Search and vector-search AI workloads on MongoDB — full-text search, vector indexes, hybrid search, RAG patterns, embedding providers, and query tuning. Packaged from the upstream mongodb/agent-skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/mongodb/agent-skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/mongodb-search-and-ai:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/mongodb/agent-skills",
+      "ref": "eba6ae3f673baecb38d8ecd9df3ea4ce1f254443",
+      "subfolder": "skills/mongodb-search-and-ai"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the 7-skill MongoDB pack from [`mongodb/agent-skills`](https://github.com/mongodb/agent-skills) to the ToolHive catalog. Content is Apache-2.0, pinned upstream to commit [`eba6ae3`](https://github.com/mongodb/agent-skills/commit/eba6ae3f673baecb38d8ecd9df3ea4ce1f254443) and packaged by Dockyard to `ghcr.io/stacklok/dockyard/skills/<name>:0.1.0` (Dockyard PR #508).

Follows the OCI-distribution pattern established by [PR #1093 (claude-api)](https://github.com/stacklok/toolhive-catalog/pull/1093), [PR #1094 (toolhive-cli-user)](https://github.com/stacklok/toolhive-catalog/pull/1094), [PR #1095 (trailofbits security skills)](https://github.com/stacklok/toolhive-catalog/pull/1095), and [PR #1109 (gemini pack)](https://github.com/stacklok/toolhive-catalog/pull/1109).

### Skills added

- `atlas-stream-processing` — real-time stream processing pipelines with MongoDB Atlas (Kafka / MongoDB sources, windowing, aggregations, enrichment)
- `mongodb-connection` — driver and deployment connection patterns (connection strings, TLS, SCRAM/X.509/AWS IAM auth, replica sets, pooling, serverless, troubleshooting)
- `mongodb-mcp-setup` — guided setup of the MongoDB MCP server (install, authenticate, configure tools and scopes for Claude Code, Cursor, and other MCP agents)
- `mongodb-natural-language-querying` — translate natural-language requests into MongoDB find / aggregation pipelines (schema-aware, index-aware)
- `mongodb-query-optimizer` — analyze and optimize queries and aggregations (explain plans, index design, stage ordering, covered queries, anti-patterns)
- `mongodb-schema-design` — document-modeling patterns (embedding, referencing, bucketing, polymorphism, extended reference), cardinality trade-offs, index strategy
- `mongodb-search-and-ai` — Atlas Search and vector search workloads (full-text, vector indexes, hybrid search, RAG, embedding providers, query tuning)

### Notes for review

- **License: `Apache-2.0`.** Confirmed at the `mongodb/agent-skills` repo root; upstream does not embed an SPDX identifier in per-skill `SKILL.md` frontmatter (allowed Dockyard manifest issue `MANIFEST_MISSING_LICENSE`). One skill (`mongodb-schema-design`) does declare `license: Apache-2.0` in its frontmatter.
- **MCP dependency satisfied.** The MongoDB MCP server is already in the catalog at `registries/toolhive/servers/mongodb/` (`docker.io/mongodb/mongodb-mcp-server:1.10.0`), so the `mongodb-mcp-setup` and `mongodb-natural-language-querying` dependencies are satisfied per `skill-criteria.md`.
- **`allowedTools` declared for 1 skill.** Only `mongodb-natural-language-querying` declares `allowed-tools: mcp__mongodb__*` in its SKILL.md frontmatter. The `allowedTools` field lists the specific tools referenced in the SKILL.md body (`collection-indexes`, `collection-schema`, `find`, `list-collections`, `list-databases`) scoped to the catalog server prefix (`mongodb/`). The other 6 skills do not declare MCP tools and omit the field.
- **No `skill/SKILL.md` subfolder.** Following the `claude-api` / `toolhive-cli-user` / `gemini` precedent — OCI is authoritative, and a commit-pinned git package is included as a fallback.
- **Icons.** All 7 skills share the same monochrome document-DB icon (stacked document, 24x24, matching the catalog's outline-stroke style). Happy to differentiate per-skill if reviewers prefer.

## Test plan

- [x] `task catalog:validate` — 113 servers and 27 skills valid in the toolhive registry (both upstream and toolhive formats)
- [x] `task catalog:build` — all 7 new skills present in `build/toolhive/registry-upstream.json`
- [ ] `task catalog:validate` in CI
- [ ] Post-merge: skills appear in the published `registry-upstream.json` feed

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)