### PR TITLE
feat(skills): add 12 Hugging Face skill entries (OCI distribution)

### DIFF
--- a/registries/toolhive/skills/hf-cli/icon.svg
+++ b/registries/toolhive/skills/hf-cli/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><circle cx="9" cy="10" r="1"/><circle cx="15" cy="10" r="1"/><path d="M8 15c1 1 2.5 1.5 4 1.5S14.5 16 16 15"/><path d="M5 13c-.8.5-1 1.3-.5 2"/><path d="M19 13c.8.5 1 1.3.5 2"/></svg>

--- a/registries/toolhive/skills/hf-cli/skill.json
+++ b/registries/toolhive/skills/hf-cli/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "hf-cli",
+  "title": "Hugging Face CLI Skill",
+  "description": "Hugging Face Hub CLI (`hf`) — downloads, uploads, auth, cache, buckets, repos, discussions/PRs, models/datasets/spaces, papers, collections, jobs, inference endpoints, webhooks, extensions; replaces the deprecated huggingface-cli. Packaged from the upstream huggingface/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/huggingface/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/hf-cli:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/huggingface/skills",
+      "ref": "061ab494cb145f43ae8f218939b99160e2c61c58",
+      "subfolder": "skills/hf-cli"
+    }
+  ]
+}

--- a/registries/toolhive/skills/hf-mcp/icon.svg
+++ b/registries/toolhive/skills/hf-mcp/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><circle cx="9" cy="10" r="1"/><circle cx="15" cy="10" r="1"/><path d="M8 15c1 1 2.5 1.5 4 1.5S14.5 16 16 15"/><path d="M5 13c-.8.5-1 1.3-.5 2"/><path d="M19 13c.8.5 1 1.3.5 2"/></svg>

--- a/registries/toolhive/skills/hf-mcp/skill.json
+++ b/registries/toolhive/skills/hf-mcp/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "hf-mcp",
+  "title": "Hugging Face MCP Skill",
+  "description": "Use the Hugging Face Hub via MCP server tools — search models, datasets, Spaces, papers; get repo details, fetch docs, run compute jobs, use Gradio Spaces as AI tools (e.g., image generation, speech transcription). Packaged from the upstream huggingface/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/huggingface/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/hf-mcp:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/huggingface/skills",
+      "ref": "061ab494cb145f43ae8f218939b99160e2c61c58",
+      "subfolder": "hf-mcp/skills/hf-mcp"
+    }
+  ]
+}

--- a/registries/toolhive/skills/huggingface-community-evals/icon.svg
+++ b/registries/toolhive/skills/huggingface-community-evals/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><circle cx="9" cy="10" r="1"/><circle cx="15" cy="10" r="1"/><path d="M8 15c1 1 2.5 1.5 4 1.5S14.5 16 16 15"/><path d="M5 13c-.8.5-1 1.3-.5 2"/><path d="M19 13c.8.5 1 1.3.5 2"/></svg>

--- a/registries/toolhive/skills/huggingface-community-evals/skill.json
+++ b/registries/toolhive/skills/huggingface-community-evals/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "huggingface-community-evals",
+  "title": "Hugging Face Community Evals Skill",
+  "description": "Run model evaluations against Hugging Face Hub models on local hardware with inspect-ai or lighteval — backend selection across vLLM, Transformers, and accelerate; smoke tests, task selection, and fallback strategy. Packaged from the upstream huggingface/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/huggingface/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/huggingface-community-evals:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/huggingface/skills",
+      "ref": "061ab494cb145f43ae8f218939b99160e2c61c58",
+      "subfolder": "skills/huggingface-community-evals"
+    }
+  ]
+}

--- a/registries/toolhive/skills/huggingface-datasets/icon.svg
+++ b/registries/toolhive/skills/huggingface-datasets/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><circle cx="9" cy="10" r="1"/><circle cx="15" cy="10" r="1"/><path d="M8 15c1 1 2.5 1.5 4 1.5S14.5 16 16 15"/><path d="M5 13c-.8.5-1 1.3-.5 2"/><path d="M19 13c.8.5 1 1.3.5 2"/></svg>

--- a/registries/toolhive/skills/huggingface-datasets/skill.json
+++ b/registries/toolhive/skills/huggingface-datasets/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "huggingface-datasets",
+  "title": "Hugging Face Datasets Skill",
+  "description": "Hugging Face Dataset Viewer API workflows — fetch subset/split metadata, paginate rows, search text, apply filters, download parquet URLs, read size and statistics; SQL queries via parquetlens. Packaged from the upstream huggingface/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/huggingface/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/huggingface-datasets:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/huggingface/skills",
+      "ref": "061ab494cb145f43ae8f218939b99160e2c61c58",
+      "subfolder": "skills/huggingface-datasets"
+    }
+  ]
+}

--- a/registries/toolhive/skills/huggingface-gradio/icon.svg
+++ b/registries/toolhive/skills/huggingface-gradio/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><circle cx="9" cy="10" r="1"/><circle cx="15" cy="10" r="1"/><path d="M8 15c1 1 2.5 1.5 4 1.5S14.5 16 16 15"/><path d="M5 13c-.8.5-1 1.3-.5 2"/><path d="M19 13c.8.5 1 1.3.5 2"/></svg>

--- a/registries/toolhive/skills/huggingface-gradio/skill.json
+++ b/registries/toolhive/skills/huggingface-gradio/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "huggingface-gradio",
+  "title": "Hugging Face Gradio Skill",
+  "description": "Build Gradio web UIs and demos in Python — Interface, Blocks, ChatInterface, event listeners, layouts, custom HTML components, gradio CLI (info, predict) for programmatic Space interactions. Packaged from the upstream huggingface/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/huggingface/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/huggingface-gradio:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/huggingface/skills",
+      "ref": "061ab494cb145f43ae8f218939b99160e2c61c58",
+      "subfolder": "skills/huggingface-gradio"
+    }
+  ]
+}

--- a/registries/toolhive/skills/huggingface-llm-trainer/icon.svg
+++ b/registries/toolhive/skills/huggingface-llm-trainer/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><circle cx="9" cy="10" r="1"/><circle cx="15" cy="10" r="1"/><path d="M8 15c1 1 2.5 1.5 4 1.5S14.5 16 16 15"/><path d="M5 13c-.8.5-1 1.3-.5 2"/><path d="M19 13c.8.5 1 1.3.5 2"/></svg>

--- a/registries/toolhive/skills/huggingface-llm-trainer/skill.json
+++ b/registries/toolhive/skills/huggingface-llm-trainer/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "huggingface-llm-trainer",
+  "title": "Hugging Face LLM Trainer Skill",
+  "description": "Train or fine-tune language and vision models with TRL (SFT, DPO, GRPO, reward modeling) or Unsloth on Hugging Face Jobs cloud GPUs — dataset validation, hardware selection, cost estimation, Trackio monitoring, Hub persistence, GGUF conversion. Packaged from the upstream huggingface/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/huggingface/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/huggingface-llm-trainer:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/huggingface/skills",
+      "ref": "061ab494cb145f43ae8f218939b99160e2c61c58",
+      "subfolder": "skills/huggingface-llm-trainer"
+    }
+  ]
+}

--- a/registries/toolhive/skills/huggingface-paper-publisher/icon.svg
+++ b/registries/toolhive/skills/huggingface-paper-publisher/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><circle cx="9" cy="10" r="1"/><circle cx="15" cy="10" r="1"/><path d="M8 15c1 1 2.5 1.5 4 1.5S14.5 16 16 15"/><path d="M5 13c-.8.5-1 1.3-.5 2"/><path d="M19 13c.8.5 1 1.3.5 2"/></svg>

--- a/registries/toolhive/skills/huggingface-paper-publisher/skill.json
+++ b/registries/toolhive/skills/huggingface-paper-publisher/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "huggingface-paper-publisher",
+  "title": "Hugging Face Paper Publisher Skill",
+  "description": "Publish and manage research papers on Hugging Face Hub — create paper pages, link papers to models/datasets/spaces, claim authorship, generate markdown research articles, manage citations and visibility. Packaged from the upstream huggingface/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/huggingface/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/huggingface-paper-publisher:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/huggingface/skills",
+      "ref": "061ab494cb145f43ae8f218939b99160e2c61c58",
+      "subfolder": "skills/huggingface-paper-publisher"
+    }
+  ]
+}

--- a/registries/toolhive/skills/huggingface-papers/icon.svg
+++ b/registries/toolhive/skills/huggingface-papers/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><circle cx="9" cy="10" r="1"/><circle cx="15" cy="10" r="1"/><path d="M8 15c1 1 2.5 1.5 4 1.5S14.5 16 16 15"/><path d="M5 13c-.8.5-1 1.3-.5 2"/><path d="M19 13c.8.5 1 1.3.5 2"/></svg>

--- a/registries/toolhive/skills/huggingface-papers/skill.json
+++ b/registries/toolhive/skills/huggingface-papers/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "huggingface-papers",
+  "title": "Hugging Face Papers Skill",
+  "description": "Look up and read Hugging Face paper pages in markdown and use the papers API — parse arXiv IDs from various URL forms, fetch structured metadata (authors, linked models/datasets/spaces, GitHub repo, project page), claim authorship, index papers. Packaged from the upstream huggingface/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/huggingface/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/huggingface-papers:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/huggingface/skills",
+      "ref": "061ab494cb145f43ae8f218939b99160e2c61c58",
+      "subfolder": "skills/huggingface-papers"
+    }
+  ]
+}

--- a/registries/toolhive/skills/huggingface-tool-builder/icon.svg
+++ b/registries/toolhive/skills/huggingface-tool-builder/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><circle cx="9" cy="10" r="1"/><circle cx="15" cy="10" r="1"/><path d="M8 15c1 1 2.5 1.5 4 1.5S14.5 16 16 15"/><path d="M5 13c-.8.5-1 1.3-.5 2"/><path d="M19 13c.8.5 1 1.3.5 2"/></svg>

--- a/registries/toolhive/skills/huggingface-tool-builder/skill.json
+++ b/registries/toolhive/skills/huggingface-tool-builder/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "huggingface-tool-builder",
+  "title": "Hugging Face Tool Builder Skill",
+  "description": "Build reusable command-line scripts and utilities using the Hugging Face API and hf CLI — chains/pipes API calls, enriches model/dataset metadata, composable NDJSON output, HF_TOKEN auth hygiene. Packaged from the upstream huggingface/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/huggingface/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/huggingface-tool-builder:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/huggingface/skills",
+      "ref": "061ab494cb145f43ae8f218939b99160e2c61c58",
+      "subfolder": "skills/huggingface-tool-builder"
+    }
+  ]
+}

--- a/registries/toolhive/skills/huggingface-trackio/icon.svg
+++ b/registries/toolhive/skills/huggingface-trackio/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><circle cx="9" cy="10" r="1"/><circle cx="15" cy="10" r="1"/><path d="M8 15c1 1 2.5 1.5 4 1.5S14.5 16 16 15"/><path d="M5 13c-.8.5-1 1.3-.5 2"/><path d="M19 13c.8.5 1 1.3.5 2"/></svg>

--- a/registries/toolhive/skills/huggingface-trackio/skill.json
+++ b/registries/toolhive/skills/huggingface-trackio/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "huggingface-trackio",
+  "title": "Hugging Face Trackio Skill",
+  "description": "Track and visualize ML training experiments with Trackio — log metrics via Python API, fire alerts for diagnostics (loss spikes, NaN gradients), retrieve metrics and alerts via CLI, sync to HF Spaces dashboards for autonomous experiment iteration. Packaged from the upstream huggingface/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/huggingface/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/huggingface-trackio:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/huggingface/skills",
+      "ref": "061ab494cb145f43ae8f218939b99160e2c61c58",
+      "subfolder": "skills/huggingface-trackio"
+    }
+  ]
+}

--- a/registries/toolhive/skills/huggingface-vision-trainer/icon.svg
+++ b/registries/toolhive/skills/huggingface-vision-trainer/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><circle cx="9" cy="10" r="1"/><circle cx="15" cy="10" r="1"/><path d="M8 15c1 1 2.5 1.5 4 1.5S14.5 16 16 15"/><path d="M5 13c-.8.5-1 1.3-.5 2"/><path d="M19 13c.8.5 1 1.3.5 2"/></svg>

--- a/registries/toolhive/skills/huggingface-vision-trainer/skill.json
+++ b/registries/toolhive/skills/huggingface-vision-trainer/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "huggingface-vision-trainer",
+  "title": "Hugging Face Vision Trainer Skill",
+  "description": "Train and fine-tune vision models on Hugging Face Jobs — object detection (D-FINE, RT-DETR v2, DETR), image classification (timm, MobileNet, ViT, DINOv3), SAM/SAM2 segmentation; COCO-format prep, Albumentations, mAP/accuracy metrics, DiceCE loss, Trackio monitoring. Packaged from the upstream huggingface/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/huggingface/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/huggingface-vision-trainer:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/huggingface/skills",
+      "ref": "061ab494cb145f43ae8f218939b99160e2c61c58",
+      "subfolder": "skills/huggingface-vision-trainer"
+    }
+  ]
+}

--- a/registries/toolhive/skills/transformers-js/icon.svg
+++ b/registries/toolhive/skills/transformers-js/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><circle cx="9" cy="10" r="1"/><circle cx="15" cy="10" r="1"/><path d="M8 15c1 1 2.5 1.5 4 1.5S14.5 16 16 15"/><path d="M5 13c-.8.5-1 1.3-.5 2"/><path d="M19 13c.8.5 1 1.3.5 2"/></svg>

--- a/registries/toolhive/skills/transformers-js/skill.json
+++ b/registries/toolhive/skills/transformers-js/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "transformers-js",
+  "title": "Transformers.js Skill",
+  "description": "Run ML models in JavaScript/TypeScript via Transformers.js — NLP, computer vision, audio, and multimodal tasks in browsers and Node.js/Bun/Deno with WebGPU/WASM; pipeline API, tokenizers, quantization (fp32/fp16/q8/q4), memory management. Packaged from the upstream huggingface/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/huggingface/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/transformers-js:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/huggingface/skills",
+      "ref": "061ab494cb145f43ae8f218939b99160e2c61c58",
+      "subfolder": "skills/transformers-js"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the 12-skill Hugging Face pack from [`huggingface/skills`](https://github.com/huggingface/skills) to the ToolHive catalog. Content is Apache-2.0, pinned upstream to commit [`061ab49`](https://github.com/huggingface/skills/commit/061ab494cb145f43ae8f218939b99160e2c61c58) and packaged by Dockyard to `ghcr.io/stacklok/dockyard/skills/<name>:0.1.0` (Dockyard PR [#501](https://github.com/stacklok/dockyard/pull/501)).

Follows the OCI-distribution pattern established by [PR #1093 (claude-api)](https://github.com/stacklok/toolhive-catalog/pull/1093), [PR #1094 (toolhive-cli-user)](https://github.com/stacklok/toolhive-catalog/pull/1094), [PR #1095 (trailofbits security skills)](https://github.com/stacklok/toolhive-catalog/pull/1095), and [PR #1109 (gemini skills)](https://github.com/stacklok/toolhive-catalog/pull/1109).

### Skills added

- `hf-cli` — Hugging Face Hub CLI (`hf`) for models, datasets, spaces, buckets, repos, jobs, inference endpoints, etc.; replaces deprecated `huggingface-cli`
- `hf-mcp` — Use the Hugging Face Hub via MCP server tools (search, repo details, docs, compute jobs, Gradio Spaces as tools)
- `huggingface-community-evals` — Run HF Hub model evaluations locally with inspect-ai or lighteval (vLLM / Transformers / accelerate backends)
- `huggingface-datasets` — Dataset Viewer API workflows (rows, pagination, filters, parquet URLs, SQL via parquetlens)
- `huggingface-gradio` — Build Gradio web UIs in Python (Interface, Blocks, ChatInterface, gradio CLI)
- `huggingface-llm-trainer` — Train/fine-tune LLMs with TRL (SFT, DPO, GRPO, reward modeling) or Unsloth on HF Jobs cloud GPUs; GGUF conversion
- `huggingface-paper-publisher` — Publish and manage research papers on HF Hub (pages, links, authorship, citations)
- `huggingface-papers` — Look up and read HF paper pages in markdown and use the papers API (arXiv IDs, structured metadata)
- `huggingface-tool-builder` — Build reusable CLI scripts using the HF API and `hf` CLI (composable NDJSON output, auth hygiene)
- `huggingface-trackio` — Track and visualize ML training experiments with Trackio (metrics, alerts, HF Space dashboards)
- `huggingface-vision-trainer` — Train vision models on HF Jobs (object detection, image classification, SAM/SAM2 segmentation)
- `transformers-js` — Run ML models in JavaScript/TypeScript via Transformers.js (NLP, vision, audio, multimodal; WebGPU/WASM)

### Notes for review

- **License: `Apache-2.0`.** Confirmed at the `huggingface/skills` repo root; upstream does not embed an SPDX identifier in per-skill SKILL.md frontmatter, which is tracked as an allowed Dockyard manifest issue.
- **MCP dependencies satisfied.** The `huggingface` MCP server entry already in this catalog (`registries/official/servers/huggingface` and `registries/toolhive/servers/huggingface`) satisfies the runtime dependency for `hf-mcp`, `huggingface-llm-trainer`, and `huggingface-vision-trainer` (they call `hf_jobs`, `hf_whoami`, `hf_doc_search`, `hf_doc_fetch`).
- **No `allowedTools`.** None of the 12 upstream SKILL.md files declare `allowed-tools` / `allowedTools` in frontmatter. `huggingface-llm-trainer` references `mcp__huggingface__hf_whoami` in the body but not in frontmatter, so no `allowedTools` is added per the frontmatter-not-body policy.
- **Non-flat upstream layout for `hf-mcp`.** Its `packages[].subfolder` is `hf-mcp/skills/hf-mcp` (matches upstream repo layout); the other 11 use the standard `skills/<name>` subfolder.
- **No `skill/SKILL.md` subfolder.** Following the `claude-api` / `toolhive-cli-user` / `gemini-*` precedent — OCI is authoritative, commit-pinned git package is included as a fallback.
- **Icons.** All 12 skills share the same monochrome 24x24 smiley SVG (thematic for Hugging Face). Happy to differentiate per-skill if reviewers prefer.

## Test plan

- [x] `task catalog:validate` — 32 skills total (20 existing + 12 new), all valid (both upstream and toolhive formats)
- [x] `task catalog:build` — all 12 new skills present under `data.skills` in `build/toolhive/registry-upstream.json`
- [ ] `task catalog:validate` in CI
- [ ] Post-merge: skills appear in the published `registry-upstream.json` feed

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)