### PR TITLE
feat(skills): add 17 Sentry skill entries (OCI distribution)

### DIFF
--- a/registries/toolhive/skills/agents-md/icon.svg
+++ b/registries/toolhive/skills/agents-md/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><path d="M7 12c1.5-2.5 3.2-3.8 5-3.8s3.5 1.3 5 3.8c-1.5 2.5-3.2 3.8-5 3.8S8.5 14.5 7 12z"/><circle cx="12" cy="12" r="1.3"/></svg>

--- a/registries/toolhive/skills/agents-md/skill.json
+++ b/registries/toolhive/skills/agents-md/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "agents-md",
+  "title": "Sentry AGENTS.md Authoring Skill",
+  "description": "Create and maintain minimal, high-signal AGENTS.md / CLAUDE.md agent docs — under 60 lines target, detects package manager and file-scoped commands, avoids filler and duplicated linter rules. Packaged from the upstream getsentry/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/getsentry/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/agents-md:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/getsentry/skills",
+      "ref": "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955",
+      "subfolder": "skills/agents-md"
+    }
+  ]
+}

--- a/registries/toolhive/skills/claude-settings-audit/icon.svg
+++ b/registries/toolhive/skills/claude-settings-audit/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><path d="M7 12c1.5-2.5 3.2-3.8 5-3.8s3.5 1.3 5 3.8c-1.5 2.5-3.2 3.8-5 3.8S8.5 14.5 7 12z"/><circle cx="12" cy="12" r="1.3"/></svg>

--- a/registries/toolhive/skills/claude-settings-audit/skill.json
+++ b/registries/toolhive/skills/claude-settings-audit/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "claude-settings-audit",
+  "title": "Sentry Claude Settings Audit Skill",
+  "description": "Analyze a repository and generate recommended Claude Code settings.json permissions for read-only commands — detects tech stack, package managers, build tools, monorepo structure, and framework-specific doc domains. Packaged from the upstream getsentry/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/getsentry/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/claude-settings-audit:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/getsentry/skills",
+      "ref": "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955",
+      "subfolder": "skills/claude-settings-audit"
+    }
+  ]
+}

--- a/registries/toolhive/skills/code-simplifier/icon.svg
+++ b/registries/toolhive/skills/code-simplifier/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><path d="M7 12c1.5-2.5 3.2-3.8 5-3.8s3.5 1.3 5 3.8c-1.5 2.5-3.2 3.8-5 3.8S8.5 14.5 7 12z"/><circle cx="12" cy="12" r="1.3"/></svg>

--- a/registries/toolhive/skills/code-simplifier/skill.json
+++ b/registries/toolhive/skills/code-simplifier/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "code-simplifier",
+  "title": "Sentry Code Simplifier Skill",
+  "description": "Simplify and refine code for clarity, consistency, and maintainability while preserving functionality — prefers explicit over clever, flattens nested ternaries, removes redundant abstractions, follows project conventions. Packaged from the upstream getsentry/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/getsentry/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/code-simplifier:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/getsentry/skills",
+      "ref": "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955",
+      "subfolder": "skills/code-simplifier"
+    }
+  ]
+}

--- a/registries/toolhive/skills/commit/icon.svg
+++ b/registries/toolhive/skills/commit/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><path d="M7 12c1.5-2.5 3.2-3.8 5-3.8s3.5 1.3 5 3.8c-1.5 2.5-3.2 3.8-5 3.8S8.5 14.5 7 12z"/><circle cx="12" cy="12" r="1.3"/></svg>

--- a/registries/toolhive/skills/commit/skill.json
+++ b/registries/toolhive/skills/commit/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "commit",
+  "title": "Sentry Commit Skill",
+  "description": "Create commits following Sentry conventional-commit format — type(scope): subject, imperative body, proper issue references (Fixes/Refs GH-NNNN, SENTRY-NNNN, LINEAR-XXX). Packaged from the upstream getsentry/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/getsentry/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/commit:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/getsentry/skills",
+      "ref": "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955",
+      "subfolder": "skills/commit"
+    }
+  ]
+}

--- a/registries/toolhive/skills/create-branch/icon.svg
+++ b/registries/toolhive/skills/create-branch/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><path d="M7 12c1.5-2.5 3.2-3.8 5-3.8s3.5 1.3 5 3.8c-1.5 2.5-3.2 3.8-5 3.8S8.5 14.5 7 12z"/><circle cx="12" cy="12" r="1.3"/></svg>

--- a/registries/toolhive/skills/create-branch/skill.json
+++ b/registries/toolhive/skills/create-branch/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "create-branch",
+  "title": "Sentry Create Branch Skill",
+  "description": "Create a git branch following Sentry naming conventions — <prefix>/<type>/<short-description> with automatic prefix resolution from GitHub user, diff-derived description, and default-branch detection. Packaged from the upstream getsentry/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/getsentry/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/create-branch:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/getsentry/skills",
+      "ref": "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955",
+      "subfolder": "skills/create-branch"
+    }
+  ]
+}

--- a/registries/toolhive/skills/django-access-review/icon.svg
+++ b/registries/toolhive/skills/django-access-review/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><path d="M7 12c1.5-2.5 3.2-3.8 5-3.8s3.5 1.3 5 3.8c-1.5 2.5-3.2 3.8-5 3.8S8.5 14.5 7 12z"/><circle cx="12" cy="12" r="1.3"/></svg>

--- a/registries/toolhive/skills/django-access-review/skill.json
+++ b/registries/toolhive/skills/django-access-review/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "django-access-review",
+  "title": "Sentry Django Access Review Skill",
+  "description": "Django access-control and IDOR review — investigates how authorization is enforced (decorators, managers, permission classes, mixins) and finds gaps where User A can access User B's data. Packaged from the upstream getsentry/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/getsentry/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/django-access-review:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/getsentry/skills",
+      "ref": "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955",
+      "subfolder": "skills/django-access-review"
+    }
+  ]
+}

--- a/registries/toolhive/skills/django-perf-review/icon.svg
+++ b/registries/toolhive/skills/django-perf-review/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><path d="M7 12c1.5-2.5 3.2-3.8 5-3.8s3.5 1.3 5 3.8c-1.5 2.5-3.2 3.8-5 3.8S8.5 14.5 7 12z"/><circle cx="12" cy="12" r="1.3"/></svg>

--- a/registries/toolhive/skills/django-perf-review/skill.json
+++ b/registries/toolhive/skills/django-perf-review/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "django-perf-review",
+  "title": "Sentry Django Performance Review Skill",
+  "description": "Django performance review — validates N+1 queries, unbounded querysets, missing indexes, and write loops before reporting; severity must match measurable impact. Packaged from the upstream getsentry/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/getsentry/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/django-perf-review:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/getsentry/skills",
+      "ref": "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955",
+      "subfolder": "skills/django-perf-review"
+    }
+  ]
+}

--- a/registries/toolhive/skills/doc-coauthoring/icon.svg
+++ b/registries/toolhive/skills/doc-coauthoring/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><path d="M7 12c1.5-2.5 3.2-3.8 5-3.8s3.5 1.3 5 3.8c-1.5 2.5-3.2 3.8-5 3.8S8.5 14.5 7 12z"/><circle cx="12" cy="12" r="1.3"/></svg>

--- a/registries/toolhive/skills/doc-coauthoring/skill.json
+++ b/registries/toolhive/skills/doc-coauthoring/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "doc-coauthoring",
+  "title": "Sentry Doc Co-Authoring Skill",
+  "description": "Guide users through a three-stage doc co-authoring workflow — context gathering, section-by-section refinement and structure, and reader testing with a fresh agent to catch blind spots. Packaged from the upstream getsentry/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/getsentry/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/doc-coauthoring:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/getsentry/skills",
+      "ref": "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955",
+      "subfolder": "skills/doc-coauthoring"
+    }
+  ]
+}

--- a/registries/toolhive/skills/find-bugs/icon.svg
+++ b/registries/toolhive/skills/find-bugs/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><path d="M7 12c1.5-2.5 3.2-3.8 5-3.8s3.5 1.3 5 3.8c-1.5 2.5-3.2 3.8-5 3.8S8.5 14.5 7 12z"/><circle cx="12" cy="12" r="1.3"/></svg>

--- a/registries/toolhive/skills/find-bugs/skill.json
+++ b/registries/toolhive/skills/find-bugs/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "find-bugs",
+  "title": "Sentry Find Bugs Skill",
+  "description": "Find bugs, security vulnerabilities, and quality issues on the current branch — diff-scoped review with security checklist covering injection, XSS, auth, IDOR, race conditions, and business-logic edge cases. Packaged from the upstream getsentry/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/getsentry/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/find-bugs:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/getsentry/skills",
+      "ref": "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955",
+      "subfolder": "skills/find-bugs"
+    }
+  ]
+}

--- a/registries/toolhive/skills/gh-review-requests/icon.svg
+++ b/registries/toolhive/skills/gh-review-requests/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><path d="M7 12c1.5-2.5 3.2-3.8 5-3.8s3.5 1.3 5 3.8c-1.5 2.5-3.2 3.8-5 3.8S8.5 14.5 7 12z"/><circle cx="12" cy="12" r="1.3"/></svg>

--- a/registries/toolhive/skills/gh-review-requests/skill.json
+++ b/registries/toolhive/skills/gh-review-requests/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "gh-review-requests",
+  "title": "Sentry GitHub Review Requests Skill",
+  "description": "Fetch unread review_requested GitHub notifications filtered by team — lists open PRs where a specified team is a requested reviewer or a team member is the author. Packaged from the upstream getsentry/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/getsentry/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/gh-review-requests:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/getsentry/skills",
+      "ref": "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955",
+      "subfolder": "skills/gh-review-requests"
+    }
+  ]
+}

--- a/registries/toolhive/skills/gha-security-review/icon.svg
+++ b/registries/toolhive/skills/gha-security-review/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><path d="M7 12c1.5-2.5 3.2-3.8 5-3.8s3.5 1.3 5 3.8c-1.5 2.5-3.2 3.8-5 3.8S8.5 14.5 7 12z"/><circle cx="12" cy="12" r="1.3"/></svg>

--- a/registries/toolhive/skills/gha-security-review/skill.json
+++ b/registries/toolhive/skills/gha-security-review/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "gha-security-review",
+  "title": "Sentry GitHub Actions Security Review Skill",
+  "description": "GitHub Actions workflow security review with concrete exploitation scenarios — pwn-request, expression injection, credential escalation, config poisoning, and supply-chain audits. Packaged from the upstream getsentry/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/getsentry/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/gha-security-review:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/getsentry/skills",
+      "ref": "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955",
+      "subfolder": "skills/gha-security-review"
+    }
+  ]
+}

--- a/registries/toolhive/skills/iterate-pr/icon.svg
+++ b/registries/toolhive/skills/iterate-pr/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><path d="M7 12c1.5-2.5 3.2-3.8 5-3.8s3.5 1.3 5 3.8c-1.5 2.5-3.2 3.8-5 3.8S8.5 14.5 7 12z"/><circle cx="12" cy="12" r="1.3"/></svg>

--- a/registries/toolhive/skills/iterate-pr/skill.json
+++ b/registries/toolhive/skills/iterate-pr/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "iterate-pr",
+  "title": "Sentry Iterate PR Skill",
+  "description": "Iterate on a PR until CI passes and review feedback is addressed — fetches categorized LOGAF-ranked feedback, auto-fixes high/medium, monitors CI with retry-safe check polling, handles review-bot findings. Packaged from the upstream getsentry/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/getsentry/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/iterate-pr:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/getsentry/skills",
+      "ref": "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955",
+      "subfolder": "skills/iterate-pr"
+    }
+  ]
+}

--- a/registries/toolhive/skills/pr-writer/icon.svg
+++ b/registries/toolhive/skills/pr-writer/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><path d="M7 12c1.5-2.5 3.2-3.8 5-3.8s3.5 1.3 5 3.8c-1.5 2.5-3.2 3.8-5 3.8S8.5 14.5 7 12z"/><circle cx="12" cy="12" r="1.3"/></svg>

--- a/registries/toolhive/skills/pr-writer/skill.json
+++ b/registries/toolhive/skills/pr-writer/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "pr-writer",
+  "title": "Sentry PR Writer Skill",
+  "description": "Create pull requests following Sentry engineering practices — conventional-commit-style titles, why-focused descriptions, issue references (Fixes/Refs), and safe gh-api edits for existing PRs. Packaged from the upstream getsentry/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/getsentry/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/pr-writer:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/getsentry/skills",
+      "ref": "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955",
+      "subfolder": "skills/pr-writer"
+    }
+  ]
+}

--- a/registries/toolhive/skills/prompt-optimizer/icon.svg
+++ b/registries/toolhive/skills/prompt-optimizer/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><path d="M7 12c1.5-2.5 3.2-3.8 5-3.8s3.5 1.3 5 3.8c-1.5 2.5-3.2 3.8-5 3.8S8.5 14.5 7 12z"/><circle cx="12" cy="12" r="1.3"/></svg>

--- a/registries/toolhive/skills/prompt-optimizer/skill.json
+++ b/registries/toolhive/skills/prompt-optimizer/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "prompt-optimizer",
+  "title": "Sentry Prompt Optimizer Skill",
+  "description": "Create, optimize, and iteratively refine agent prompts via eval-driven workflow — model-family-specific guidance (Claude, OpenAI, Gemini), prompt markers, meta-optimization loop, and cross-family adapter notes. Packaged from the upstream getsentry/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/getsentry/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/prompt-optimizer:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/getsentry/skills",
+      "ref": "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955",
+      "subfolder": "skills/prompt-optimizer"
+    }
+  ]
+}

--- a/registries/toolhive/skills/security-review/icon.svg
+++ b/registries/toolhive/skills/security-review/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><path d="M7 12c1.5-2.5 3.2-3.8 5-3.8s3.5 1.3 5 3.8c-1.5 2.5-3.2 3.8-5 3.8S8.5 14.5 7 12z"/><circle cx="12" cy="12" r="1.3"/></svg>

--- a/registries/toolhive/skills/security-review/skill.json
+++ b/registries/toolhive/skills/security-review/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "security-review",
+  "title": "Sentry Security Review Skill",
+  "description": "Security code review for vulnerabilities — systematic, confidence-scored reporting of injection, XSS, auth, crypto, and deserialization issues with framework-aware false-positive filtering. Packaged from the upstream getsentry/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/getsentry/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/security-review:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/getsentry/skills",
+      "ref": "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955",
+      "subfolder": "skills/security-review"
+    }
+  ]
+}

--- a/registries/toolhive/skills/skill-scanner/icon.svg
+++ b/registries/toolhive/skills/skill-scanner/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><path d="M7 12c1.5-2.5 3.2-3.8 5-3.8s3.5 1.3 5 3.8c-1.5 2.5-3.2 3.8-5 3.8S8.5 14.5 7 12z"/><circle cx="12" cy="12" r="1.3"/></svg>

--- a/registries/toolhive/skills/skill-scanner/skill.json
+++ b/registries/toolhive/skills/skill-scanner/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "skill-scanner",
+  "title": "Sentry Skill Scanner Skill",
+  "description": "Scan agent skills for security issues — prompt injection, malicious scripts, excessive permissions, secret exposure, supply-chain risks; combines static pattern scanner with agent behavioral analysis. Packaged from the upstream getsentry/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/getsentry/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/skill-scanner:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/getsentry/skills",
+      "ref": "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955",
+      "subfolder": "skills/skill-scanner"
+    }
+  ]
+}

--- a/registries/toolhive/skills/skill-writer/icon.svg
+++ b/registries/toolhive/skills/skill-writer/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#181717" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/><path d="M7 12c1.5-2.5 3.2-3.8 5-3.8s3.5 1.3 5 3.8c-1.5 2.5-3.2 3.8-5 3.8S8.5 14.5 7 12z"/><circle cx="12" cy="12" r="1.3"/></svg>

--- a/registries/toolhive/skills/skill-writer/skill.json
+++ b/registries/toolhive/skills/skill-writer/skill.json
@@ -1,0 +1,31 @@
+{
+  "namespace": "io.github.stacklok",
+  "name": "skill-writer",
+  "title": "Sentry Skill Writer Skill",
+  "description": "Create, synthesize, and iteratively improve agent skills per the Agent Skills specification — handles source capture with depth gates, authoring, description optimization, registration, and validation. Packaged from the upstream getsentry/skills repository.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/getsentry/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/skill-writer:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/getsentry/skills",
+      "ref": "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955",
+      "subfolder": "skills/skill-writer"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the Sentry skill pack from [`getsentry/skills`](https://github.com/getsentry/skills) to the ToolHive catalog. Content is Apache-2.0, pinned upstream to commit [`94ea2a2`](https://github.com/getsentry/skills/commit/94ea2a26c70f3f646f07a613ffe5cd3d4eca1955) and packaged by Dockyard (see [stacklok/dockyard#498](https://github.com/stacklok/dockyard/pull/498)) to `ghcr.io/stacklok/dockyard/skills/<name>:0.1.0`.

Follows the OCI-distribution pattern established by [PR #1093 (claude-api)](https://github.com/stacklok/toolhive-catalog/pull/1093), [PR #1094 (toolhive-cli-user)](https://github.com/stacklok/toolhive-catalog/pull/1094), [PR #1095 (trailofbits security skills)](https://github.com/stacklok/toolhive-catalog/pull/1095), and [PR #1109 (google-gemini)](https://github.com/stacklok/toolhive-catalog/pull/1109).

### Skills added (17)

**Agent docs and workflow**
- `agents-md` — minimal, high-signal AGENTS.md / CLAUDE.md docs (under 60 lines target, package-manager detection, no linter duplication)
- `claude-settings-audit` — generate recommended Claude Code `settings.json` read-only permissions from detected stack
- `doc-coauthoring` — structured three-stage doc co-authoring workflow (context gathering, refinement, reader testing)
- `prompt-optimizer` — eval-driven prompt authoring and meta-optimization across Claude / OpenAI / Gemini
- `skill-writer` — author and synthesize Agent Skills per the skills specification

**Git and PR lifecycle**
- `create-branch` — Sentry branch naming convention with automatic prefix + diff-derived description
- `commit` — Sentry conventional-commit format with imperative body and issue references
- `pr-writer` — create/update PRs with why-focused descriptions and safe `gh-api` edits
- `iterate-pr` — iterate on a PR until CI passes and feedback is addressed (LOGAF-ranked, retry-safe polling)
- `gh-review-requests` — fetch unread `review_requested` notifications filtered by team

**Code review and quality**
- `code-simplifier` — simplify and refine code for clarity while preserving behavior
- `find-bugs` — diff-scoped branch review with security + bug checklist (injection, XSS, auth, IDOR, races)

**Django-specific review**
- `django-access-review` — Django access-control / IDOR review (decorators, managers, permission classes)
- `django-perf-review` — validated N+1 / unbounded-queryset / index / write-loop review

**Security**
- `security-review` — OWASP-style vulnerability review with confidence-scored reporting
- `gha-security-review` — GitHub Actions security review (pwn-request, expression injection, credential escalation, supply chain)
- `skill-scanner` — scan agent skills for prompt injection, malicious scripts, excessive permissions, secret exposure

### Skills NOT added

- **`code-review` (intentionally skipped)** — the upstream Sentry `code-review` skill collides with the existing homegrown catalog entry at [`registries/toolhive/skills/code-review/`](https://github.com/stacklok/toolhive-catalog/tree/main/registries/toolhive/skills/code-review), which uses this repo as its git source. To preserve the existing entry, the Sentry `code-review` skill is omitted from this PR. Follows the precedent of [PR #1095](https://github.com/stacklok/toolhive-catalog/pull/1095) skipping `zeroize-audit`.

  Two options to revisit later:
  1. **Keep skipped** — leave the homegrown `code-review` as the canonical entry.
  2. **Rename** — add the Sentry skill as `sentry-code-review` (catalog entry name + directory), keeping the OCI identifier pinned to `ghcr.io/stacklok/dockyard/skills/code-review:0.1.0` since that tag is fixed upstream.

### Notes for review

- **License: `Apache-2.0`.** Confirmed at the `getsentry/skills` repo root; upstream does not embed an SPDX identifier in per-skill `SKILL.md` frontmatter, which is tracked as an allowed Dockyard manifest issue (`MANIFEST_MISSING_LICENSE`).
- **No `allowedTools`.** None of the 17 skills declare `mcp__*` tools — they only use Claude Code built-ins (`Read`, `Grep`, `Glob`, `Bash`, `Task`), which are always satisfied and out of scope for the catalog's MCP-dependency surface.
- **No `skill/SKILL.md` subfolder.** Following the `claude-api` / `toolhive-cli-user` / `gemini` precedent — OCI is authoritative, duplicating `SKILL.md` risks shadowing and drift. A commit-pinned git package is included as a fallback.
- **Icons.** All 17 skills share the same monochrome shield+eye SVG (thematic for Sentry — the watchful sentry). Happy to differentiate per-skill if reviewers prefer.

## Test plan

- [x] `task catalog:validate` — 37 skills total, all valid (both upstream and toolhive formats)
- [x] `task catalog:build` — all 17 new skills present under `data.skills` in `build/toolhive/registry-upstream.json`
- [x] Verified the homegrown `code-review` entry is untouched (still points to `stacklok/toolhive-catalog` as its git source)
- [ ] `task catalog:validate` in CI
- [ ] Post-merge: skills appear in the published `registry-upstream.json` feed

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>

Generated with [Claude Code](https://claude.com/claude-code)