### PR TITLE
chore: mark mcp-optimizer as deprecated

### DIFF
--- a/registries/toolhive/servers/mcp-optimizer/server.json
+++ b/registries/toolhive/servers/mcp-optimizer/server.json
@@ -21,7 +21,7 @@
             "signer_identity": "/.github/workflows/release.yml",
             "sigstore_url": "tuf-repo-cdn.sigstore.dev"
           },
-          "status": "Active",
+          "status": "Deprecated",
           "tags": [
             "mcp",
             "proxy",


### PR DESCRIPTION
## Summary
- Sets `status` from `Active` to `Deprecated` for the `mcp-optimizer` server entry.

## Test plan
- [x] `task catalog:validate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)