### PR TITLE
ci: use GitHub App token for workflows that open PRs and push commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,8 +80,17 @@ jobs:
     needs: [lint, validate-and-test]
     if: github.ref == 'refs/heads/main' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -162,7 +171,7 @@ jobs:
             gh pr merge "$BRANCH" --auto --squash || true
           fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ steps.metadata.outputs.version }}
 
   build-pr:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,9 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    concurrency:
+      group: update-catalog-data
+      cancel-in-progress: false
     needs: [lint, validate-and-test]
     if: github.ref == 'refs/heads/main' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     steps:
@@ -86,6 +89,17 @@ jobs:
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Get app user ID
+        id: app-user
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          USER_ID=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)
+          echo "id=$USER_ID" >> "$GITHUB_OUTPUT"
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -120,8 +134,8 @@ jobs:
         run: |
           BRANCH="update-catalog-data-${VERSION}"
 
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          git config --local user.name "${APP_SLUG}[bot]"
+          git config --local user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
 
           # Create or reset the branch
           git checkout -B "$BRANCH"
@@ -173,6 +187,8 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ steps.metadata.outputs.version }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          APP_USER_ID: ${{ steps.app-user.outputs.id }}
 
   build-pr:
     name: Build Check

--- a/.github/workflows/update-metadata.yml
+++ b/.github/workflows/update-metadata.yml
@@ -12,14 +12,19 @@ on:
         default: '5'
         type: string
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   update-metadata:
     name: Update Server Metadata
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Generate app token
         id: app-token
@@ -27,6 +32,17 @@ jobs:
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Get app user ID
+        id: app-user
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          USER_ID=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)
+          echo "id=$USER_ID" >> "$GITHUB_OUTPUT"
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -49,11 +65,14 @@ jobs:
           INPUT_COUNT: ${{ github.event.inputs.count || '5' }}
 
       - name: Switch to metadata branch
+        env:
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          APP_USER_ID: ${{ steps.app-user.outputs.id }}
         run: |
           BRANCH="catalog-update-metadata"
 
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          git config --local user.name "${APP_SLUG}[bot]"
+          git config --local user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
 
           # Fetch remote branch if it exists so we can build on it
           git fetch origin "$BRANCH" 2>/dev/null || true

--- a/.github/workflows/update-metadata.yml
+++ b/.github/workflows/update-metadata.yml
@@ -21,10 +21,17 @@ jobs:
     name: Update Server Metadata
     runs-on: ubuntu-latest
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -118,5 +125,5 @@ jobs:
             gh pr merge "$BRANCH" --auto --squash || true
           fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           UPDATE_COUNT: ${{ steps.count.outputs.value }}

--- a/.github/workflows/update-tools.yml
+++ b/.github/workflows/update-tools.yml
@@ -357,6 +357,17 @@ jobs:
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Get app user ID
+        id: app-user
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          USER_ID=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)
+          echo "id=$USER_ID" >> "$GITHUB_OUTPUT"
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -386,8 +397,8 @@ jobs:
       - name: Commit and push all changes
         if: steps.check_changes.outputs.changes == 'true'
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          git config --local user.name "${APP_SLUG}[bot]"
+          git config --local user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
 
           # Pull any remote changes first to avoid conflicts
           git pull origin "$BRANCH_REF" --rebase
@@ -443,6 +454,8 @@ jobs:
         env:
           BRANCH_REF: ${{ github.head_ref || github.ref_name }}
           GH_ACTOR: ${{ github.actor }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          APP_USER_ID: ${{ steps.app-user.outputs.id }}
 
   comment-summary:
     name: Post Summary Comment

--- a/.github/workflows/update-tools.yml
+++ b/.github/workflows/update-tools.yml
@@ -351,10 +351,17 @@ jobs:
     if: always() && needs.detect-changes.outputs.has-changes == 'true' && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           ref: ${{ github.head_ref || github.ref }}
 
       - name: Download all commit info artifacts


### PR DESCRIPTION
## Summary

- Migrates `update-metadata.yml`, `ci.yml` (`update-catalog-data` job), and `update-tools.yml` (`commit-all-changes` job) from `secrets.GITHUB_TOKEN` to a GitHub App installation token via `actions/create-github-app-token`.
- Reuses the same `RELEASE_APP_CLIENT_ID` / `RELEASE_APP_PRIVATE_KEY` naming already in use in `toolhive-registry-server`, so the same org-level GitHub App can be installed here.
- Leaves `release.yml`, `claude.yml`, and the lint/test/build-pr jobs untouched — they don't open PRs or push commits, so `GITHUB_TOKEN` is fine.

## Why

Events produced by `GITHUB_TOKEN` do not trigger downstream workflows. That's why PRs opened by the daily metadata workflow (e.g. #1171) and the daily catalog-data workflow (e.g. #1170) land without CI runs, and why auto-update commits pushed onto contributor PR branches by `update-tools` don't re-trigger CI on the PR.

Using a GitHub App installation token mints a token tied to the app's identity, and events from that token *do* trigger downstream workflows.

## Required repo configuration

Before merging, the repo needs:

- The same GitHub App used by `toolhive-registry-server` installed on `stacklok/toolhive-catalog`, with `contents: write` and `pull_requests: write` on this repo.
- `RELEASE_APP_CLIENT_ID` available as a variable to this repo (org-level or repo-level).
- `RELEASE_APP_PRIVATE_KEY` available as a secret to this repo (org-level or repo-level).

If those aren't in place at merge time, the affected workflows will fail at the `Generate app token` step.

## Caveat on `update-tools.yml`

This workflow uses the `pull_request` trigger (not `pull_request_target`), so secrets remain unavailable to fork PRs regardless of this change. The migration only changes behavior for same-repo PRs — which is where the missing-CI symptom shows up anyway.

## Test plan

- [ ] Confirm `RELEASE_APP_CLIENT_ID` (var) and `RELEASE_APP_PRIVATE_KEY` (secret) are accessible from this repo.
- [ ] After merge: trigger `update-metadata.yml` via `workflow_dispatch` and confirm the resulting PR has CI runs.
- [ ] After merge: trigger `ci.yml` via `workflow_dispatch` on `main` and confirm the catalog-data PR has CI runs.
- [ ] After merge: open a same-repo PR that touches a `server.json` and confirm the auto-update commit re-triggers CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)