### PR TITLE
feat: sync dockyard-sourced skills with their published spec.yaml

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -1,0 +1,138 @@
+name: Sync Dockyard Skills
+
+on:
+  schedule:
+    # Run daily at 3:00 AM UTC, an hour after update-metadata.yml.
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+    inputs:
+      dockyard-ref:
+        description: 'Branch or commit ref of stacklok/dockyard to read from'
+        required: false
+        default: 'main'
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  sync-skills:
+    name: Sync Dockyard Skills
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Get app user ID
+        id: app-user
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          USER_ID=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)
+          echo "id=$USER_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Build catalog
+        run: go build -o /tmp/catalog ./cmd/catalog
+
+      - name: Switch to sync branch
+        env:
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          APP_USER_ID: ${{ steps.app-user.outputs.id }}
+        run: |
+          BRANCH="catalog-sync-skills"
+
+          git config --local user.name "${APP_SLUG}[bot]"
+          git config --local user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+
+          # Build on top of any accumulated changes from previous runs.
+          git fetch origin "$BRANCH" 2>/dev/null || true
+          if git rev-parse "origin/$BRANCH" >/dev/null 2>&1; then
+            git checkout -B "$BRANCH" "origin/$BRANCH"
+          else
+            git checkout -B "$BRANCH"
+          fi
+
+      - name: Sync dockyard-sourced skills
+        env:
+          DOCKYARD_REF: ${{ github.event.inputs.dockyard-ref || 'main' }}
+        run: |
+          /tmp/catalog sync-skills --all --dockyard-ref "$DOCKYARD_REF" -v
+
+      - name: Validate after sync
+        run: /tmp/catalog validate -v
+
+      - name: Check for changes
+        id: check-changes
+        run: |
+          if git diff --quiet; then
+            echo "No changes detected"
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "Changes detected"
+            echo "changed=true" >> $GITHUB_OUTPUT
+            git diff --stat
+          fi
+
+      - name: Commit and open or update PR
+        if: steps.check-changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          BRANCH="catalog-sync-skills"
+
+          git add -u registries/
+          git commit -m "chore: sync skills with dockyard"
+          git push -f origin "$BRANCH"
+
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null || true)
+
+          if [ -n "$EXISTING_PR" ]; then
+            echo "PR #$EXISTING_PR already exists, updated branch"
+          else
+            gh pr create \
+              --title "chore: sync skills with dockyard" \
+              --body "$(cat <<'BODY'
+          ## Dockyard Skill Sync
+
+          This PR aligns the OCI tag and git ref of every dockyard-sourced
+          `skill.json` with the corresponding `skills/<name>/spec.yaml` in
+          [stacklok/dockyard](https://github.com/stacklok/dockyard).
+
+          Each scheduled run reads dockyard's `spec.yaml` for every skill whose
+          first OCI package targets `ghcr.io/stacklok/dockyard/skills/*` and
+          rewrites both the OCI tag (`packages[].identifier`) and the upstream
+          git ref (`packages[].ref`) so the two stay in lockstep with whatever
+          dockyard last published.
+
+          ---
+          *This is an automated PR created by the daily skill sync workflow.*
+          BODY
+          )" \
+              --head "$BRANCH"
+
+            gh pr merge "$BRANCH" --auto --squash || true
+          fi

--- a/README.md
+++ b/README.md
@@ -363,9 +363,24 @@ task catalog:build
 # Update metadata for oldest entries
 task catalog:update-metadata:oldest
 
+# Preview a sync of every dockyard-sourced skill (no writes)
+task catalog:sync-skills:all:dry-run
+
 # See all available commands
 task
 ```
+
+### Dockyard skill sync
+
+Skills whose first OCI package targets `ghcr.io/stacklok/dockyard/skills/<name>:*`
+are kept in lockstep with the `skills/<name>/spec.yaml` files in
+[stacklok/dockyard](https://github.com/stacklok/dockyard). The
+[`sync-skills` workflow](.github/workflows/sync-skills.yml) runs daily, executes
+`catalog sync-skills --all`, and opens (or refreshes) a single
+`catalog-sync-skills` PR that bumps both the OCI tag (`packages[].identifier`)
+and the upstream git ref (`packages[].ref`) so they always match what dockyard
+last published. To run it manually, use `task catalog:sync-skills:all` or
+trigger the workflow via `workflow_dispatch`.
 
 ## License
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -101,6 +101,29 @@ tasks:
       - sh: test -n "{{.SERVER}}"
         msg: "Please specify a server.json file with SERVER=path/to/server.json"
 
+  catalog:sync-skills:
+    desc: Sync a single dockyard-sourced skill.json with stacklok/dockyard
+    deps: [build]
+    cmds:
+      - ./{{.BUILD_DIR}}/catalog sync-skills {{.SKILL}} {{.CLI_ARGS}}
+    vars:
+      SKILL: '{{.SKILL | default ""}}'
+    preconditions:
+      - sh: test -n "{{.SKILL}}"
+        msg: "Please specify a skill.json file with SKILL=path/to/skill.json"
+
+  catalog:sync-skills:all:
+    desc: Sync every dockyard-sourced skill with stacklok/dockyard
+    deps: [build]
+    cmds:
+      - ./{{.BUILD_DIR}}/catalog sync-skills --all -v {{.CLI_ARGS}}
+
+  catalog:sync-skills:all:dry-run:
+    desc: Preview every dockyard-sourced skill bump without writing
+    deps: [build]
+    cmds:
+      - ./{{.BUILD_DIR}}/catalog sync-skills --all --dry-run -v
+
   version:
     desc: Show version information
     deps: [build]

--- a/cmd/catalog/main.go
+++ b/cmd/catalog/main.go
@@ -104,6 +104,7 @@ func init() {
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(updateMetadataCmd)
 	rootCmd.AddCommand(updateToolsCmd)
+	rootCmd.AddCommand(syncSkillsCmd)
 }
 
 func main() {

--- a/cmd/catalog/sync_skills.go
+++ b/cmd/catalog/sync_skills.go
@@ -1,0 +1,511 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/stacklok/toolhive-catalog/internal/skilljson"
+)
+
+const (
+	defaultDockyardBaseURL = "https://raw.githubusercontent.com/stacklok/dockyard"
+
+	statusUpdated = "updated"
+	statusNoop    = "noop"
+	statusSkipped = "skipped"
+	statusMissing = "missing"
+	statusError   = "error"
+)
+
+var (
+	syncSkillsAll      bool
+	syncSkillsDryRun   bool
+	syncSkillsDockyard string
+	syncSkillsBaseURL  string
+)
+
+var syncSkillsCmd = &cobra.Command{
+	Use:   "sync-skills [skill.json]",
+	Short: "Sync dockyard-published skills with their upstream spec.yaml",
+	Long: `Reads each skill.json whose first OCI package targets
+ghcr.io/stacklok/dockyard/skills/<name>:* and aligns the OCI tag and
+git ref with the corresponding skills/<name>/spec.yaml in
+github.com/stacklok/dockyard.
+
+Modes:
+  catalog sync-skills <skill.json>   Sync a single file
+  catalog sync-skills --all          Sync every dockyard-sourced skill`,
+	Args: validateSyncSkillsArgs,
+	RunE: runSyncSkills,
+}
+
+func init() {
+	syncSkillsCmd.Flags().BoolVar(
+		&syncSkillsAll, "all", false,
+		"Sync all dockyard-sourced skills under the registries directory",
+	)
+	syncSkillsCmd.Flags().BoolVarP(
+		&syncSkillsDryRun, "dry-run", "d", false,
+		"Show changes without writing",
+	)
+	syncSkillsCmd.Flags().StringVar(
+		&syncSkillsDockyard, "dockyard-ref", "main",
+		"Branch or commit ref of stacklok/dockyard to read spec.yaml from",
+	)
+	syncSkillsCmd.Flags().StringVar(
+		&syncSkillsBaseURL, "dockyard-base-url", defaultDockyardBaseURL,
+		"Base URL for dockyard raw content (mainly for tests)",
+	)
+}
+
+func validateSyncSkillsArgs(_ *cobra.Command, args []string) error {
+	if syncSkillsAll && len(args) > 0 {
+		return fmt.Errorf("cannot use --all with a positional argument")
+	}
+	if !syncSkillsAll && len(args) == 0 {
+		return fmt.Errorf("requires a skill.json path or --all")
+	}
+	if len(args) > 1 {
+		return fmt.Errorf("accepts at most 1 arg(s), received %d", len(args))
+	}
+	return nil
+}
+
+// syncOptions bundles all state needed to perform a sync. Decoupling these
+// from package-level cobra flags makes the underlying logic unit-testable
+// in parallel.
+type syncOptions struct {
+	BaseURL     string
+	DockyardRef string
+	DryRun      bool
+	HTTP        *http.Client
+}
+
+// dockyardSpec mirrors the relevant subset of dockyard's skills/<name>/spec.yaml.
+type dockyardSpec struct {
+	Metadata struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+	Spec struct {
+		Repository string `yaml:"repository"`
+		Ref        string `yaml:"ref"`
+		Path       string `yaml:"path"`
+		Version    string `yaml:"version"`
+	} `yaml:"spec"`
+}
+
+// syncResult captures what happened to a single skill.
+type syncResult struct {
+	Path      string
+	SkillName string
+	Status    string
+	Detail    string
+	IDBefore  string
+	IDAfter   string
+	RefBefore string
+	RefAfter  string
+	// Planned is set in dry-run mode when the sync would have written
+	// changes, so the summary can distinguish would-update from true noop.
+	Planned bool
+}
+
+func defaultSyncOptions() syncOptions {
+	return syncOptions{
+		BaseURL:     syncSkillsBaseURL,
+		DockyardRef: syncSkillsDockyard,
+		DryRun:      syncSkillsDryRun,
+		HTTP:        &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+func runSyncSkills(_ *cobra.Command, args []string) error {
+	ctx := context.Background()
+	opts := defaultSyncOptions()
+	if syncSkillsAll {
+		return runSyncSkillsAll(ctx, opts, registriesDir)
+	}
+	res := syncOneSkill(ctx, opts, args[0])
+	printSyncResult(res, true)
+	if res.Status == statusError {
+		return fmt.Errorf("sync failed for %s: %s", res.Path, res.Detail)
+	}
+	return nil
+}
+
+func runSyncSkillsAll(ctx context.Context, opts syncOptions, root string) error {
+	paths, err := findDockyardSkillFiles(root)
+	if err != nil {
+		return err
+	}
+	if len(paths) == 0 {
+		fmt.Println("No dockyard-sourced skills found")
+		return nil
+	}
+
+	fmt.Printf("Syncing %d dockyard-sourced skill(s)\n\n", len(paths))
+
+	results := make([]syncResult, 0, len(paths))
+	for _, p := range paths {
+		results = append(results, syncOneSkill(ctx, opts, p))
+	}
+
+	printSyncSummary(results)
+
+	if errs := countByStatus(results, statusError); errs > 0 {
+		return fmt.Errorf("%d/%d sync(s) failed", errs, len(results))
+	}
+	return nil
+}
+
+// findDockyardSkillFiles walks the registries directory and returns paths to
+// every skill.json whose first OCI package targets the dockyard prefix.
+func findDockyardSkillFiles(root string) ([]string, error) {
+	regs, err := os.ReadDir(root)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read registries directory %s: %w", root, err)
+	}
+	var out []string
+	for _, reg := range regs {
+		if !reg.IsDir() || strings.HasPrefix(reg.Name(), ".") {
+			continue
+		}
+		paths, err := dockyardSkillsInRegistry(filepath.Join(root, reg.Name(), skillsSubdir))
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, paths...)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func dockyardSkillsInRegistry(skillsDir string) ([]string, error) {
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read %s: %w", skillsDir, err)
+	}
+	var out []string
+	for _, e := range entries {
+		if !e.IsDir() || strings.HasPrefix(e.Name(), ".") {
+			continue
+		}
+		path := filepath.Join(skillsDir, e.Name(), "skill.json")
+		sf, err := skilljson.Load(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		if idx, _, _ := sf.DockyardOCIPackage(); idx >= 0 {
+			out = append(out, path)
+		}
+	}
+	return out, nil
+}
+
+// syncOneSkill performs the full sync flow for a single skill.json path.
+// It never panics; failures are reported via the returned syncResult.
+func syncOneSkill(ctx context.Context, opts syncOptions, path string) syncResult {
+	res := syncResult{Path: path}
+
+	sf, err := skilljson.Load(path)
+	if err != nil {
+		return errorResult(res, err.Error())
+	}
+
+	ociIdx, name, currentTag := sf.DockyardOCIPackage()
+	if ociIdx < 0 {
+		res.Status = statusSkipped
+		res.Detail = "no dockyard OCI package"
+		return res
+	}
+	res.SkillName = name
+	res.IDBefore = sf.Skill.Packages[ociIdx].Identifier
+
+	spec, errRes, ok := loadDockyardSpec(ctx, opts, res, name)
+	if !ok {
+		return errRes
+	}
+
+	gitIdx := sf.GitPackage()
+	if skipRes, ok := guardGitPackage(sf, gitIdx, spec, &res); !ok {
+		return skipRes
+	}
+
+	return applySync(sf, ociIdx, gitIdx, currentTag, name, spec, opts, res)
+}
+
+// loadDockyardSpec fetches and validates a dockyard spec.yaml for the named
+// skill. The (result, ok) sentinel mirrors a "happy path returns true" pattern
+// so the caller can short-circuit on missing/invalid specs without nesting.
+func loadDockyardSpec(
+	ctx context.Context, opts syncOptions, res syncResult, name string,
+) (*dockyardSpec, syncResult, bool) {
+	spec, err := fetchDockyardSpec(ctx, opts, name)
+	if err != nil {
+		if isNotFoundErr(err) {
+			res.Status = statusMissing
+			res.Detail = "not present in dockyard"
+			return nil, res, false
+		}
+		return nil, errorResult(res, err.Error()), false
+	}
+	if spec.Spec.Version == "" {
+		return nil, errorResult(res, "dockyard spec.yaml is missing spec.version"), false
+	}
+	return spec, res, true
+}
+
+// guardGitPackage validates the git package against the dockyard spec.
+// On mismatch it returns (skipResult, false). On match (or absence of a git
+// package) it records the current ref into res via pointer and returns ok=true.
+func guardGitPackage(
+	sf *skilljson.SkillFile, gitIdx int, spec *dockyardSpec, res *syncResult,
+) (syncResult, bool) {
+	if gitIdx < 0 {
+		return syncResult{}, true
+	}
+	gp := sf.Skill.Packages[gitIdx]
+	if skip, detail := checkGitMatches(gp.URL, gp.Subfolder, spec); skip {
+		out := *res
+		out.Status = statusSkipped
+		out.Detail = detail
+		return out, false
+	}
+	res.RefBefore = gp.Ref
+	return syncResult{}, true
+}
+
+// applySync performs the actual rewrite and write phase based on whether the
+// tag/ref need to bump. dryRun short-circuits before touching disk.
+func applySync(
+	sf *skilljson.SkillFile,
+	ociIdx, gitIdx int,
+	currentTag, name string,
+	spec *dockyardSpec,
+	opts syncOptions,
+	res syncResult,
+) syncResult {
+	newID := skilljson.DockyardSkillPrefix + name + ":" + spec.Spec.Version
+	tagBumped := currentTag != spec.Spec.Version
+	refBumped := gitIdx >= 0 && spec.Spec.Ref != "" && sf.Skill.Packages[gitIdx].Ref != spec.Spec.Ref
+
+	if !tagBumped && !refBumped {
+		res.Status = statusNoop
+		res.IDAfter = res.IDBefore
+		res.RefAfter = res.RefBefore
+		return res
+	}
+
+	if tagBumped {
+		if err := sf.SetIdentifier(ociIdx, newID); err != nil {
+			return errorResult(res, err.Error())
+		}
+	}
+	if refBumped {
+		if err := sf.SetRef(gitIdx, spec.Spec.Ref); err != nil {
+			return errorResult(res, err.Error())
+		}
+	}
+
+	res.IDAfter = sf.Skill.Packages[ociIdx].Identifier
+	if gitIdx >= 0 {
+		res.RefAfter = sf.Skill.Packages[gitIdx].Ref
+	}
+
+	if opts.DryRun {
+		res.Status = statusNoop
+		res.Detail = "[DRY RUN] would update"
+		res.Planned = true
+		return res
+	}
+
+	if err := sf.Write(); err != nil {
+		return errorResult(res, err.Error())
+	}
+	res.Status = statusUpdated
+	return res
+}
+
+func errorResult(res syncResult, detail string) syncResult {
+	res.Status = statusError
+	res.Detail = detail
+	return res
+}
+
+// checkGitMatches enforces that the catalog git package and the dockyard
+// spec point at the same upstream repository and subfolder. A mismatch
+// causes the skill to be skipped (not silently rewritten).
+func checkGitMatches(catalogURL, catalogSubfolder string, spec *dockyardSpec) (skip bool, detail string) {
+	if !repoURLsMatch(catalogURL, spec.Spec.Repository) {
+		return true, fmt.Sprintf(
+			"repository mismatch: catalog has %q, dockyard advertises %q",
+			catalogURL, spec.Spec.Repository)
+	}
+	if spec.Spec.Path != "" && catalogSubfolder != "" && catalogSubfolder != spec.Spec.Path {
+		return true, fmt.Sprintf(
+			"subfolder mismatch: catalog has %q, dockyard advertises %q",
+			catalogSubfolder, spec.Spec.Path)
+	}
+	return false, ""
+}
+
+// fetchDockyardSpec retrieves and parses the spec.yaml for the given skill name
+// from stacklok/dockyard at the configured ref.
+func fetchDockyardSpec(ctx context.Context, opts syncOptions, name string) (*dockyardSpec, error) {
+	specURL := fmt.Sprintf(
+		"%s/%s/skills/%s/spec.yaml",
+		strings.TrimRight(opts.BaseURL, "/"),
+		url.PathEscape(opts.DockyardRef),
+		url.PathEscape(name),
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, specURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build request: %w", err)
+	}
+	resp, err := opts.HTTP.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch %s: %w", specURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, errNotFound{url: specURL}
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d fetching %s", resp.StatusCode, specURL)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+	var spec dockyardSpec
+	if err := yaml.Unmarshal(body, &spec); err != nil {
+		return nil, fmt.Errorf("failed to parse spec.yaml for %s: %w", name, err)
+	}
+	return &spec, nil
+}
+
+type errNotFound struct {
+	url string
+}
+
+func (e errNotFound) Error() string { return "not found: " + e.url }
+
+func isNotFoundErr(err error) bool {
+	_, ok := err.(errNotFound)
+	return ok
+}
+
+// repoURLsMatch compares two git repository URLs while tolerating common
+// suffix differences (".git", trailing slash). Empty inputs always return
+// false so the sanity guard fails closed.
+func repoURLsMatch(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	return canonRepoURL(a) == canonRepoURL(b)
+}
+
+func canonRepoURL(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimSuffix(s, "/")
+	s = strings.TrimSuffix(s, ".git")
+	return s
+}
+
+func countByStatus(rs []syncResult, status string) int {
+	n := 0
+	for _, r := range rs {
+		if r.Status == status {
+			n++
+		}
+	}
+	return n
+}
+
+func printSyncResult(r syncResult, single bool) {
+	switch r.Status {
+	case statusUpdated:
+		fmt.Printf("UPDATED  %s (%s)\n", r.Path, r.SkillName)
+		printDelta(r)
+	case statusNoop:
+		if r.Planned {
+			fmt.Printf("DRY-RUN  %s (%s)\n", r.Path, r.SkillName)
+			printDelta(r)
+			return
+		}
+		if single || verbose {
+			fmt.Printf("NOOP     %s (%s)\n", r.Path, r.SkillName)
+		}
+	case statusSkipped:
+		fmt.Printf("SKIPPED  %s (%s): %s\n", r.Path, r.SkillName, r.Detail)
+	case statusMissing:
+		fmt.Printf("MISSING  %s (%s): %s\n", r.Path, r.SkillName, r.Detail)
+	case statusError:
+		fmt.Fprintf(os.Stderr, "ERROR    %s (%s): %s\n", r.Path, r.SkillName, r.Detail)
+	}
+}
+
+func printDelta(r syncResult) {
+	if r.IDBefore != r.IDAfter {
+		fmt.Printf("  identifier: %s -> %s\n", r.IDBefore, r.IDAfter)
+	}
+	if r.RefBefore != r.RefAfter && r.RefAfter != "" {
+		fmt.Printf("  ref:        %s -> %s\n", r.RefBefore, r.RefAfter)
+	}
+}
+
+func printSyncSummary(results []syncResult) {
+	for _, r := range results {
+		printSyncResult(r, false)
+	}
+	planned := 0
+	noop := 0
+	for _, r := range results {
+		if r.Status != statusNoop {
+			continue
+		}
+		if r.Planned {
+			planned++
+		} else {
+			noop++
+		}
+	}
+	fmt.Println()
+	if planned > 0 {
+		fmt.Printf("Summary: %d would-update, %d noop, %d skipped, %d missing, %d error (of %d) [dry run]\n",
+			planned,
+			noop,
+			countByStatus(results, statusSkipped),
+			countByStatus(results, statusMissing),
+			countByStatus(results, statusError),
+			len(results),
+		)
+		return
+	}
+	fmt.Printf("Summary: %d updated, %d noop, %d skipped, %d missing, %d error (of %d)\n",
+		countByStatus(results, statusUpdated),
+		noop,
+		countByStatus(results, statusSkipped),
+		countByStatus(results, statusMissing),
+		countByStatus(results, statusError),
+		len(results),
+	)
+}

--- a/cmd/catalog/sync_skills_test.go
+++ b/cmd/catalog/sync_skills_test.go
@@ -1,0 +1,386 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const fixtureSkillJSON = `{
+  "namespace": "io.github.stacklok",
+  "name": "security-review",
+  "title": "Sentry Security Review Skill",
+  "description": "Security code review for vulnerabilities.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/getsentry/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/security-review:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/getsentry/skills",
+      "ref": "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955",
+      "subfolder": "skills/security-review"
+    }
+  ]
+}
+`
+
+const fixtureNonDockyardSkillJSON = `{
+  "namespace": "io.github.stacklok",
+  "name": "skill-creator",
+  "title": "Skill Creator",
+  "description": "Catalog-hosted skill.",
+  "version": "0.1.0",
+  "packages": [
+    {
+      "registryType": "git",
+      "url": "https://github.com/stacklok/toolhive-catalog",
+      "ref": "main",
+      "subfolder": "registries/toolhive/skills/skill-creator/skill"
+    }
+  ]
+}
+`
+
+const (
+	originalRef = "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955"
+	bumpedRef   = "f2cff985bcec174fcd096db65a23f06ec9bdde29"
+)
+
+// dockyardSpecYAML returns a spec.yaml body with the given fields. The skill
+// name is fixed to "security-review" because all current tests share that
+// fixture.
+func dockyardSpecYAML(repo, ref, path, version string) string {
+	return fmt.Sprintf(`metadata:
+  name: security-review
+  description: "test"
+
+spec:
+  repository: %q
+  ref: %q
+  path: %q
+  version: %q
+`, repo, ref, path, version)
+}
+
+// fakeDockyard returns an httptest.Server that serves spec.yaml files for the
+// given map of skill name -> body. Skills missing from the map yield 404.
+func fakeDockyard(t *testing.T, specs map[string]string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/main/skills/", func(w http.ResponseWriter, r *http.Request) {
+		const prefix = "/main/skills/"
+		rest := strings.TrimPrefix(r.URL.Path, prefix)
+		name, _, ok := strings.Cut(rest, "/")
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		body, exists := specs[name]
+		if !exists {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte(body))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func optsFor(srv *httptest.Server, dryRun bool) syncOptions {
+	return syncOptions{
+		BaseURL:     srv.URL,
+		DockyardRef: "main",
+		DryRun:      dryRun,
+		HTTP:        srv.Client(),
+	}
+}
+
+func writeSkill(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "skill.json")
+	if err := os.WriteFile(path, []byte(body), 0600); err != nil {
+		t.Fatalf("failed to write fixture: %v", err)
+	}
+	return path
+}
+
+func TestSyncOneSkill_TagOnly(t *testing.T) {
+	t.Parallel()
+	srv := fakeDockyard(t, map[string]string{
+		"security-review": dockyardSpecYAML(
+			"https://github.com/getsentry/skills",
+			originalRef, "skills/security-review", "0.2.0",
+		),
+	})
+
+	path := writeSkill(t, fixtureSkillJSON)
+	res := syncOneSkill(context.Background(), optsFor(srv, false), path)
+	if res.Status != statusUpdated {
+		t.Fatalf("expected updated, got %s (%s)", res.Status, res.Detail)
+	}
+	got, _ := os.ReadFile(path)
+	if !strings.Contains(string(got), ":0.2.0") {
+		t.Errorf("new tag not present: %s", got)
+	}
+	if !strings.Contains(string(got), originalRef) {
+		t.Errorf("ref should not have changed")
+	}
+}
+
+func TestSyncOneSkill_RefOnly(t *testing.T) {
+	t.Parallel()
+	srv := fakeDockyard(t, map[string]string{
+		"security-review": dockyardSpecYAML(
+			"https://github.com/getsentry/skills",
+			bumpedRef, "skills/security-review", "0.1.0",
+		),
+	})
+
+	path := writeSkill(t, fixtureSkillJSON)
+	res := syncOneSkill(context.Background(), optsFor(srv, false), path)
+	if res.Status != statusUpdated {
+		t.Fatalf("expected updated, got %s (%s)", res.Status, res.Detail)
+	}
+	got, _ := os.ReadFile(path)
+	if !strings.Contains(string(got), bumpedRef) {
+		t.Errorf("new ref not present in file")
+	}
+	if !strings.Contains(string(got), ":0.1.0") {
+		t.Errorf("tag should not have changed")
+	}
+}
+
+func TestSyncOneSkill_Both(t *testing.T) {
+	t.Parallel()
+	srv := fakeDockyard(t, map[string]string{
+		"security-review": dockyardSpecYAML(
+			"https://github.com/getsentry/skills",
+			bumpedRef, "skills/security-review", "0.2.0",
+		),
+	})
+
+	path := writeSkill(t, fixtureSkillJSON)
+	res := syncOneSkill(context.Background(), optsFor(srv, false), path)
+	if res.Status != statusUpdated {
+		t.Fatalf("expected updated, got %s (%s)", res.Status, res.Detail)
+	}
+	got, _ := os.ReadFile(path)
+	if !strings.Contains(string(got), ":0.2.0") || !strings.Contains(string(got), bumpedRef) {
+		t.Errorf("expected both updates in file:\n%s", got)
+	}
+}
+
+func TestSyncOneSkill_NoOp(t *testing.T) {
+	t.Parallel()
+	srv := fakeDockyard(t, map[string]string{
+		"security-review": dockyardSpecYAML(
+			"https://github.com/getsentry/skills",
+			originalRef, "skills/security-review", "0.1.0",
+		),
+	})
+
+	path := writeSkill(t, fixtureSkillJSON)
+	before, _ := os.ReadFile(path)
+	res := syncOneSkill(context.Background(), optsFor(srv, false), path)
+	if res.Status != statusNoop {
+		t.Fatalf("expected noop, got %s (%s)", res.Status, res.Detail)
+	}
+	after, _ := os.ReadFile(path)
+	if string(before) != string(after) {
+		t.Errorf("file mutated despite noop result")
+	}
+}
+
+func TestSyncOneSkill_DryRun(t *testing.T) {
+	t.Parallel()
+	srv := fakeDockyard(t, map[string]string{
+		"security-review": dockyardSpecYAML(
+			"https://github.com/getsentry/skills",
+			bumpedRef, "skills/security-review", "0.2.0",
+		),
+	})
+
+	path := writeSkill(t, fixtureSkillJSON)
+	before, _ := os.ReadFile(path)
+	res := syncOneSkill(context.Background(), optsFor(srv, true), path)
+	if res.Status != statusNoop {
+		t.Fatalf("expected noop in dry-run, got %s (%s)", res.Status, res.Detail)
+	}
+	if res.IDAfter == res.IDBefore && res.RefAfter == res.RefBefore {
+		t.Errorf("expected dry-run to record a planned change")
+	}
+	after, _ := os.ReadFile(path)
+	if string(before) != string(after) {
+		t.Errorf("dry-run mutated the file on disk")
+	}
+}
+
+func TestSyncOneSkill_RepoMismatchSkips(t *testing.T) {
+	t.Parallel()
+	srv := fakeDockyard(t, map[string]string{
+		"security-review": dockyardSpecYAML(
+			"https://github.com/example/other-skills",
+			bumpedRef, "skills/security-review", "0.2.0",
+		),
+	})
+
+	path := writeSkill(t, fixtureSkillJSON)
+	before, _ := os.ReadFile(path)
+	res := syncOneSkill(context.Background(), optsFor(srv, false), path)
+	if res.Status != statusSkipped {
+		t.Fatalf("expected skipped, got %s (%s)", res.Status, res.Detail)
+	}
+	if !strings.Contains(res.Detail, "repository mismatch") {
+		t.Errorf("expected repository mismatch detail, got %q", res.Detail)
+	}
+	after, _ := os.ReadFile(path)
+	if string(before) != string(after) {
+		t.Errorf("file mutated despite skipped result")
+	}
+}
+
+func TestSyncOneSkill_SubfolderMismatchSkips(t *testing.T) {
+	t.Parallel()
+	srv := fakeDockyard(t, map[string]string{
+		"security-review": dockyardSpecYAML(
+			"https://github.com/getsentry/skills",
+			bumpedRef, "different/path", "0.2.0",
+		),
+	})
+
+	path := writeSkill(t, fixtureSkillJSON)
+	res := syncOneSkill(context.Background(), optsFor(srv, false), path)
+	if res.Status != statusSkipped {
+		t.Fatalf("expected skipped, got %s (%s)", res.Status, res.Detail)
+	}
+	if !strings.Contains(res.Detail, "subfolder mismatch") {
+		t.Errorf("expected subfolder mismatch detail, got %q", res.Detail)
+	}
+}
+
+func TestSyncOneSkill_Missing404(t *testing.T) {
+	t.Parallel()
+	srv := fakeDockyard(t, map[string]string{})
+
+	path := writeSkill(t, fixtureSkillJSON)
+	res := syncOneSkill(context.Background(), optsFor(srv, false), path)
+	if res.Status != statusMissing {
+		t.Fatalf("expected missing, got %s (%s)", res.Status, res.Detail)
+	}
+}
+
+func TestSyncOneSkill_NoDockyardPackageSkips(t *testing.T) {
+	t.Parallel()
+	srv := fakeDockyard(t, map[string]string{})
+
+	path := writeSkill(t, fixtureNonDockyardSkillJSON)
+	res := syncOneSkill(context.Background(), optsFor(srv, false), path)
+	if res.Status != statusSkipped {
+		t.Fatalf("expected skipped, got %s (%s)", res.Status, res.Detail)
+	}
+}
+
+func TestSyncOneSkill_MalformedYAMLErrors(t *testing.T) {
+	t.Parallel()
+	srv := fakeDockyard(t, map[string]string{
+		"security-review": "spec:\n  version: [unterminated",
+	})
+
+	path := writeSkill(t, fixtureSkillJSON)
+	res := syncOneSkill(context.Background(), optsFor(srv, false), path)
+	if res.Status != statusError {
+		t.Fatalf("expected error, got %s (%s)", res.Status, res.Detail)
+	}
+}
+
+func TestFindDockyardSkillFiles(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mustWrite := func(rel, body string) {
+		full := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	mustWrite("toolhive/skills/security-review/skill.json", fixtureSkillJSON)
+	mustWrite("toolhive/skills/skill-creator/skill.json", fixtureNonDockyardSkillJSON)
+	mustWrite(".hidden/skills/foo/skill.json", fixtureSkillJSON)
+	mustWrite("official/servers/foo/server.json", "{}")
+
+	paths, err := findDockyardSkillFiles(root)
+	if err != nil {
+		t.Fatalf("findDockyardSkillFiles: %v", err)
+	}
+	if len(paths) != 1 {
+		t.Fatalf("expected 1 dockyard skill, got %d (%v)", len(paths), paths)
+	}
+	if !strings.HasSuffix(paths[0], "security-review/skill.json") {
+		t.Errorf("unexpected path: %s", paths[0])
+	}
+}
+
+func TestRunSyncSkillsAllReportsErrorExit(t *testing.T) {
+	t.Parallel()
+	srv := fakeDockyard(t, map[string]string{
+		"security-review": "spec:\n  version: [unterminated",
+	})
+
+	root := t.TempDir()
+	dir := filepath.Join(root, "toolhive", "skills", "security-review")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "skill.json"), []byte(fixtureSkillJSON), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := runSyncSkillsAll(context.Background(), optsFor(srv, false), root); err == nil {
+		t.Fatal("expected error from --all when a skill fails")
+	}
+}
+
+func TestRepoURLsMatch(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"https://github.com/foo/bar", "https://github.com/foo/bar", true},
+		{"https://github.com/foo/bar.git", "https://github.com/foo/bar", true},
+		{"https://github.com/foo/bar/", "https://github.com/foo/bar.git", true},
+		{"https://github.com/foo/bar", "https://github.com/foo/baz", false},
+		{"", "https://github.com/foo/bar", false},
+		{"https://github.com/foo/bar", "", false},
+	}
+	for _, tc := range cases {
+		if got := repoURLsMatch(tc.a, tc.b); got != tc.want {
+			t.Errorf("repoURLsMatch(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
+		}
+	}
+}

--- a/internal/skilljson/skilljson.go
+++ b/internal/skilljson/skilljson.go
@@ -1,0 +1,153 @@
+// Package skilljson provides utilities for reading and surgically modifying
+// individual skill.json files. Updates are performed as byte-level
+// substitutions so the original key order, indentation, and trailing newline
+// of the file are preserved across rewrites.
+package skilljson
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	thvregistry "github.com/stacklok/toolhive-core/registry/types"
+)
+
+// DockyardSkillPrefix is the OCI identifier prefix for skills published by
+// the stacklok/dockyard pipeline.
+const DockyardSkillPrefix = "ghcr.io/stacklok/dockyard/skills/"
+
+// SkillFile represents a loaded skill.json with both its parsed structure
+// and its original bytes for round-trip fidelity.
+type SkillFile struct {
+	// Path is the filesystem path to the skill.json file.
+	Path string
+	// Skill is the parsed skill structure.
+	Skill thvregistry.Skill
+	// rawBytes preserves the original file bytes for surgical edits.
+	rawBytes []byte
+}
+
+// Load reads and parses a skill.json from the given path.
+func Load(path string) (*SkillFile, error) {
+	data, err := os.ReadFile(path) // #nosec G304 - path comes from caller (registry directory walk)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s: %w", path, err)
+	}
+
+	var skill thvregistry.Skill
+	if err := json.Unmarshal(data, &skill); err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", path, err)
+	}
+
+	return &SkillFile{
+		Path:     path,
+		Skill:    skill,
+		rawBytes: data,
+	}, nil
+}
+
+// DockyardOCIPackage returns the index of the first OCI package whose
+// identifier starts with [DockyardSkillPrefix], along with the parsed
+// skill name and current tag from the identifier. Returns idx == -1
+// when no such package is present.
+func (sf *SkillFile) DockyardOCIPackage() (idx int, skillName, currentTag string) {
+	for i, p := range sf.Skill.Packages {
+		if p.RegistryType != "oci" {
+			continue
+		}
+		if !strings.HasPrefix(p.Identifier, DockyardSkillPrefix) {
+			continue
+		}
+		rest := strings.TrimPrefix(p.Identifier, DockyardSkillPrefix)
+		colon := strings.IndexByte(rest, ':')
+		if colon <= 0 || colon == len(rest)-1 {
+			continue
+		}
+		return i, rest[:colon], rest[colon+1:]
+	}
+	return -1, "", ""
+}
+
+// GitPackage returns the index of the first git package, or -1 if none.
+func (sf *SkillFile) GitPackage() int {
+	for i, p := range sf.Skill.Packages {
+		if p.RegistryType == "git" {
+			return i
+		}
+	}
+	return -1
+}
+
+// SetIdentifier replaces the OCI identifier of the package at idx with a
+// byte-level substitution. The old identifier must occur exactly once in
+// the raw file bytes.
+func (sf *SkillFile) SetIdentifier(idx int, newIdentifier string) error {
+	if idx < 0 || idx >= len(sf.Skill.Packages) {
+		return fmt.Errorf("package index %d out of range (have %d packages)", idx, len(sf.Skill.Packages))
+	}
+	old := sf.Skill.Packages[idx].Identifier
+	if old == newIdentifier {
+		return nil
+	}
+	oldEnc, err := json.Marshal(old)
+	if err != nil {
+		return fmt.Errorf("failed to encode old identifier: %w", err)
+	}
+	newEnc, err := json.Marshal(newIdentifier)
+	if err != nil {
+		return fmt.Errorf("failed to encode new identifier: %w", err)
+	}
+	if count := bytes.Count(sf.rawBytes, oldEnc); count != 1 {
+		return fmt.Errorf("expected exactly 1 occurrence of identifier %q in %s, found %d", old, sf.Path, count)
+	}
+	sf.rawBytes = bytes.Replace(sf.rawBytes, oldEnc, newEnc, 1)
+	sf.Skill.Packages[idx].Identifier = newIdentifier
+	return nil
+}
+
+// SetRef replaces the ref of the package at idx with a byte-level
+// substitution. The match is scoped to a `"ref": "<old>"` token to avoid
+// touching unrelated string occurrences. Both spaced and unspaced forms
+// of the JSON key are accepted.
+func (sf *SkillFile) SetRef(idx int, newRef string) error {
+	if idx < 0 || idx >= len(sf.Skill.Packages) {
+		return fmt.Errorf("package index %d out of range (have %d packages)", idx, len(sf.Skill.Packages))
+	}
+	old := sf.Skill.Packages[idx].Ref
+	if old == newRef {
+		return nil
+	}
+	oldVal, err := json.Marshal(old)
+	if err != nil {
+		return fmt.Errorf("failed to encode old ref: %w", err)
+	}
+	newVal, err := json.Marshal(newRef)
+	if err != nil {
+		return fmt.Errorf("failed to encode new ref: %w", err)
+	}
+
+	candidates := [][2][]byte{
+		{[]byte(`"ref": ` + string(oldVal)), []byte(`"ref": ` + string(newVal))},
+		{[]byte(`"ref":` + string(oldVal)), []byte(`"ref":` + string(newVal))},
+	}
+	for _, c := range candidates {
+		if bytes.Count(sf.rawBytes, c[0]) == 1 {
+			sf.rawBytes = bytes.Replace(sf.rawBytes, c[0], c[1], 1)
+			sf.Skill.Packages[idx].Ref = newRef
+			return nil
+		}
+	}
+	return fmt.Errorf("expected exactly 1 occurrence of `\"ref\": %s` in %s", oldVal, sf.Path)
+}
+
+// Bytes returns the current (possibly modified) raw bytes of the skill.json.
+func (sf *SkillFile) Bytes() []byte {
+	return sf.rawBytes
+}
+
+// Write writes the current raw bytes back to the file path.
+func (sf *SkillFile) Write() error {
+	return os.WriteFile(sf.Path, sf.rawBytes, 0600)
+}

--- a/internal/skilljson/skilljson_test.go
+++ b/internal/skilljson/skilljson_test.go
@@ -1,0 +1,251 @@
+package skilljson
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const sampleSkill = `{
+  "namespace": "io.github.stacklok",
+  "name": "security-review",
+  "title": "Sentry Security Review Skill",
+  "description": "Security code review for vulnerabilities.",
+  "version": "0.1.0",
+  "status": "active",
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "https://github.com/getsentry/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/security-review:0.1.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/getsentry/skills",
+      "ref": "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955",
+      "subfolder": "skills/security-review"
+    }
+  ]
+}
+`
+
+func writeFixture(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "skill.json")
+	if err := os.WriteFile(path, []byte(contents), 0600); err != nil {
+		t.Fatalf("failed to write fixture: %v", err)
+	}
+	return path
+}
+
+func TestLoad(t *testing.T) {
+	t.Parallel()
+	path := writeFixture(t, sampleSkill)
+	sf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if sf.Skill.Name != "security-review" {
+		t.Errorf("expected name security-review, got %q", sf.Skill.Name)
+	}
+	if len(sf.Skill.Packages) != 2 {
+		t.Fatalf("expected 2 packages, got %d", len(sf.Skill.Packages))
+	}
+}
+
+func TestLoadMalformed(t *testing.T) {
+	t.Parallel()
+	path := writeFixture(t, "{not json}")
+	if _, err := Load(path); err == nil {
+		t.Fatal("expected error loading malformed skill.json")
+	}
+}
+
+func TestDockyardOCIPackage(t *testing.T) {
+	t.Parallel()
+	path := writeFixture(t, sampleSkill)
+	sf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	idx, name, tag := sf.DockyardOCIPackage()
+	if idx != 0 {
+		t.Errorf("expected idx 0, got %d", idx)
+	}
+	if name != "security-review" {
+		t.Errorf("expected skill name security-review, got %q", name)
+	}
+	if tag != "0.1.0" {
+		t.Errorf("expected tag 0.1.0, got %q", tag)
+	}
+}
+
+func TestDockyardOCIPackageNotFound(t *testing.T) {
+	t.Parallel()
+	path := writeFixture(t, strings.Replace(sampleSkill,
+		"ghcr.io/stacklok/dockyard/skills/security-review:0.1.0",
+		"ghcr.io/example/other:1.0.0", 1))
+	sf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if idx, _, _ := sf.DockyardOCIPackage(); idx != -1 {
+		t.Errorf("expected -1, got %d", idx)
+	}
+}
+
+func TestGitPackage(t *testing.T) {
+	t.Parallel()
+	path := writeFixture(t, sampleSkill)
+	sf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if got := sf.GitPackage(); got != 1 {
+		t.Errorf("expected git package idx 1, got %d", got)
+	}
+}
+
+func TestSetIdentifierBumpsTag(t *testing.T) {
+	t.Parallel()
+	path := writeFixture(t, sampleSkill)
+	sf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	newID := "ghcr.io/stacklok/dockyard/skills/security-review:0.2.0"
+	if err := sf.SetIdentifier(0, newID); err != nil {
+		t.Fatalf("SetIdentifier failed: %v", err)
+	}
+	if sf.Skill.Packages[0].Identifier != newID {
+		t.Errorf("identifier not updated in struct, got %q", sf.Skill.Packages[0].Identifier)
+	}
+	if !strings.Contains(string(sf.Bytes()), newID) {
+		t.Errorf("new identifier not present in raw bytes")
+	}
+	if strings.Contains(string(sf.Bytes()), ":0.1.0") {
+		t.Errorf("old tag still present in raw bytes")
+	}
+}
+
+func TestSetIdentifierNoOp(t *testing.T) {
+	t.Parallel()
+	path := writeFixture(t, sampleSkill)
+	sf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	before := string(sf.Bytes())
+	if err := sf.SetIdentifier(0, sf.Skill.Packages[0].Identifier); err != nil {
+		t.Fatalf("SetIdentifier failed on no-op: %v", err)
+	}
+	if string(sf.Bytes()) != before {
+		t.Errorf("no-op SetIdentifier mutated bytes")
+	}
+}
+
+func TestSetIdentifierOutOfRange(t *testing.T) {
+	t.Parallel()
+	path := writeFixture(t, sampleSkill)
+	sf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if err := sf.SetIdentifier(99, "ghcr.io/foo:1"); err == nil {
+		t.Error("expected out-of-range error")
+	}
+}
+
+func TestSetRefBumpsRef(t *testing.T) {
+	t.Parallel()
+	path := writeFixture(t, sampleSkill)
+	sf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	newRef := "f2cff985bcec174fcd096db65a23f06ec9bdde29"
+	if err := sf.SetRef(1, newRef); err != nil {
+		t.Fatalf("SetRef failed: %v", err)
+	}
+	if sf.Skill.Packages[1].Ref != newRef {
+		t.Errorf("ref not updated in struct, got %q", sf.Skill.Packages[1].Ref)
+	}
+	if !strings.Contains(string(sf.Bytes()), newRef) {
+		t.Errorf("new ref not present in raw bytes")
+	}
+	if strings.Contains(string(sf.Bytes()), "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955") {
+		t.Errorf("old ref still present in raw bytes")
+	}
+}
+
+func TestSetRefUnspaced(t *testing.T) {
+	t.Parallel()
+	path := writeFixture(t, strings.ReplaceAll(sampleSkill,
+		`"ref": "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955"`,
+		`"ref":"94ea2a26c70f3f646f07a613ffe5cd3d4eca1955"`))
+	sf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if err := sf.SetRef(1, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"); err != nil {
+		t.Fatalf("SetRef failed on unspaced form: %v", err)
+	}
+	if !strings.Contains(string(sf.Bytes()),
+		`"ref":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"`) {
+		t.Errorf("unspaced ref not rewritten correctly")
+	}
+}
+
+func TestSetRefNoOp(t *testing.T) {
+	t.Parallel()
+	path := writeFixture(t, sampleSkill)
+	sf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	before := string(sf.Bytes())
+	if err := sf.SetRef(1, sf.Skill.Packages[1].Ref); err != nil {
+		t.Fatalf("SetRef failed on no-op: %v", err)
+	}
+	if string(sf.Bytes()) != before {
+		t.Errorf("no-op SetRef mutated bytes")
+	}
+}
+
+func TestWriteRoundTrip(t *testing.T) {
+	t.Parallel()
+	path := writeFixture(t, sampleSkill)
+	sf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	newID := "ghcr.io/stacklok/dockyard/skills/security-review:0.2.0"
+	if err := sf.SetIdentifier(0, newID); err != nil {
+		t.Fatalf("SetIdentifier failed: %v", err)
+	}
+	if err := sf.Write(); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+	if !strings.Contains(string(got), newID) {
+		t.Errorf("written file does not contain new identifier")
+	}
+	if !strings.HasSuffix(string(got), "\n") {
+		t.Errorf("trailing newline not preserved")
+	}
+}


### PR DESCRIPTION
## Summary

- Add a new `catalog sync-skills` subcommand and a daily `sync-skills.yml` workflow that keep every skill whose first OCI package targets `ghcr.io/stacklok/dockyard/skills/*` aligned with the corresponding `skills/<name>/spec.yaml` in [stacklok/dockyard](https://github.com/stacklok/dockyard).
- Each run rewrites both the OCI tag (`packages[].identifier`) and the upstream git ref (`packages[].ref`) in lockstep, sourced from dockyard's `spec.yaml` (the actual source of truth).
- New `internal/skilljson` package performs surgical byte-level edits so the rewrites preserve the original key order, indentation, and trailing newline of `skill.json`.
- New Taskfile targets: `catalog:sync-skills`, `catalog:sync-skills:all`, `catalog:sync-skills:all:dry-run`.

## Why

Skills sourced from dockyard were being maintained by hand. Today's catalog already drifts: e.g. `security-review` is pinned at `94ea2a26…` while dockyard's current `spec.yaml` advertises `f2cff985…`, and the cloudflare family is on `0397d7d8…` vs dockyard's `7c449def…`.

A naive Renovate setup would not solve this cleanly:

- `docker` datasource on the OCI tag works, but the git ref is *not* upstream HEAD — it is the specific commit dockyard built from. A `git-refs` datasource pointing at the upstream repo would drift away from what dockyard actually published.
- Dockyard sometimes re-publishes the same OCI tag with a new ref (silent re-pin), which a tag-only manager would miss entirely.

Reading dockyard's `spec.yaml` directly is the only way to keep both fields consistent under all real-world scenarios. The new subcommand mirrors the existing `update-metadata` / `update-tools` pattern (Go subcommand + scheduled workflow + accumulating PR) instead of introducing a parallel Renovate-only flow.

## Implementation

- `internal/skilljson` — load + targeted rewrite of `packages[].identifier` and `packages[].ref` via `bytes.Replace`, with uniqueness assertions to fail closed on ambiguous matches.
- `cmd/catalog/sync_skills.go` — single-file and `--all` modes, `--dry-run`, `--dockyard-ref`, and `--dockyard-base-url` (for tests). Sanity guards skip skills whose catalog git package points at a different repository or subfolder than dockyard advertises (instead of silently rewriting).
- `.github/workflows/sync-skills.yml` — daily 03:00 UTC + `workflow_dispatch`, RELEASE_APP installation token, accumulating `catalog-sync-skills` PR with auto-merge enabled. Runs `catalog validate -v` after the sync as a guardrail.

## Edge cases handled

- New skills present in dockyard but missing from the catalog → not auto-added; curation stays human.
- Skills present in the catalog but missing from dockyard → reported as `MISSING`, not deleted.
- Silent re-pin (same tag, new ref) → handled, since `spec.ref` is the source.
- Repository / subfolder mismatch between catalog and dockyard → `SKIPPED` with a clear reason rather than a silent rewrite.

## Out of scope

- Verifying cosign/sigstore signatures on dockyard images (existing `verify-provenance` flow is server-only — can be added in a follow-up).
- Auto-creating or removing skill directories.

## Test plan

- [x] `task test` — `internal/skilljson` and `cmd/catalog` unit tests pass, including an httptest-backed fake dockyard server.
- [x] `task lint` — clean across the repo.
- [x] `task catalog:validate` — passes after the new code lands.
- [x] `./build/catalog sync-skills --all --dry-run` against real dockyard reports `94 would-update, 31 noop, 0 skipped, 0 missing, 0 error (of 125)`, including the `security-review` and cloudflare drift visible today.
- [ ] After merge: trigger `sync-skills.yml` via `workflow_dispatch` and confirm the resulting PR rewrites both fields in lockstep and merges cleanly.

## Note on releases

`sync-skills` only writes to `registries/`. New catalog releases continue to flow through the existing `update-catalog-data` job in `ci.yml` (rebuilds `pkg/catalog/*/data/**`) followed by `release.yml` (tags `v0.YYYYMMDD.0`). No release-pipeline changes in this PR.