### PR TITLE
ci: skip update-tools on the bot's own synchronize pushes

### DIFF
--- a/.github/workflows/update-tools.yml
+++ b/.github/workflows/update-tools.yml
@@ -94,8 +94,14 @@ jobs:
     name: Detect Changed Servers
     runs-on: ubuntu-latest
     needs: [security-check]
+    # Skip on the bot's own synchronize pushes: commit-all-changes pushes with
+    # an app token, which (unlike GITHUB_TOKEN) re-triggers pull_request events.
+    # Without this guard the workflow re-runs on its own commit and loops.
     if: |
       always() &&
+      !(github.event_name == 'pull_request' &&
+        github.event.action == 'synchronize' &&
+        github.event.sender.login == 'toolhive-release-app[bot]') &&
       (github.event_name == 'workflow_dispatch' ||
        (github.event_name == 'pull_request' && needs.security-check.outputs.should-run == 'true'))
     outputs:


### PR DESCRIPTION
## Summary

- Adds a guard to `update-tools.yml`'s `detect-changes` job that skips the workflow when the triggering event is a `pull_request: synchronize` whose sender is `toolhive-release-app[bot]`.
- Breaks the self-triggering loop seen on #1187 (429 bot commits, each only rewriting `metadata.last_updated`) without changing any other trigger path.

## Context

`commit-all-changes` pushes with a GitHub App installation token (`RELEASE_APP_*`). That token is intentional: unlike the default `GITHUB_TOKEN`, app-token pushes re-trigger downstream workflows so `ci.yml` runs on the bot's final commit — which is what makes the green status check on PR HEAD trustworthy.

The side effect is that `update-tools.yml` *also* listens to `pull_request` events, so it fires on its own pushes and commits a fresh `metadata.last_updated` every iteration (the in-memory `cmp.Equal` check on `[]mcp.Tool` returns "different" even when the on-disk JSON is byte-identical).

## What this PR changes

The guard scope is deliberately narrow:

| Event | Sender | Runs after this PR? |
|---|---|---|
| `pull_request: opened` | anyone | yes (unchanged) |
| `pull_request: synchronize` | human | yes (unchanged) |
| `pull_request: synchronize` | `toolhive-release-app[bot]` | **no** (loop broken) |
| `workflow_dispatch` | anyone | yes (unchanged) |

`ci.yml` is unaffected — it runs on every `pull_request` event including the bot's pushes — so the merge-gate semantics ("green CI on bot's HEAD = safe to merge") are preserved.

## Follow-ups (separate PRs)

- Make `cmd/catalog/update_tools.go` truly idempotent so a legitimate run on stable upstream data doesn't produce a timestamp-only diff (root cause of the noise commits, independent of the workflow loop).
- Optional: validate-before-commit reorder so a generated-but-invalid state never reaches the branch.

## Test plan

- [ ] Confirm a human push to a PR still triggers `update-tools` (action=`synchronize`, sender ≠ bot).
- [ ] Confirm PR open still triggers `update-tools` (action=`opened`).
- [ ] Confirm the bot's auto-commit does **not** re-trigger `update-tools` (action=`synchronize`, sender=bot) — workflow run shows `detect-changes` skipped.
- [ ] Confirm `ci.yml` still runs on the bot's auto-commit and posts a status check on HEAD.
- [ ] `workflow_dispatch` manual run still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)