### PR TITLE
ci: move automated PR workflows to weekly Friday/Monday cadence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,9 @@ on:
     branches:
       - main
   schedule:
-    # Run daily at 00:00 UTC to catch any updates
-    - cron: '0 0 * * *'
+    # Run weekly on Mondays at 5:00 AM UTC, after the weekend merge window, so the
+    # rebuild captures everything merged Fri-Sun before the Monday release fires.
+    - cron: '0 5 * * 1'
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
     paths:
       - 'pkg/catalog/*/data/**'
   schedule:
-    - cron: '0 6 * * *' # daily at 6 AM UTC
+    - cron: '0 6 * * 1' # weekly on Mondays at 6 AM UTC, after Friday's data updates have merged over the weekend
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -2,8 +2,8 @@ name: Sync Dockyard Skills
 
 on:
   schedule:
-    # Run daily at 3:00 AM UTC, an hour after update-metadata.yml.
-    - cron: '0 3 * * *'
+    # Run weekly on Fridays at 3:00 AM UTC, an hour after update-metadata.yml.
+    - cron: '0 3 * * 5'
   workflow_dispatch:
     inputs:
       dockyard-ref:

--- a/.github/workflows/update-metadata.yml
+++ b/.github/workflows/update-metadata.yml
@@ -2,8 +2,8 @@ name: Update Server Metadata
 
 on:
   schedule:
-    # Run daily at 2:00 AM UTC
-    - cron: '0 2 * * *'
+    # Run weekly on Fridays at 2:00 AM UTC
+    - cron: '0 2 * * 5'
   workflow_dispatch:
     inputs:
       count:

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,9 @@
   "extends": [
     "config:recommended"
   ],
+  "schedule": [
+    "before 3am on friday"
+  ],
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION
## Summary

Reduce daily chore PR noise (`update registry metadata`, `sync skills`, `update catalog data files`, Renovate dep bumps) by moving the five automated workflows that produce them to a weekly cadence: ingestion on Friday, publication on Monday, with the weekend as a buffer for human-reviewed PRs.

## Schedule (UTC)

**Friday — ingestion**
- Renovate: opens dep PRs *before 03:00* (`renovate.json`)
- 02:00 — `update-metadata.yml` (stars / pulls)
- 03:00 — `sync-skills.yml` (dockyard skill specs)

**Fri–Sun — merge window**
- Patch-update Renovate PRs auto-merge as usual; non-patch and other PRs get reviewed by maintainers.

**Monday — publication**
- 05:00 — `ci.yml` catalog-data rebuild (was daily) — opens its PR which auto-merges within minutes
- 06:00 — `release.yml` cron (also still fires via the `pkg/catalog/*/data/**` push trigger as a safety net)

## Notes

- Renovate vulnerability alerts bypass the schedule by design — security fixes still come through immediately.
- The `release.yml` push trigger on `pkg/catalog/*/data/**` is preserved, so ad-hoc catalog data changes during the week still produce a release.

## Test plan
- [ ] Verify the next Friday cron fires `update-metadata`, `sync-skills`, and Renovate within the expected window.
- [ ] Verify the next Monday cron rebuilds catalog data and publishes a release.
- [ ] Confirm no extra unscheduled fires from the workflows after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)