### PR TITLE
refactor(provenance): drop registry/converters dependency

### DIFF
--- a/cmd/catalog/update_metadata.go
+++ b/cmd/catalog/update_metadata.go
@@ -10,7 +10,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/spf13/cobra"
 	"github.com/stacklok/toolhive-core/container/verifier"
-	"github.com/stacklok/toolhive-core/registry/converters"
 	toolhiveRegistry "github.com/stacklok/toolhive-core/registry/types"
 
 	"github.com/stacklok/toolhive-catalog/internal/metadata"
@@ -187,17 +186,14 @@ func verifyServerProvenance(
 		return fmt.Errorf("provenance verification is only supported for package servers")
 	}
 
-	imgMeta, err := converters.ServerJSONToImageMetadata(&sf.ServerJSON)
-	if err != nil {
-		return fmt.Errorf("failed to convert for verification: %w", err)
-	}
+	imageRef := sf.ServerJSON.Packages[0].Identifier
 
-	v, err := verifier.New(imgMeta.Provenance, authn.DefaultKeychain)
+	v, err := verifier.New(ext.Provenance, authn.DefaultKeychain)
 	if err != nil {
 		return fmt.Errorf("failed to create verifier: %w", err)
 	}
 
-	if err := v.VerifyServer(imgMeta.Image, imgMeta.Provenance); err != nil {
+	if err := v.VerifyServer(imageRef, ext.Provenance); err != nil {
 		return fmt.Errorf("verification failed: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

- The provenance check in `cmd/catalog/update_metadata.go` was running `server.json` through `converters.ServerJSONToImageMetadata` only to extract two values that the verifier already accepts directly: an image reference and `*registry.Provenance`.
- `sf.GetExtensions()` is already called earlier in the same function and returns the same `*registry.Provenance` value the converter would set. The image ref is just `Packages[0].Identifier`.
- Pass those to `verifier.New` / `VerifyServer` directly so this repo no longer imports `registry/converters`.

This removes the toolhive-catalog blocker on the upstream effort to delete the legacy registry Go types and the `registry/converters` package from `toolhive-core`. The remaining consumer is `stacklok/toolhive` (tracked in toolhive#5278).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./cmd/catalog/...` green
- [ ] CI lint + tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)