### PR TITLE
feat: add refresh env to toolhive-doc-mcp entries

### DIFF
--- a/registries/official/servers/toolhive-doc-mcp/server.json
+++ b/registries/official/servers/toolhive-doc-mcp/server.json
@@ -103,6 +103,11 @@
       "environmentVariables": [
         {
           "default": "false",
+          "description": "Enable/disable automatic daily refresh of the documentation database",
+          "name": "REFRESH_ENABLED"
+        },
+        {
+          "default": "false",
           "description": "Enable/disable OpenTelemetry logging",
           "name": "OTEL_ENABLED"
         },

--- a/registries/toolhive/servers/toolhive-doc-mcp/server.json
+++ b/registries/toolhive/servers/toolhive-doc-mcp/server.json
@@ -103,6 +103,11 @@
       "environmentVariables": [
         {
           "default": "false",
+          "description": "Enable/disable automatic daily refresh of the documentation database",
+          "name": "REFRESH_ENABLED"
+        },
+        {
+          "default": "false",
           "description": "Enable/disable OpenTelemetry logging",
           "name": "OTEL_ENABLED"
         },


### PR DESCRIPTION
The toolhive-doc-mcp server has a REFRESH_ENABLED env var to control the automatic daily refresh. Adding to its registry entry.

Related to https://github.com/StacklokLabs/toolhive-doc-mcp/pull/220

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>