### PR TITLE
chore(server): add provenance to toolhive-doc-mcp entries

### DIFF
--- a/registries/official/servers/toolhive-doc-mcp/server.json
+++ b/registries/official/servers/toolhive-doc-mcp/server.json
@@ -9,6 +9,13 @@
             "stars": 3
           },
           "overview": "## ToolHive Docs MCP Server\n\nThe toolhive-doc-mcp server allows you to search ToolHive documentation for help with using and contributing to the project (local version). The system maintains a pre-built SQLite vector database containing documentation that undergoes parsing, chunking, and embedding using a local bge-small-en-v1.5 model. When queried, it performs semantic search by comparing queries against stored embeddings to return relevant documentation chunks.",
+          "provenance": {
+            "cert_issuer": "https://token.actions.githubusercontent.com",
+            "repository_uri": "https://github.com/StacklokLabs/toolhive-doc-mcp",
+            "runner_environment": "github-hosted",
+            "signer_identity": "/.github/workflows/release.yml",
+            "sigstore_url": "tuf-repo-cdn.sigstore.dev"
+          },
           "status": "Active",
           "tags": [
             "docs",

--- a/registries/toolhive/servers/toolhive-doc-mcp/server.json
+++ b/registries/toolhive/servers/toolhive-doc-mcp/server.json
@@ -9,6 +9,13 @@
             "stars": 3
           },
           "overview": "## ToolHive Docs MCP Server\n\nThe toolhive-doc-mcp server allows you to search ToolHive documentation for help with using and contributing to the project (local version). The system maintains a pre-built SQLite vector database containing documentation that undergoes parsing, chunking, and embedding using a local bge-small-en-v1.5 model. When queried, it performs semantic search by comparing queries against stored embeddings to return relevant documentation chunks.",
+          "provenance": {
+            "cert_issuer": "https://token.actions.githubusercontent.com",
+            "repository_uri": "https://github.com/StacklokLabs/toolhive-doc-mcp",
+            "runner_environment": "github-hosted",
+            "signer_identity": "/.github/workflows/release.yml",
+            "sigstore_url": "tuf-repo-cdn.sigstore.dev"
+          },
           "status": "Active",
           "tags": [
             "docs",


### PR DESCRIPTION
## Summary

Adds the sigstore/cosign provenance block to both the `official/` and `toolhive/` registry entries for `toolhive-doc-mcp`. Images have been signed keylessly from `StacklokLabs/toolhive-doc-mcp`'s `release.yml` for some time, but the expected signing identity wasn't recorded in the catalog, so `catalog update-metadata --verify-provenance` was silently skipping these entries (`if ext.Provenance == nil { ... skipping verification }`). Peers like `osv` already have this block; this brings `toolhive-doc-mcp` in line.

## Test plan

- [x] `task build`
- [x] `./build/catalog update-metadata --verify-provenance --dry-run -v registries/official/servers/toolhive-doc-mcp/server.json` → `Provenance verified successfully`
- [x] `./build/catalog update-metadata --verify-provenance --dry-run -v registries/toolhive/servers/toolhive-doc-mcp/server.json` → `Provenance verified successfully`