### PR TITLE
chore: migrate 10 tag latest catalog entries to versioned identifiers

### DIFF
--- a/pkg/catalog/official/data/registry-upstream.json
+++ b/pkg/catalog/official/data/registry-upstream.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/stacklok/toolhive-core/main/registry/types/data/upstream-registry.schema.json",
   "version": "1.0.0",
   "meta": {
-    "last_updated": "2026-05-25T06:34:21Z"
+    "last_updated": "2026-05-29T13:12:18Z"
   },
   "data": {
     "servers": [
@@ -4157,8 +4157,8 @@
             "io.github.stacklok": {
               "ghcr.io/stacklok/dockyard/npx/browserbase-mcp-server:2.4.3": {
                 "metadata": {
-                  "last_updated": "2026-04-07T03:03:37Z",
-                  "stars": 3230
+                  "last_updated": "2026-05-22T03:21:50Z",
+                  "stars": 3348
                 },
                 "overview": "## Browserbase MCP Server\n\nThe browserbase MCP server is a Model Context Protocol (MCP) server that gives AI assistants full, programmable control of real web browsers running in the cloud. Powered by Browserbase, it enables AI-driven workflows to load pages, execute JavaScript, interact with dynamic UIs, and capture screenshots or HTML — making it possible to automate and reason over modern, JavaScript-heavy websites that traditional HTTP-based tools can't handle. This server is ideal for web automation, end-to-end testing, live research, and data extraction workflows that require a real browser environment.",
                 "permissions": {
@@ -7747,8 +7747,8 @@
                   "license": "Apache-2.0"
                 },
                 "metadata": {
-                  "last_updated": "2026-04-08T03:03:51Z",
-                  "stars": 326
+                  "last_updated": "2026-05-29T03:21:49Z",
+                  "stars": 484
                 },
                 "overview": "## Cloudflare API (Remote)\n\nThe Cloudflare API remote MCP server is Cloudflare's official managed Model Context Protocol server providing token-efficient access to the entire Cloudflare API. Powered by Code Mode, it exposes over 2,500 API endpoints across Workers, KV, R2, D1, Pages, DNS, Firewall, Load Balancers, Stream, Images, AI Gateway, Vectorize, Access, Zero Trust, and more through just two tools in approximately 1,000 tokens. It supports OAuth and API token authentication via Streamable HTTP transport.",
                 "status": "Active",
@@ -7975,7 +7975,7 @@
         "packages": [
           {
             "registryType": "oci",
-            "identifier": "quay.io/crowdstrike/falcon-mcp:latest",
+            "identifier": "quay.io/crowdstrike/falcon-mcp:0.10.0",
             "transport": {
               "type": "streamable-http",
               "url": "http://localhost:8000"
@@ -8012,7 +8012,7 @@
         "_meta": {
           "io.modelcontextprotocol.registry/publisher-provided": {
             "io.github.stacklok": {
-              "quay.io/crowdstrike/falcon-mcp:latest": {
+              "quay.io/crowdstrike/falcon-mcp:0.10.0": {
                 "args": [
                   "--transport",
                   "streamable-http",
@@ -8194,8 +8194,8 @@
                   "license": "Proprietary"
                 },
                 "metadata": {
-                  "last_updated": "2026-04-08T03:03:50Z",
-                  "stars": 30
+                  "last_updated": "2026-05-22T03:20:53Z",
+                  "stars": 38
                 },
                 "overview": "## Datadog (Remote)\n\nThe Datadog remote MCP server is Datadog's official managed Model Context Protocol server that connects AI agents to Datadog's observability platform. It provides structured access to logs, metrics, traces, dashboards, monitors, incidents, hosts, services, events, and notebooks through toolsets that can be selectively enabled. The server uses Streamable HTTP transport with API key and application key authentication, and supports regional endpoints for different Datadog sites.",
                 "status": "Active",
@@ -13372,8 +13372,8 @@
                   "license": "Proprietary"
                 },
                 "metadata": {
-                  "last_updated": "2026-04-08T03:03:51Z",
-                  "stars": 3507
+                  "last_updated": "2026-05-29T03:21:49Z",
+                  "stars": 4134
                 },
                 "overview": "## Google Maps Grounding Lite (Remote)\n\nThe Google Maps Grounding Lite remote MCP server is Google's official managed Model Context Protocol server providing access to Google Maps Platform geospatial data. It offers three tools for place search with summaries and Google Maps links, weather lookups with current conditions and forecasts, and route computation with distance and duration data. Authentication requires a Google Maps API key passed via the X-Goog-Api-Key header. The server is currently experimental and available at no charge during the pre-GA preview period.",
                 "status": "Active",
@@ -13711,8 +13711,8 @@
             "io.github.stacklok": {
               "ghcr.io/stacklok/dockyard/npx/graphlit-mcp-server:1.0.20260112001": {
                 "metadata": {
-                  "last_updated": "2026-04-08T03:03:51Z",
-                  "stars": 373
+                  "last_updated": "2026-05-29T03:21:49Z",
+                  "stars": 376
                 },
                 "overview": "## Graphlit MCP Server\n\nThe graphlit MCP server is a Model Context Protocol (MCP) server that enables AI assistants and agents to interact directly with Graphlit, a platform for ingesting, processing, organizing, and querying unstructured content using knowledge graphs and embeddings. It allows AI-driven workflows to load documents, media, and web content into Graphlit and then reason over that content using structured queries — without building custom ingestion or retrieval pipelines. This server is especially useful for knowledge management, content intelligence, retrieval-augmented generation (RAG), and research workflows that span large, heterogeneous content collections.",
                 "permissions": {
@@ -28494,8 +28494,8 @@
                   "--enable-write-tools"
                 ],
                 "metadata": {
-                  "last_updated": "2026-04-08T03:03:51Z",
-                  "stars": 58
+                  "last_updated": "2026-05-22T03:22:20Z",
+                  "stars": 69
                 },
                 "overview": "## PagerDuty MCP Server\n\nThe pagerduty MCP server is a Model Context Protocol (MCP) server that enables AI assistants and agents to interact directly with PagerDuty, the incident management and on-call platform. It allows AI-driven workflows to access incidents, services, schedules, and on-call status information, bringing real-time incident response context into AI-assisted operations. This server is especially useful for incident triage, on-call support, operational awareness, and post-incident analysis where PagerDuty serves as the primary system of record.",
                 "permissions": {
@@ -34258,7 +34258,7 @@
         "description": "Integrates Perplexity AI's Sonar API for live web searches, in-depth research, and reasoning tasks.",
         "title": "Perplexity",
         "repository": {
-          "url": "https://github.com/ppl-ai/modelcontextprotocol",
+          "url": "https://github.com/perplexityai/modelcontextprotocol",
           "source": "github"
         },
         "version": "1.0.0",
@@ -34274,7 +34274,7 @@
         "packages": [
           {
             "registryType": "oci",
-            "identifier": "docker.io/mcp/perplexity-ask:latest",
+            "identifier": "ghcr.io/stacklok/dockyard/npx/perplexity-ask:0.9.0",
             "transport": {
               "type": "stdio"
             },
@@ -34291,7 +34291,7 @@
         "_meta": {
           "io.modelcontextprotocol.registry/publisher-provided": {
             "io.github.stacklok": {
-              "docker.io/mcp/perplexity-ask:latest": {
+              "ghcr.io/stacklok/dockyard/npx/perplexity-ask:0.9.0": {
                 "metadata": {
                   "last_updated": "2026-04-19T03:04:12Z",
                   "stars": 2092
@@ -37188,7 +37188,7 @@
         "packages": [
           {
             "registryType": "oci",
-            "identifier": "docker.io/mcp/redis:latest",
+            "identifier": "ghcr.io/stacklok/dockyard/uvx/redis-mcp-server:0.5.0",
             "transport": {
               "type": "stdio"
             },
@@ -37253,10 +37253,10 @@
         "_meta": {
           "io.modelcontextprotocol.registry/publisher-provided": {
             "io.github.stacklok": {
-              "docker.io/mcp/redis:latest": {
+              "ghcr.io/stacklok/dockyard/uvx/redis-mcp-server:0.5.0": {
                 "metadata": {
-                  "last_updated": "2026-04-07T03:03:37Z",
-                  "stars": 474
+                  "last_updated": "2026-05-22T03:21:55Z",
+                  "stars": 511
                 },
                 "overview": "## Redis MCP Server\n\nThe redis MCP server enables LLMs to interact with Redis key-value databases through a set of standardized tools. The server connects to Redis databases and provides MCP tools for basic operations (CRUD operations, database management), data structures (full support for strings, hashes, lists, sets, sorted sets, JSON), vector search functionality, and streams/Pub/Sub features for messaging and time-series data handling.",
                 "permissions": {
@@ -37590,6 +37590,61 @@
                       "type": "object"
                     },
                     "name": "hset"
+                  },
+                  {
+                    "annotations": {},
+                    "description": "\nPerform a hybrid search combining a Redis filter expression with KNN vector similarity.\n\nHybrid search pre-filters documents by metadata before ranking by vector similarity —\nthe standard pattern for production RAG and semantic search pipelines.\n\nFilter expression examples:\n    \"*\"                              → no filter, pure vector search (same as vector_search_hash)\n    \"@category:{news}\"              → tag filter\n    \"@year:[2020 2024]\"             → numeric range\n    \"@lang:{en} @year:[2022 +inf]\"  → combined tag + range\n    \"@title:redis\"                  → full-text match on a text field\n\nFull filter syntax: https://redis.io/docs/latest/develop/interact/search-and-query/query/\n\nArgs:\n    query_vector:       List of floats to use as the query vector.\n    filter_expression:  Redis filter expression to restrict candidates before KNN ranking.\n                        Defaults to '*' (no filter).\n    index_name:         Name of the Redis index (default: 'vector_index').\n    vector_field:       Name of the indexed vector field (default: 'vector').\n    k:                  Number of nearest neighbors to return.\n    return_fields:      Additional fields to include in results (optional).\n\nReturns:\n    A list of matched documents with their similarity score, or an error message.\n",
+                    "inputSchema": {
+                      "properties": {
+                        "filter_expression": {
+                          "default": "*",
+                          "title": "Filter Expression",
+                          "type": "string"
+                        },
+                        "index_name": {
+                          "default": "vector_index",
+                          "title": "Index Name",
+                          "type": "string"
+                        },
+                        "k": {
+                          "default": 5,
+                          "title": "K",
+                          "type": "integer"
+                        },
+                        "query_vector": {
+                          "items": {
+                            "type": "number"
+                          },
+                          "title": "Query Vector",
+                          "type": "array"
+                        },
+                        "return_fields": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null,
+                          "title": "Return Fields"
+                        },
+                        "vector_field": {
+                          "default": "vector",
+                          "title": "Vector Field",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "query_vector"
+                      ],
+                      "type": "object"
+                    },
+                    "name": "hybrid_search"
                   },
                   {
                     "annotations": {},
@@ -38271,6 +38326,36 @@
                   },
                   {
                     "annotations": {},
+                    "description": "Acknowledge entries that were processed by a consumer group.\n\nArgs:\n    key (str): The stream key.\n    group_name (str): The consumer group name.\n    entry_ids (List[str]): Entry IDs to acknowledge.\n\nReturns:\n    str: Confirmation message or an error message.\n",
+                    "inputSchema": {
+                      "properties": {
+                        "entry_ids": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "title": "Entry Ids",
+                          "type": "array"
+                        },
+                        "group_name": {
+                          "title": "Group Name",
+                          "type": "string"
+                        },
+                        "key": {
+                          "title": "Key",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "group_name",
+                        "entry_ids"
+                      ],
+                      "type": "object"
+                    },
+                    "name": "xack"
+                  },
+                  {
+                    "annotations": {},
                     "description": "Add an entry to a Redis stream with an optional expiration time.\n\nArgs:\n    key (str): The stream key.\n    fields (dict): The fields and values for the stream entry.\n    expiration (int, optional): Expiration time in seconds.\n\nReturns:\n    str: The ID of the added entry or an error message.\n",
                     "inputSchema": {
                       "properties": {
@@ -38328,6 +38413,60 @@
                   },
                   {
                     "annotations": {},
+                    "description": "Create a consumer group for a Redis stream.\n\nArgs:\n    key (str): The stream key.\n    group_name (str): The consumer group name.\n    start_id (str, optional): Stream ID from which the group starts consuming.\n    mkstream (bool, optional): Create the stream if it does not exist.\n\nReturns:\n    str: Confirmation message or an error message.\n",
+                    "inputSchema": {
+                      "properties": {
+                        "group_name": {
+                          "title": "Group Name",
+                          "type": "string"
+                        },
+                        "key": {
+                          "title": "Key",
+                          "type": "string"
+                        },
+                        "mkstream": {
+                          "default": true,
+                          "title": "Mkstream",
+                          "type": "boolean"
+                        },
+                        "start_id": {
+                          "default": "$",
+                          "title": "Start Id",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "group_name"
+                      ],
+                      "type": "object"
+                    },
+                    "name": "xgroup_create"
+                  },
+                  {
+                    "annotations": {},
+                    "description": "Destroy a consumer group for a Redis stream.\n\nArgs:\n    key (str): The stream key.\n    group_name (str): The consumer group name.\n\nReturns:\n    str: Confirmation message or an error message.\n",
+                    "inputSchema": {
+                      "properties": {
+                        "group_name": {
+                          "title": "Group Name",
+                          "type": "string"
+                        },
+                        "key": {
+                          "title": "Key",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "group_name"
+                      ],
+                      "type": "object"
+                    },
+                    "name": "xgroup_destroy"
+                  },
+                  {
+                    "annotations": {},
                     "description": "Read entries from a Redis stream.\n\nArgs:\n    key (str): The stream key.\n    count (int, optional): Number of entries to retrieve.\n\nReturns:\n    str: The retrieved stream entries or an error message.\n",
                     "inputSchema": {
                       "properties": {
@@ -38347,6 +38486,55 @@
                       "type": "object"
                     },
                     "name": "xrange"
+                  },
+                  {
+                    "annotations": {},
+                    "description": "Read entries from a Redis stream using a consumer group.\n\nArgs:\n    key (str): The stream key.\n    group_name (str): The consumer group name.\n    consumer_name (str): The consumer name.\n    count (int, optional): Maximum number of entries to retrieve.\n    block_ms (int, optional): Maximum time to block waiting for entries.\n        Use None for a non-blocking read. 0 is rejected because Redis treats\n        BLOCK 0 as an indefinite wait.\n    stream_id (str, optional): Stream ID to read from. Use \"\u003e\" for new messages.\n\nReturns:\n    str: The retrieved stream entries or an error message.\n",
+                    "inputSchema": {
+                      "properties": {
+                        "block_ms": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null,
+                          "title": "Block Ms"
+                        },
+                        "consumer_name": {
+                          "title": "Consumer Name",
+                          "type": "string"
+                        },
+                        "count": {
+                          "default": 1,
+                          "title": "Count",
+                          "type": "integer"
+                        },
+                        "group_name": {
+                          "title": "Group Name",
+                          "type": "string"
+                        },
+                        "key": {
+                          "title": "Key",
+                          "type": "string"
+                        },
+                        "stream_id": {
+                          "default": "\u003e",
+                          "title": "Stream Id",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "group_name",
+                        "consumer_name"
+                      ],
+                      "type": "object"
+                    },
+                    "name": "xreadgroup"
                   },
                   {
                     "annotations": {},
@@ -38458,6 +38646,7 @@
                   "hget",
                   "hgetall",
                   "hset",
+                  "hybrid_search",
                   "info",
                   "json_del",
                   "json_get",
@@ -38483,9 +38672,13 @@
                   "type",
                   "unsubscribe",
                   "vector_search_hash",
+                  "xack",
                   "xadd",
                   "xdel",
+                  "xgroup_create",
+                  "xgroup_destroy",
                   "xrange",
+                  "xreadgroup",
                   "zadd",
                   "zrange",
                   "zrem"
@@ -38595,7 +38788,7 @@
         "packages": [
           {
             "registryType": "oci",
-            "identifier": "semgrep/semgrep:latest",
+            "identifier": "docker.io/semgrep/semgrep:1.164.0",
             "transport": {
               "type": "stdio"
             },
@@ -38611,7 +38804,7 @@
         "_meta": {
           "io.modelcontextprotocol.registry/publisher-provided": {
             "io.github.stacklok": {
-              "semgrep/semgrep:latest": {
+              "docker.io/semgrep/semgrep:1.164.0": {
                 "args": [
                   "semgrep",
                   "mcp"
@@ -40635,7 +40828,7 @@
         "packages": [
           {
             "registryType": "oci",
-            "identifier": "docker.io/mcp/stripe:latest",
+            "identifier": "ghcr.io/stacklok/dockyard/npx/stripe-mcp:0.3.3",
             "transport": {
               "type": "stdio"
             },
@@ -40651,7 +40844,7 @@
         "_meta": {
           "io.modelcontextprotocol.registry/publisher-provided": {
             "io.github.stacklok": {
-              "docker.io/mcp/stripe:latest": {
+              "ghcr.io/stacklok/dockyard/npx/stripe-mcp:0.3.3": {
                 "args": [
                   "--tools=all"
                 ],

--- a/pkg/catalog/toolhive/data/registry-upstream.json
+++ b/pkg/catalog/toolhive/data/registry-upstream.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/stacklok/toolhive-core/main/registry/types/data/upstream-registry.schema.json",
   "version": "1.0.0",
   "meta": {
-    "last_updated": "2026-05-25T06:34:21Z"
+    "last_updated": "2026-05-29T13:12:18Z"
   },
   "data": {
     "servers": [
@@ -8487,8 +8487,8 @@
                   "license": "Apache-2.0"
                 },
                 "metadata": {
-                  "last_updated": "2026-04-08T03:03:51Z",
-                  "stars": 326
+                  "last_updated": "2026-05-29T03:21:48Z",
+                  "stars": 484
                 },
                 "overview": "## Cloudflare API (Remote)\n\nThe Cloudflare API remote MCP server is Cloudflare's official managed Model Context Protocol server providing token-efficient access to the entire Cloudflare API. Powered by Code Mode, it exposes over 2,500 API endpoints across Workers, KV, R2, D1, Pages, DNS, Firewall, Load Balancers, Stream, Images, AI Gateway, Vectorize, Access, Zero Trust, and more through just two tools in approximately 1,000 tokens. It supports OAuth and API token authentication via Streamable HTTP transport.",
                 "status": "Active",
@@ -8715,7 +8715,7 @@
         "packages": [
           {
             "registryType": "oci",
-            "identifier": "quay.io/crowdstrike/falcon-mcp:latest",
+            "identifier": "quay.io/crowdstrike/falcon-mcp:0.10.0",
             "transport": {
               "type": "streamable-http",
               "url": "http://localhost:8000"
@@ -8752,7 +8752,7 @@
         "_meta": {
           "io.modelcontextprotocol.registry/publisher-provided": {
             "io.github.stacklok": {
-              "quay.io/crowdstrike/falcon-mcp:latest": {
+              "quay.io/crowdstrike/falcon-mcp:0.10.0": {
                 "args": [
                   "--transport",
                   "streamable-http",
@@ -8934,8 +8934,8 @@
                   "license": "Proprietary"
                 },
                 "metadata": {
-                  "last_updated": "2026-04-08T03:03:50Z",
-                  "stars": 30
+                  "last_updated": "2026-05-22T03:20:52Z",
+                  "stars": 38
                 },
                 "overview": "## Datadog (Remote)\n\nThe Datadog remote MCP server is Datadog's official managed Model Context Protocol server that connects AI agents to Datadog's observability platform. It provides structured access to logs, metrics, traces, dashboards, monitors, incidents, hosts, services, events, and notebooks through toolsets that can be selectively enabled. The server uses Streamable HTTP transport with API key and application key authentication, and supports regional endpoints for different Datadog sites.",
                 "status": "Active",
@@ -10669,7 +10669,7 @@
         "packages": [
           {
             "registryType": "oci",
-            "identifier": "docker.io/mcp/everything:latest",
+            "identifier": "ghcr.io/stacklok/dockyard/npx/server-everything:2026.1.26",
             "transport": {
               "type": "stdio"
             }
@@ -10678,7 +10678,7 @@
         "_meta": {
           "io.modelcontextprotocol.registry/publisher-provided": {
             "io.github.stacklok": {
-              "docker.io/mcp/everything:latest": {
+              "ghcr.io/stacklok/dockyard/npx/server-everything:2026.1.26": {
                 "metadata": {
                   "last_updated": "2026-05-08T03:06:20Z",
                   "stars": 85231
@@ -12466,7 +12466,7 @@
         "packages": [
           {
             "registryType": "oci",
-            "identifier": "docker.io/mcp/git:latest",
+            "identifier": "ghcr.io/stacklok/dockyard/uvx/mcp-server-git:2026.1.14",
             "transport": {
               "type": "stdio"
             }
@@ -12475,7 +12475,7 @@
         "_meta": {
           "io.modelcontextprotocol.registry/publisher-provided": {
             "io.github.stacklok": {
-              "docker.io/mcp/git:latest": {
+              "ghcr.io/stacklok/dockyard/uvx/mcp-server-git:2026.1.14": {
                 "metadata": {
                   "last_updated": "2026-04-18T03:03:09Z",
                   "stars": 84011
@@ -15198,8 +15198,8 @@
                   "license": "Proprietary"
                 },
                 "metadata": {
-                  "last_updated": "2026-04-08T03:03:51Z",
-                  "stars": 3507
+                  "last_updated": "2026-05-29T03:21:49Z",
+                  "stars": 4134
                 },
                 "overview": "## Google Maps Grounding Lite (Remote)\n\nThe Google Maps Grounding Lite remote MCP server is Google's official managed Model Context Protocol server providing access to Google Maps Platform geospatial data. It offers three tools for place search with summaries and Google Maps links, weather lookups with current conditions and forecasts, and route computation with distance and duration data. Authentication requires a Google Maps API key passed via the X-Goog-Api-Key header. The server is currently experimental and available at no charge during the pre-GA preview period.",
                 "status": "Active",
@@ -25949,7 +25949,7 @@
         "packages": [
           {
             "registryType": "oci",
-            "identifier": "docker.io/mcp/memory:latest",
+            "identifier": "ghcr.io/stacklok/dockyard/npx/server-memory:2026.1.26",
             "transport": {
               "type": "stdio"
             },
@@ -25964,7 +25964,7 @@
         "_meta": {
           "io.modelcontextprotocol.registry/publisher-provided": {
             "io.github.stacklok": {
-              "docker.io/mcp/memory:latest": {
+              "ghcr.io/stacklok/dockyard/npx/server-memory:2026.1.26": {
                 "metadata": {
                   "last_updated": "2026-05-08T03:06:10Z",
                   "stars": 85231
@@ -39269,7 +39269,7 @@
         "description": "Integrates Perplexity AI's Sonar API for live web searches, in-depth research, and reasoning tasks.",
         "title": "Perplexity",
         "repository": {
-          "url": "https://github.com/ppl-ai/modelcontextprotocol",
+          "url": "https://github.com/perplexityai/modelcontextprotocol",
           "source": "github"
         },
         "version": "1.0.0",
@@ -39285,7 +39285,7 @@
         "packages": [
           {
             "registryType": "oci",
-            "identifier": "docker.io/mcp/perplexity-ask:latest",
+            "identifier": "ghcr.io/stacklok/dockyard/npx/perplexity-ask:0.9.0",
             "transport": {
               "type": "stdio"
             },
@@ -39302,7 +39302,7 @@
         "_meta": {
           "io.modelcontextprotocol.registry/publisher-provided": {
             "io.github.stacklok": {
-              "docker.io/mcp/perplexity-ask:latest": {
+              "ghcr.io/stacklok/dockyard/npx/perplexity-ask:0.9.0": {
                 "metadata": {
                   "last_updated": "2026-04-19T03:04:11Z",
                   "stars": 2092
@@ -42604,7 +42604,7 @@
         "packages": [
           {
             "registryType": "oci",
-            "identifier": "docker.io/mcp/redis:latest",
+            "identifier": "ghcr.io/stacklok/dockyard/uvx/redis-mcp-server:0.5.0",
             "transport": {
               "type": "stdio"
             },
@@ -42669,7 +42669,7 @@
         "_meta": {
           "io.modelcontextprotocol.registry/publisher-provided": {
             "io.github.stacklok": {
-              "docker.io/mcp/redis:latest": {
+              "ghcr.io/stacklok/dockyard/uvx/redis-mcp-server:0.5.0": {
                 "metadata": {
                   "last_updated": "2026-05-07T03:06:47Z",
                   "stars": 504
@@ -44204,7 +44204,7 @@
         "packages": [
           {
             "registryType": "oci",
-            "identifier": "semgrep/semgrep:latest",
+            "identifier": "docker.io/semgrep/semgrep:1.164.0",
             "transport": {
               "type": "stdio"
             },
@@ -44220,7 +44220,7 @@
         "_meta": {
           "io.modelcontextprotocol.registry/publisher-provided": {
             "io.github.stacklok": {
-              "semgrep/semgrep:latest": {
+              "docker.io/semgrep/semgrep:1.164.0": {
                 "args": [
                   "semgrep",
                   "mcp"
@@ -45985,7 +45985,7 @@
         "packages": [
           {
             "registryType": "oci",
-            "identifier": "docker.io/mcp/sequentialthinking:latest",
+            "identifier": "ghcr.io/stacklok/dockyard/npx/server-sequential-thinking:2025.12.18",
             "transport": {
               "type": "stdio"
             }
@@ -45994,7 +45994,7 @@
         "_meta": {
           "io.modelcontextprotocol.registry/publisher-provided": {
             "io.github.stacklok": {
-              "docker.io/mcp/sequentialthinking:latest": {
+              "ghcr.io/stacklok/dockyard/npx/server-sequential-thinking:2025.12.18": {
                 "metadata": {
                   "last_updated": "2026-04-19T03:04:11Z",
                   "stars": 84056
@@ -46540,7 +46540,7 @@
         "packages": [
           {
             "registryType": "oci",
-            "identifier": "docker.io/mcp/stripe:latest",
+            "identifier": "ghcr.io/stacklok/dockyard/npx/stripe-mcp:0.3.3",
             "transport": {
               "type": "stdio"
             },
@@ -46556,7 +46556,7 @@
         "_meta": {
           "io.modelcontextprotocol.registry/publisher-provided": {
             "io.github.stacklok": {
-              "docker.io/mcp/stripe:latest": {
+              "ghcr.io/stacklok/dockyard/npx/stripe-mcp:0.3.3": {
                 "args": [
                   "--tools=all"
                 ],
@@ -50604,7 +50604,7 @@
         "packages": [
           {
             "registryType": "oci",
-            "identifier": "docker.io/mcp/time:latest",
+            "identifier": "ghcr.io/stacklok/dockyard/uvx/mcp-server-time:2026.1.26",
             "transport": {
               "type": "stdio"
             }
@@ -50613,7 +50613,7 @@
         "_meta": {
           "io.modelcontextprotocol.registry/publisher-provided": {
             "io.github.stacklok": {
-              "docker.io/mcp/time:latest": {
+              "ghcr.io/stacklok/dockyard/uvx/mcp-server-time:2026.1.26": {
                 "metadata": {
                   "last_updated": "2026-04-18T03:03:09Z",
                   "stars": 84011
@@ -52566,12 +52566,12 @@
         "packages": [
           {
             "registryType": "oci",
-            "identifier": "ghcr.io/stacklok/dockyard/skills/forge-app-builder:0.1.1"
+            "identifier": "ghcr.io/stacklok/dockyard/skills/forge-app-builder:0.1.2"
           },
           {
             "registryType": "git",
             "url": "https://github.com/atlassian/forge-skills",
-            "ref": "2ab11f061033333640cc3cb59bfe817944e4f205",
+            "ref": "bfe376cee02cac671b3b7d91e2ed34ac0220da5c",
             "subfolder": "skills/forge-app-builder"
           }
         ]
@@ -52597,12 +52597,12 @@
         "packages": [
           {
             "registryType": "oci",
-            "identifier": "ghcr.io/stacklok/dockyard/skills/forge-app-review:0.1.1"
+            "identifier": "ghcr.io/stacklok/dockyard/skills/forge-app-review:0.1.2"
           },
           {
             "registryType": "git",
             "url": "https://github.com/atlassian/forge-skills",
-            "ref": "2ab11f061033333640cc3cb59bfe817944e4f205",
+            "ref": "bfe376cee02cac671b3b7d91e2ed34ac0220da5c",
             "subfolder": "skills/forge-app-review"
           }
         ]
@@ -52628,12 +52628,12 @@
         "packages": [
           {
             "registryType": "oci",
-            "identifier": "ghcr.io/stacklok/dockyard/skills/forge-debugger:0.1.1"
+            "identifier": "ghcr.io/stacklok/dockyard/skills/forge-debugger:0.1.2"
           },
           {
             "registryType": "git",
             "url": "https://github.com/atlassian/forge-skills",
-            "ref": "2ab11f061033333640cc3cb59bfe817944e4f205",
+            "ref": "bfe376cee02cac671b3b7d91e2ed34ac0220da5c",
             "subfolder": "skills/forge-debugger"
           }
         ]

--- a/registries/official/servers/crowdstrike-falcon/server.json
+++ b/registries/official/servers/crowdstrike-falcon/server.json
@@ -3,7 +3,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.stacklok": {
-        "quay.io/crowdstrike/falcon-mcp:latest": {
+        "quay.io/crowdstrike/falcon-mcp:0.10.0": {
           "args": [
             "--transport",
             "streamable-http",
@@ -115,7 +115,7 @@
           "name": "FALCON_MCP_DEBUG"
         }
       ],
-      "identifier": "quay.io/crowdstrike/falcon-mcp:latest",
+      "identifier": "quay.io/crowdstrike/falcon-mcp:0.10.0",
       "registryType": "oci",
       "transport": {
         "type": "streamable-http",

--- a/registries/official/servers/perplexity-ask/server.json
+++ b/registries/official/servers/perplexity-ask/server.json
@@ -3,7 +3,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.stacklok": {
-        "docker.io/mcp/perplexity-ask:latest": {
+        "ghcr.io/stacklok/dockyard/npx/perplexity-ask:0.9.0": {
           "metadata": {
             "last_updated": "2026-04-19T03:04:12Z",
             "stars": 2092
@@ -162,7 +162,7 @@
           "name": "PERPLEXITY_API_KEY"
         }
       ],
-      "identifier": "docker.io/mcp/perplexity-ask:latest",
+      "identifier": "ghcr.io/stacklok/dockyard/npx/perplexity-ask:0.9.0",
       "registryType": "oci",
       "transport": {
         "type": "stdio"
@@ -171,7 +171,7 @@
   ],
   "repository": {
     "source": "github",
-    "url": "https://github.com/ppl-ai/modelcontextprotocol"
+    "url": "https://github.com/perplexityai/modelcontextprotocol"
   },
   "title": "Perplexity",
   "version": "1.0.0"

--- a/registries/official/servers/perplexity-ask/server.json
+++ b/registries/official/servers/perplexity-ask/server.json
@@ -5,7 +5,7 @@
       "io.github.stacklok": {
         "ghcr.io/stacklok/dockyard/npx/perplexity-ask:0.9.0": {
           "metadata": {
-            "last_updated": "2026-04-19T03:04:12Z",
+            "last_updated": "2026-05-29T13:15:39Z",
             "stars": 2092
           },
           "overview": "## Perplexity Ask MCP Server\n\nThe perplexity-ask MCP server integrates Perplexity AI's Sonar API for live web searches, in-depth research, and reasoning tasks. The server provides three specialized tools: perplexity_ask for quick web search using the Sonar API, perplexity_research for comprehensive research with detailed citations, and perplexity_reason for advanced reasoning for complex problem-solving.",
@@ -30,20 +30,31 @@
           "tier": "Official",
           "tool_definitions": [
             {
-              "annotations": {},
-              "description": "Engages in a conversation using the Sonar API. Accepts an array of messages (each with a role and content) and returns a ask completion response from the Perplexity model.",
+              "annotations": {
+                "destructiveHint": false,
+                "idempotentHint": false,
+                "openWorldHint": true,
+                "readOnlyHint": true
+              },
+              "description": "Answer a question using web-grounded AI (Sonar Pro model). Best for: quick factual questions, summaries, explanations, and general Q\u0026A. Returns a text response with numbered citations. Fastest and cheapest option. Supports filtering by recency (hour/day/week/month/year), domain restrictions, and search context size. For in-depth multi-source research, use perplexity_research instead. For step-by-step reasoning and analysis, use perplexity_reason instead.",
               "inputSchema": {
                 "properties": {
                   "messages": {
                     "description": "Array of conversation messages",
                     "items": {
+                      "additionalProperties": false,
                       "properties": {
                         "content": {
                           "description": "The content of the message",
                           "type": "string"
                         },
                         "role": {
-                          "description": "Role of the message (e.g., system, user, assistant)",
+                          "description": "Role of the message sender",
+                          "enum": [
+                            "system",
+                            "user",
+                            "assistant"
+                          ],
                           "type": "string"
                         }
                       },
@@ -54,6 +65,33 @@
                       "type": "object"
                     },
                     "type": "array"
+                  },
+                  "search_context_size": {
+                    "description": "Controls how much web context is retrieved. 'low' (default) is fastest, 'high' provides more comprehensive results.",
+                    "enum": [
+                      "low",
+                      "medium",
+                      "high"
+                    ],
+                    "type": "string"
+                  },
+                  "search_domain_filter": {
+                    "description": "Restrict search results to specific domains (e.g., ['wikipedia.org', 'arxiv.org']). Use '-' prefix for exclusion (e.g., ['-reddit.com']).",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "search_recency_filter": {
+                    "description": "Filter search results by recency. Use 'hour' for very recent news, 'day' for today's updates, 'week' for this week, etc.",
+                    "enum": [
+                      "hour",
+                      "day",
+                      "week",
+                      "month",
+                      "year"
+                    ],
+                    "type": "string"
                   }
                 },
                 "required": [
@@ -64,20 +102,31 @@
               "name": "perplexity_ask"
             },
             {
-              "annotations": {},
-              "description": "Performs reasoning tasks using the Perplexity API. Accepts an array of messages (each with a role and content) and returns a well-reasoned response using the sonar-reasoning-pro model.",
+              "annotations": {
+                "destructiveHint": false,
+                "idempotentHint": false,
+                "openWorldHint": true,
+                "readOnlyHint": true
+              },
+              "description": "Analyze a question using step-by-step reasoning with web grounding (Sonar Reasoning Pro model). Best for: math, logic, comparisons, complex arguments, and tasks requiring chain-of-thought. Returns a reasoned response with numbered citations. Supports filtering by recency (hour/day/week/month/year), domain restrictions, and search context size. For quick factual questions, use perplexity_ask instead. For comprehensive multi-source research, use perplexity_research instead.",
               "inputSchema": {
                 "properties": {
                   "messages": {
                     "description": "Array of conversation messages",
                     "items": {
+                      "additionalProperties": false,
                       "properties": {
                         "content": {
                           "description": "The content of the message",
                           "type": "string"
                         },
                         "role": {
-                          "description": "Role of the message (e.g., system, user, assistant)",
+                          "description": "Role of the message sender",
+                          "enum": [
+                            "system",
+                            "user",
+                            "assistant"
+                          ],
                           "type": "string"
                         }
                       },
@@ -88,6 +137,37 @@
                       "type": "object"
                     },
                     "type": "array"
+                  },
+                  "search_context_size": {
+                    "description": "Controls how much web context is retrieved. 'low' (default) is fastest, 'high' provides more comprehensive results.",
+                    "enum": [
+                      "low",
+                      "medium",
+                      "high"
+                    ],
+                    "type": "string"
+                  },
+                  "search_domain_filter": {
+                    "description": "Restrict search results to specific domains (e.g., ['wikipedia.org', 'arxiv.org']). Use '-' prefix for exclusion (e.g., ['-reddit.com']).",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "search_recency_filter": {
+                    "description": "Filter search results by recency. Use 'hour' for very recent news, 'day' for today's updates, 'week' for this week, etc.",
+                    "enum": [
+                      "hour",
+                      "day",
+                      "week",
+                      "month",
+                      "year"
+                    ],
+                    "type": "string"
+                  },
+                  "strip_thinking": {
+                    "description": "If true, removes \u003cthink\u003e...\u003c/think\u003e tags and their content from the response to save context tokens. Default is false.",
+                    "type": "boolean"
                   }
                 },
                 "required": [
@@ -98,20 +178,31 @@
               "name": "perplexity_reason"
             },
             {
-              "annotations": {},
-              "description": "Performs deep research using the Perplexity API. Accepts an array of messages (each with a role and content) and returns a comprehensive research response with citations.",
+              "annotations": {
+                "destructiveHint": false,
+                "idempotentHint": false,
+                "openWorldHint": true,
+                "readOnlyHint": true
+              },
+              "description": "Conduct deep, multi-source research on a topic (Sonar Deep Research model). Best for: literature reviews, comprehensive overviews, investigative queries needing many sources. Returns a detailed response with numbered citations. Significantly slower than other tools (30+ seconds). For quick factual questions, use perplexity_ask instead. For logical analysis and reasoning, use perplexity_reason instead.",
               "inputSchema": {
                 "properties": {
                   "messages": {
                     "description": "Array of conversation messages",
                     "items": {
+                      "additionalProperties": false,
                       "properties": {
                         "content": {
                           "description": "The content of the message",
                           "type": "string"
                         },
                         "role": {
-                          "description": "Role of the message (e.g., system, user, assistant)",
+                          "description": "Role of the message sender",
+                          "enum": [
+                            "system",
+                            "user",
+                            "assistant"
+                          ],
                           "type": "string"
                         }
                       },
@@ -122,6 +213,20 @@
                       "type": "object"
                     },
                     "type": "array"
+                  },
+                  "reasoning_effort": {
+                    "description": "Controls depth of deep research reasoning. Higher values produce more thorough analysis.",
+                    "enum": [
+                      "minimal",
+                      "low",
+                      "medium",
+                      "high"
+                    ],
+                    "type": "string"
+                  },
+                  "strip_thinking": {
+                    "description": "If true, removes \u003cthink\u003e...\u003c/think\u003e tags and their content from the response to save context tokens. Default is false.",
+                    "type": "boolean"
                   }
                 },
                 "required": [
@@ -130,12 +235,51 @@
                 "type": "object"
               },
               "name": "perplexity_research"
+            },
+            {
+              "annotations": {
+                "destructiveHint": false,
+                "idempotentHint": false,
+                "openWorldHint": true,
+                "readOnlyHint": true
+              },
+              "description": "Search the web and return a ranked list of results with titles, URLs, snippets, and dates. Best for: finding specific URLs, checking recent news, verifying facts, discovering sources. Returns formatted results (title, URL, snippet, date) — no AI synthesis. For AI-generated answers with citations, use perplexity_ask instead.",
+              "inputSchema": {
+                "properties": {
+                  "country": {
+                    "description": "ISO 3166-1 alpha-2 country code for regional results (e.g., 'US', 'GB')",
+                    "type": "string"
+                  },
+                  "max_results": {
+                    "description": "Maximum number of results to return (1-20, default: 10)",
+                    "maximum": 20,
+                    "minimum": 1,
+                    "type": "number"
+                  },
+                  "max_tokens_per_page": {
+                    "description": "Maximum tokens to extract per webpage (default: 1024)",
+                    "maximum": 2048,
+                    "minimum": 256,
+                    "type": "number"
+                  },
+                  "query": {
+                    "description": "Search query string",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "query"
+                ],
+                "type": "object"
+              },
+              "name": "perplexity_search"
             }
           ],
           "tools": [
             "perplexity_ask",
             "perplexity_reason",
-            "perplexity_research"
+            "perplexity_research",
+            "perplexity_search"
           ]
         }
       }

--- a/registries/official/servers/redis/server.json
+++ b/registries/official/servers/redis/server.json
@@ -3,7 +3,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.stacklok": {
-        "docker.io/mcp/redis:latest": {
+        "ghcr.io/stacklok/dockyard/uvx/redis-mcp-server:0.5.0": {
           "metadata": {
             "last_updated": "2026-05-22T03:21:55Z",
             "stars": 511
@@ -1506,7 +1506,7 @@
           "name": "MCP_TRANSPORT"
         }
       ],
-      "identifier": "docker.io/mcp/redis:latest",
+      "identifier": "ghcr.io/stacklok/dockyard/uvx/redis-mcp-server:0.5.0",
       "registryType": "oci",
       "transport": {
         "type": "stdio"

--- a/registries/official/servers/redis/server.json
+++ b/registries/official/servers/redis/server.json
@@ -5,7 +5,7 @@
       "io.github.stacklok": {
         "ghcr.io/stacklok/dockyard/uvx/redis-mcp-server:0.5.0": {
           "metadata": {
-            "last_updated": "2026-05-22T03:21:55Z",
+            "last_updated": "2026-05-29T13:16:14Z",
             "stars": 511
           },
           "overview": "## Redis MCP Server\n\nThe redis MCP server enables LLMs to interact with Redis key-value databases through a set of standardized tools. The server connects to Redis databases and provides MCP tools for basic operations (CRUD operations, database management), data structures (full support for strings, hashes, lists, sets, sorted sets, JSON), vector search functionality, and streams/Pub/Sub features for messaging and time-series data handling.",
@@ -1076,36 +1076,6 @@
             },
             {
               "annotations": {},
-              "description": "Acknowledge entries that were processed by a consumer group.\n\nArgs:\n    key (str): The stream key.\n    group_name (str): The consumer group name.\n    entry_ids (List[str]): Entry IDs to acknowledge.\n\nReturns:\n    str: Confirmation message or an error message.\n",
-              "inputSchema": {
-                "properties": {
-                  "entry_ids": {
-                    "items": {
-                      "type": "string"
-                    },
-                    "title": "Entry Ids",
-                    "type": "array"
-                  },
-                  "group_name": {
-                    "title": "Group Name",
-                    "type": "string"
-                  },
-                  "key": {
-                    "title": "Key",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "key",
-                  "group_name",
-                  "entry_ids"
-                ],
-                "type": "object"
-              },
-              "name": "xack"
-            },
-            {
-              "annotations": {},
               "description": "Add an entry to a Redis stream with an optional expiration time.\n\nArgs:\n    key (str): The stream key.\n    fields (dict): The fields and values for the stream entry.\n    expiration (int, optional): Expiration time in seconds.\n\nReturns:\n    str: The ID of the added entry or an error message.\n",
               "inputSchema": {
                 "properties": {
@@ -1163,60 +1133,6 @@
             },
             {
               "annotations": {},
-              "description": "Create a consumer group for a Redis stream.\n\nArgs:\n    key (str): The stream key.\n    group_name (str): The consumer group name.\n    start_id (str, optional): Stream ID from which the group starts consuming.\n    mkstream (bool, optional): Create the stream if it does not exist.\n\nReturns:\n    str: Confirmation message or an error message.\n",
-              "inputSchema": {
-                "properties": {
-                  "group_name": {
-                    "title": "Group Name",
-                    "type": "string"
-                  },
-                  "key": {
-                    "title": "Key",
-                    "type": "string"
-                  },
-                  "mkstream": {
-                    "default": true,
-                    "title": "Mkstream",
-                    "type": "boolean"
-                  },
-                  "start_id": {
-                    "default": "$",
-                    "title": "Start Id",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "key",
-                  "group_name"
-                ],
-                "type": "object"
-              },
-              "name": "xgroup_create"
-            },
-            {
-              "annotations": {},
-              "description": "Destroy a consumer group for a Redis stream.\n\nArgs:\n    key (str): The stream key.\n    group_name (str): The consumer group name.\n\nReturns:\n    str: Confirmation message or an error message.\n",
-              "inputSchema": {
-                "properties": {
-                  "group_name": {
-                    "title": "Group Name",
-                    "type": "string"
-                  },
-                  "key": {
-                    "title": "Key",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "key",
-                  "group_name"
-                ],
-                "type": "object"
-              },
-              "name": "xgroup_destroy"
-            },
-            {
-              "annotations": {},
               "description": "Read entries from a Redis stream.\n\nArgs:\n    key (str): The stream key.\n    count (int, optional): Number of entries to retrieve.\n\nReturns:\n    str: The retrieved stream entries or an error message.\n",
               "inputSchema": {
                 "properties": {
@@ -1236,55 +1152,6 @@
                 "type": "object"
               },
               "name": "xrange"
-            },
-            {
-              "annotations": {},
-              "description": "Read entries from a Redis stream using a consumer group.\n\nArgs:\n    key (str): The stream key.\n    group_name (str): The consumer group name.\n    consumer_name (str): The consumer name.\n    count (int, optional): Maximum number of entries to retrieve.\n    block_ms (int, optional): Maximum time to block waiting for entries.\n        Use None for a non-blocking read. 0 is rejected because Redis treats\n        BLOCK 0 as an indefinite wait.\n    stream_id (str, optional): Stream ID to read from. Use \"\u003e\" for new messages.\n\nReturns:\n    str: The retrieved stream entries or an error message.\n",
-              "inputSchema": {
-                "properties": {
-                  "block_ms": {
-                    "anyOf": [
-                      {
-                        "type": "integer"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Block Ms"
-                  },
-                  "consumer_name": {
-                    "title": "Consumer Name",
-                    "type": "string"
-                  },
-                  "count": {
-                    "default": 1,
-                    "title": "Count",
-                    "type": "integer"
-                  },
-                  "group_name": {
-                    "title": "Group Name",
-                    "type": "string"
-                  },
-                  "key": {
-                    "title": "Key",
-                    "type": "string"
-                  },
-                  "stream_id": {
-                    "default": "\u003e",
-                    "title": "Stream Id",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "key",
-                  "group_name",
-                  "consumer_name"
-                ],
-                "type": "object"
-              },
-              "name": "xreadgroup"
             },
             {
               "annotations": {},
@@ -1422,13 +1289,9 @@
             "type",
             "unsubscribe",
             "vector_search_hash",
-            "xack",
             "xadd",
             "xdel",
-            "xgroup_create",
-            "xgroup_destroy",
             "xrange",
-            "xreadgroup",
             "zadd",
             "zrange",
             "zrem"

--- a/registries/official/servers/semgrep/server.json
+++ b/registries/official/servers/semgrep/server.json
@@ -3,7 +3,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.stacklok": {
-        "semgrep/semgrep:latest": {
+        "docker.io/semgrep/semgrep:1.164.0": {
           "args": [
             "semgrep",
             "mcp"
@@ -316,7 +316,7 @@
           "name": "SEMGREP_APP_TOKEN"
         }
       ],
-      "identifier": "semgrep/semgrep:latest",
+      "identifier": "docker.io/semgrep/semgrep:1.164.0",
       "registryType": "oci",
       "transport": {
         "type": "stdio"

--- a/registries/official/servers/semgrep/server.json
+++ b/registries/official/servers/semgrep/server.json
@@ -9,7 +9,7 @@
             "mcp"
           ],
           "metadata": {
-            "last_updated": "2026-04-10T03:04:30Z",
+            "last_updated": "2026-05-29T13:16:20Z",
             "stars": 14745
           },
           "overview": "## Semgrep MCP Server\n\nThe semgrep MCP server scans code for security vulnerabilities using Semgrep with 5,000+ semantic analysis rules. This tool provides static security analysis across multiple programming languages, leveraging thousands of semantic rules for identifying vulnerabilities. It enables abstract syntax tree generation, supply chain security scanning, and supports custom rule creation for organization-specific security requirements.",
@@ -80,14 +80,21 @@
               "inputSchema": {
                 "properties": {
                   "autotriage_verdict": {
-                    "default": "VERDICT_TRUE_POSITIVE",
-                    "description": "Autotriage verdict of the issues to filter by.",
-                    "enum": [
-                      "VERDICT_TRUE_POSITIVE",
-                      "VERDICT_FALSE_POSITIVE"
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "VERDICT_TRUE_POSITIVE",
+                          "VERDICT_FALSE_POSITIVE"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
                     ],
-                    "title": "Autotriage Verdict",
-                    "type": "string"
+                    "default": null,
+                    "description": "Autotriage verdict of the issues to filter by. If not provided, findings with any verdict (including unrated) are returned.",
+                    "title": "Autotriage Verdict"
                   },
                   "confidence": {
                     "anyOf": [
@@ -125,6 +132,15 @@
                     "description": "Maximum number of findings to return",
                     "title": "Limit",
                     "type": "integer"
+                  },
+                  "refs": {
+                    "default": [],
+                    "description": "List of git refs (branch names) to filter findings by. If not provided, only findings on the primary branch are returned.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Refs",
+                    "type": "array"
                   },
                   "repos": {
                     "default": [],

--- a/registries/official/servers/stripe/server.json
+++ b/registries/official/servers/stripe/server.json
@@ -3,7 +3,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.stacklok": {
-        "docker.io/mcp/stripe:latest": {
+        "ghcr.io/stacklok/dockyard/npx/stripe-mcp:0.3.3": {
           "args": [
             "--tools=all"
           ],
@@ -782,7 +782,7 @@
           "name": "STRIPE_SECRET_KEY"
         }
       ],
-      "identifier": "docker.io/mcp/stripe:latest",
+      "identifier": "ghcr.io/stacklok/dockyard/npx/stripe-mcp:0.3.3",
       "registryType": "oci",
       "transport": {
         "type": "stdio"

--- a/registries/toolhive/servers/crowdstrike-falcon/server.json
+++ b/registries/toolhive/servers/crowdstrike-falcon/server.json
@@ -3,7 +3,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.stacklok": {
-        "quay.io/crowdstrike/falcon-mcp:latest": {
+        "quay.io/crowdstrike/falcon-mcp:0.10.0": {
           "args": [
             "--transport",
             "streamable-http",
@@ -115,7 +115,7 @@
           "name": "FALCON_MCP_DEBUG"
         }
       ],
-      "identifier": "quay.io/crowdstrike/falcon-mcp:latest",
+      "identifier": "quay.io/crowdstrike/falcon-mcp:0.10.0",
       "registryType": "oci",
       "transport": {
         "type": "streamable-http",

--- a/registries/toolhive/servers/everything/server.json
+++ b/registries/toolhive/servers/everything/server.json
@@ -3,7 +3,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.stacklok": {
-        "docker.io/mcp/everything:latest": {
+        "ghcr.io/stacklok/dockyard/npx/server-everything:2026.1.26": {
           "metadata": {
             "last_updated": "2026-05-08T03:06:20Z",
             "stars": 85231
@@ -205,7 +205,7 @@
   "name": "io.github.stacklok/everything",
   "packages": [
     {
-      "identifier": "docker.io/mcp/everything:latest",
+      "identifier": "ghcr.io/stacklok/dockyard/npx/server-everything:2026.1.26",
       "registryType": "oci",
       "transport": {
         "type": "stdio"

--- a/registries/toolhive/servers/everything/server.json
+++ b/registries/toolhive/servers/everything/server.json
@@ -5,7 +5,7 @@
       "io.github.stacklok": {
         "ghcr.io/stacklok/dockyard/npx/server-everything:2026.1.26": {
           "metadata": {
-            "last_updated": "2026-05-08T03:06:20Z",
+            "last_updated": "2026-05-29T13:15:40Z",
             "stars": 85231
           },
           "overview": "## Everything MCP Server\n\nThe everything-mcp-server is a reference and demonstration Model Context Protocol (MCP) server that exposes a broad collection of example tools in a single implementation. The server is designed as a learning and testing resource, showcasing how MCP functions end-to-end through diverse tool types encompassing data access, computation, state management, and side effects that AI assistants can invoke during workflows. Rather than integrating with external services, this implementation serves primarily for educational purposes, client validation, debugging, and protocol testing — making it valuable for developers onboarding to MCP, understanding server architecture, and conducting regression testing.",
@@ -31,29 +31,24 @@
           "tool_definitions": [
             {
               "annotations": {},
-              "description": "Adds two numbers",
+              "description": "Echoes back the input string",
               "inputSchema": {
                 "properties": {
-                  "a": {
-                    "description": "First number",
-                    "type": "number"
-                  },
-                  "b": {
-                    "description": "Second number",
-                    "type": "number"
+                  "message": {
+                    "description": "Message to echo",
+                    "type": "string"
                   }
                 },
                 "required": [
-                  "a",
-                  "b"
+                  "message"
                 ],
                 "type": "object"
               },
-              "name": "add"
+              "name": "echo"
             },
             {
               "annotations": {},
-              "description": "Demonstrates how annotations can be used to provide metadata about content",
+              "description": "Demonstrates how annotations can be used to provide metadata about content.",
               "inputSchema": {
                 "properties": {
                   "includeImage": {
@@ -76,24 +71,35 @@
                 ],
                 "type": "object"
               },
-              "name": "annotatedMessage"
+              "name": "get-annotated-message"
             },
             {
               "annotations": {},
-              "description": "Echoes back the input",
+              "description": "Returns all environment variables, helpful for debugging MCP server configuration",
               "inputSchema": {
-                "properties": {
-                  "message": {
-                    "description": "Message to echo",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "message"
-                ],
+                "properties": {},
+                "required": [],
                 "type": "object"
               },
-              "name": "echo"
+              "name": "get-env"
+            },
+            {
+              "annotations": {},
+              "description": "Returns up to ten resource links that reference different types of resources",
+              "inputSchema": {
+                "properties": {
+                  "count": {
+                    "default": 3,
+                    "description": "Number of resource links to return (1-10)",
+                    "maximum": 10,
+                    "minimum": 1,
+                    "type": "number"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "get-resource-links"
             },
             {
               "annotations": {},
@@ -101,32 +107,154 @@
               "inputSchema": {
                 "properties": {
                   "resourceId": {
-                    "description": "ID of the resource to reference (1-100)",
-                    "maximum": 100,
-                    "minimum": 1,
+                    "default": 1,
+                    "description": "ID of the text resource to fetch",
+                    "type": "number"
+                  },
+                  "resourceType": {
+                    "default": "Text",
+                    "enum": [
+                      "Text",
+                      "Blob"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "get-resource-reference"
+            },
+            {
+              "annotations": {},
+              "description": "Returns structured content along with an output schema for client data validation",
+              "inputSchema": {
+                "properties": {
+                  "location": {
+                    "description": "Choose city",
+                    "enum": [
+                      "New York",
+                      "Chicago",
+                      "Los Angeles"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "location"
+                ],
+                "type": "object"
+              },
+              "name": "get-structured-content"
+            },
+            {
+              "annotations": {},
+              "description": "Returns the sum of two numbers",
+              "inputSchema": {
+                "properties": {
+                  "a": {
+                    "description": "First number",
+                    "type": "number"
+                  },
+                  "b": {
+                    "description": "Second number",
                     "type": "number"
                   }
                 },
                 "required": [
-                  "resourceId"
+                  "a",
+                  "b"
                 ],
                 "type": "object"
               },
-              "name": "getResourceReference"
+              "name": "get-sum"
             },
             {
               "annotations": {},
-              "description": "Returns the MCP_TINY_IMAGE",
+              "description": "Returns a tiny MCP logo image.",
               "inputSchema": {
                 "properties": {},
                 "required": [],
                 "type": "object"
               },
-              "name": "getTinyImage"
+              "name": "get-tiny-image"
             },
             {
               "annotations": {},
-              "description": "Demonstrates a long running operation with progress updates",
+              "description": "Compresses a single file using gzip compression. Depending upon the selected output type, returns either the compressed data as a gzipped resource or a resource link, allowing it to be downloaded in a subsequent request during the current session.",
+              "inputSchema": {
+                "properties": {
+                  "data": {
+                    "default": "https://raw.githubusercontent.com/modelcontextprotocol/servers/refs/heads/main/README.md",
+                    "description": "URL or data URI of the file content to compress",
+                    "format": "uri",
+                    "type": "string"
+                  },
+                  "name": {
+                    "default": "README.md.gz",
+                    "description": "Name of the output file",
+                    "type": "string"
+                  },
+                  "outputType": {
+                    "default": "resourceLink",
+                    "description": "How the resulting gzipped file should be returned. 'resourceLink' returns a link to a resource that can be read later, 'resource' returns a full resource object.",
+                    "enum": [
+                      "resourceLink",
+                      "resource"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "gzip-file-as-resource"
+            },
+            {
+              "annotations": {},
+              "description": "Simulates a deep research operation that gathers, analyzes, and synthesizes information. Demonstrates MCP task-based operations with progress through multiple stages. If 'ambiguous' is true and client supports elicitation, sends an elicitation request for clarification.",
+              "inputSchema": {
+                "properties": {
+                  "ambiguous": {
+                    "default": false,
+                    "description": "Simulate an ambiguous query that requires clarification (triggers input_required status)",
+                    "type": "boolean"
+                  },
+                  "topic": {
+                    "description": "The research topic to investigate",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "topic"
+                ],
+                "type": "object"
+              },
+              "name": "simulate-research-query"
+            },
+            {
+              "annotations": {},
+              "description": "Toggles simulated, random-leveled logging on or off.",
+              "inputSchema": {
+                "properties": {},
+                "required": [],
+                "type": "object"
+              },
+              "name": "toggle-simulated-logging"
+            },
+            {
+              "annotations": {},
+              "description": "Toggles simulated resource subscription updates on or off.",
+              "inputSchema": {
+                "properties": {},
+                "required": [],
+                "type": "object"
+              },
+              "name": "toggle-subscriber-updates"
+            },
+            {
+              "annotations": {},
+              "description": "Demonstrates a long running operation with progress updates.",
               "inputSchema": {
                 "properties": {
                   "duration": {
@@ -143,50 +271,23 @@
                 "required": [],
                 "type": "object"
               },
-              "name": "longRunningOperation"
-            },
-            {
-              "annotations": {},
-              "description": "Prints all environment variables, helpful for debugging MCP server configuration",
-              "inputSchema": {
-                "properties": {},
-                "required": [],
-                "type": "object"
-              },
-              "name": "printEnv"
-            },
-            {
-              "annotations": {},
-              "description": "Samples from an LLM using MCP's sampling feature",
-              "inputSchema": {
-                "properties": {
-                  "maxTokens": {
-                    "default": 100,
-                    "description": "Maximum number of tokens to generate",
-                    "type": "number"
-                  },
-                  "prompt": {
-                    "description": "The prompt to send to the LLM",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "prompt"
-                ],
-                "type": "object"
-              },
-              "name": "sampleLLM"
+              "name": "trigger-long-running-operation"
             }
           ],
           "tools": [
-            "add",
-            "annotatedMessage",
             "echo",
-            "getResourceReference",
-            "getTinyImage",
-            "longRunningOperation",
-            "printEnv",
-            "sampleLLM"
+            "get-annotated-message",
+            "get-env",
+            "get-resource-links",
+            "get-resource-reference",
+            "get-structured-content",
+            "get-sum",
+            "get-tiny-image",
+            "gzip-file-as-resource",
+            "simulate-research-query",
+            "toggle-simulated-logging",
+            "toggle-subscriber-updates",
+            "trigger-long-running-operation"
           ]
         }
       }

--- a/registries/toolhive/servers/git/server.json
+++ b/registries/toolhive/servers/git/server.json
@@ -5,7 +5,7 @@
       "io.github.stacklok": {
         "ghcr.io/stacklok/dockyard/uvx/mcp-server-git:2026.1.14": {
           "metadata": {
-            "last_updated": "2026-04-18T03:03:09Z",
+            "last_updated": "2026-05-29T13:16:19Z",
             "stars": 84011
           },
           "overview": "## Git MCP Server\n\nThe git-mcp-server is a Model Context Protocol (MCP) server that gives AI assistants direct access to Git repositories through a structured, AI-friendly interface. It enables AI-driven workflows to read repository state, inspect history, and reason about changes without switching tools or manually invoking Git commands. It is especially useful for code understanding, change analysis, release preparation, and development workflows where repository context needs to be embedded directly into an AI assistant.",
@@ -52,6 +52,56 @@
                 "type": "object"
               },
               "name": "git_add"
+            },
+            {
+              "annotations": {},
+              "description": "List Git branches",
+              "inputSchema": {
+                "properties": {
+                  "branch_type": {
+                    "description": "Whether to list local branches ('local'), remote branches ('remote') or all branches('all').",
+                    "title": "Branch Type",
+                    "type": "string"
+                  },
+                  "contains": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "The commit sha that branch should contain. Do not pass anything to this param if no commit sha is specified",
+                    "title": "Contains"
+                  },
+                  "not_contains": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "The commit sha that branch should NOT contain. Do not pass anything to this param if no commit sha is specified",
+                    "title": "Not Contains"
+                  },
+                  "repo_path": {
+                    "description": "The path to the Git repository.",
+                    "title": "Repo Path",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "repo_path",
+                  "branch_type"
+                ],
+                "type": "object"
+              },
+              "name": "git_branch"
             },
             {
               "annotations": {},
@@ -136,6 +186,11 @@
               "description": "Shows differences between branches or commits",
               "inputSchema": {
                 "properties": {
+                  "context_lines": {
+                    "default": 3,
+                    "title": "Context Lines",
+                    "type": "integer"
+                  },
                   "repo_path": {
                     "title": "Repo Path",
                     "type": "string"
@@ -158,6 +213,11 @@
               "description": "Shows changes that are staged for commit",
               "inputSchema": {
                 "properties": {
+                  "context_lines": {
+                    "default": 3,
+                    "title": "Context Lines",
+                    "type": "integer"
+                  },
                   "repo_path": {
                     "title": "Repo Path",
                     "type": "string"
@@ -175,6 +235,11 @@
               "description": "Shows changes in the working directory that are not yet staged",
               "inputSchema": {
                 "properties": {
+                  "context_lines": {
+                    "default": 3,
+                    "title": "Context Lines",
+                    "type": "integer"
+                  },
                   "repo_path": {
                     "title": "Repo Path",
                     "type": "string"
@@ -189,26 +254,22 @@
             },
             {
               "annotations": {},
-              "description": "Initialize a new Git repository",
-              "inputSchema": {
-                "properties": {
-                  "repo_path": {
-                    "title": "Repo Path",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "repo_path"
-                ],
-                "type": "object"
-              },
-              "name": "git_init"
-            },
-            {
-              "annotations": {},
               "description": "Shows the commit logs",
               "inputSchema": {
                 "properties": {
+                  "end_timestamp": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "End timestamp for filtering commits. Accepts: ISO 8601 format (e.g., '2024-01-15T14:30:25'), relative dates (e.g., '2 weeks ago', 'yesterday'), or absolute dates (e.g., '2024-01-15', 'Jan 15 2024')",
+                    "title": "End Timestamp"
+                  },
                   "max_count": {
                     "default": 10,
                     "title": "Max Count",
@@ -217,6 +278,19 @@
                   "repo_path": {
                     "title": "Repo Path",
                     "type": "string"
+                  },
+                  "start_timestamp": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Start timestamp for filtering commits. Accepts: ISO 8601 format (e.g., '2024-01-15T14:30:25'), relative dates (e.g., '2 weeks ago', 'yesterday'), or absolute dates (e.g., '2024-01-15', 'Jan 15 2024')",
+                    "title": "Start Timestamp"
                   }
                 },
                 "required": [
@@ -285,13 +359,13 @@
           ],
           "tools": [
             "git_add",
+            "git_branch",
             "git_checkout",
             "git_commit",
             "git_create_branch",
             "git_diff",
             "git_diff_staged",
             "git_diff_unstaged",
-            "git_init",
             "git_log",
             "git_reset",
             "git_show",

--- a/registries/toolhive/servers/git/server.json
+++ b/registries/toolhive/servers/git/server.json
@@ -3,7 +3,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.stacklok": {
-        "docker.io/mcp/git:latest": {
+        "ghcr.io/stacklok/dockyard/uvx/mcp-server-git:2026.1.14": {
           "metadata": {
             "last_updated": "2026-04-18T03:03:09Z",
             "stars": 84011
@@ -314,7 +314,7 @@
   "name": "io.github.stacklok/git",
   "packages": [
     {
-      "identifier": "docker.io/mcp/git:latest",
+      "identifier": "ghcr.io/stacklok/dockyard/uvx/mcp-server-git:2026.1.14",
       "registryType": "oci",
       "transport": {
         "type": "stdio"

--- a/registries/toolhive/servers/memory/server.json
+++ b/registries/toolhive/servers/memory/server.json
@@ -3,7 +3,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.stacklok": {
-        "docker.io/mcp/memory:latest": {
+        "ghcr.io/stacklok/dockyard/npx/server-memory:2026.1.26": {
           "metadata": {
             "last_updated": "2026-05-08T03:06:10Z",
             "stars": 85231
@@ -322,7 +322,7 @@
           "name": "MEMORY_FILE_PATH"
         }
       ],
-      "identifier": "docker.io/mcp/memory:latest",
+      "identifier": "ghcr.io/stacklok/dockyard/npx/server-memory:2026.1.26",
       "registryType": "oci",
       "transport": {
         "type": "stdio"

--- a/registries/toolhive/servers/memory/server.json
+++ b/registries/toolhive/servers/memory/server.json
@@ -5,7 +5,7 @@
       "io.github.stacklok": {
         "ghcr.io/stacklok/dockyard/npx/server-memory:2026.1.26": {
           "metadata": {
-            "last_updated": "2026-05-08T03:06:10Z",
+            "last_updated": "2026-05-29T13:15:41Z",
             "stars": 85231
           },
           "overview": "## Memory MCP Server\n\nThe memory MCP server provides AI assistants with persistent, long-term memory across interactions. It allows AI workflows to maintain context and knowledge beyond individual conversations, supporting personalization and enabling continuity in assistant interactions. The system works by running as an MCP service that manages persistent storage, handling indexing and retrieval so AI clients can access historical context during reasoning tasks — enabling assistants to develop awareness of user preferences and prior decisions over extended periods.",

--- a/registries/toolhive/servers/perplexity-ask/server.json
+++ b/registries/toolhive/servers/perplexity-ask/server.json
@@ -5,7 +5,7 @@
       "io.github.stacklok": {
         "ghcr.io/stacklok/dockyard/npx/perplexity-ask:0.9.0": {
           "metadata": {
-            "last_updated": "2026-04-19T03:04:11Z",
+            "last_updated": "2026-05-29T13:15:49Z",
             "stars": 2092
           },
           "overview": "## Perplexity Ask MCP Server\n\nThe perplexity-ask MCP server integrates Perplexity AI's Sonar API for live web searches, in-depth research, and reasoning tasks. The server provides three specialized tools: perplexity_ask for quick web search using the Sonar API, perplexity_research for comprehensive research with detailed citations, and perplexity_reason for advanced reasoning for complex problem-solving.",
@@ -30,20 +30,31 @@
           "tier": "Official",
           "tool_definitions": [
             {
-              "annotations": {},
-              "description": "Engages in a conversation using the Sonar API. Accepts an array of messages (each with a role and content) and returns a ask completion response from the Perplexity model.",
+              "annotations": {
+                "destructiveHint": false,
+                "idempotentHint": false,
+                "openWorldHint": true,
+                "readOnlyHint": true
+              },
+              "description": "Answer a question using web-grounded AI (Sonar Pro model). Best for: quick factual questions, summaries, explanations, and general Q\u0026A. Returns a text response with numbered citations. Fastest and cheapest option. Supports filtering by recency (hour/day/week/month/year), domain restrictions, and search context size. For in-depth multi-source research, use perplexity_research instead. For step-by-step reasoning and analysis, use perplexity_reason instead.",
               "inputSchema": {
                 "properties": {
                   "messages": {
                     "description": "Array of conversation messages",
                     "items": {
+                      "additionalProperties": false,
                       "properties": {
                         "content": {
                           "description": "The content of the message",
                           "type": "string"
                         },
                         "role": {
-                          "description": "Role of the message (e.g., system, user, assistant)",
+                          "description": "Role of the message sender",
+                          "enum": [
+                            "system",
+                            "user",
+                            "assistant"
+                          ],
                           "type": "string"
                         }
                       },
@@ -54,6 +65,33 @@
                       "type": "object"
                     },
                     "type": "array"
+                  },
+                  "search_context_size": {
+                    "description": "Controls how much web context is retrieved. 'low' (default) is fastest, 'high' provides more comprehensive results.",
+                    "enum": [
+                      "low",
+                      "medium",
+                      "high"
+                    ],
+                    "type": "string"
+                  },
+                  "search_domain_filter": {
+                    "description": "Restrict search results to specific domains (e.g., ['wikipedia.org', 'arxiv.org']). Use '-' prefix for exclusion (e.g., ['-reddit.com']).",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "search_recency_filter": {
+                    "description": "Filter search results by recency. Use 'hour' for very recent news, 'day' for today's updates, 'week' for this week, etc.",
+                    "enum": [
+                      "hour",
+                      "day",
+                      "week",
+                      "month",
+                      "year"
+                    ],
+                    "type": "string"
                   }
                 },
                 "required": [
@@ -64,20 +102,31 @@
               "name": "perplexity_ask"
             },
             {
-              "annotations": {},
-              "description": "Performs reasoning tasks using the Perplexity API. Accepts an array of messages (each with a role and content) and returns a well-reasoned response using the sonar-reasoning-pro model.",
+              "annotations": {
+                "destructiveHint": false,
+                "idempotentHint": false,
+                "openWorldHint": true,
+                "readOnlyHint": true
+              },
+              "description": "Analyze a question using step-by-step reasoning with web grounding (Sonar Reasoning Pro model). Best for: math, logic, comparisons, complex arguments, and tasks requiring chain-of-thought. Returns a reasoned response with numbered citations. Supports filtering by recency (hour/day/week/month/year), domain restrictions, and search context size. For quick factual questions, use perplexity_ask instead. For comprehensive multi-source research, use perplexity_research instead.",
               "inputSchema": {
                 "properties": {
                   "messages": {
                     "description": "Array of conversation messages",
                     "items": {
+                      "additionalProperties": false,
                       "properties": {
                         "content": {
                           "description": "The content of the message",
                           "type": "string"
                         },
                         "role": {
-                          "description": "Role of the message (e.g., system, user, assistant)",
+                          "description": "Role of the message sender",
+                          "enum": [
+                            "system",
+                            "user",
+                            "assistant"
+                          ],
                           "type": "string"
                         }
                       },
@@ -88,6 +137,37 @@
                       "type": "object"
                     },
                     "type": "array"
+                  },
+                  "search_context_size": {
+                    "description": "Controls how much web context is retrieved. 'low' (default) is fastest, 'high' provides more comprehensive results.",
+                    "enum": [
+                      "low",
+                      "medium",
+                      "high"
+                    ],
+                    "type": "string"
+                  },
+                  "search_domain_filter": {
+                    "description": "Restrict search results to specific domains (e.g., ['wikipedia.org', 'arxiv.org']). Use '-' prefix for exclusion (e.g., ['-reddit.com']).",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "search_recency_filter": {
+                    "description": "Filter search results by recency. Use 'hour' for very recent news, 'day' for today's updates, 'week' for this week, etc.",
+                    "enum": [
+                      "hour",
+                      "day",
+                      "week",
+                      "month",
+                      "year"
+                    ],
+                    "type": "string"
+                  },
+                  "strip_thinking": {
+                    "description": "If true, removes \u003cthink\u003e...\u003c/think\u003e tags and their content from the response to save context tokens. Default is false.",
+                    "type": "boolean"
                   }
                 },
                 "required": [
@@ -98,20 +178,31 @@
               "name": "perplexity_reason"
             },
             {
-              "annotations": {},
-              "description": "Performs deep research using the Perplexity API. Accepts an array of messages (each with a role and content) and returns a comprehensive research response with citations.",
+              "annotations": {
+                "destructiveHint": false,
+                "idempotentHint": false,
+                "openWorldHint": true,
+                "readOnlyHint": true
+              },
+              "description": "Conduct deep, multi-source research on a topic (Sonar Deep Research model). Best for: literature reviews, comprehensive overviews, investigative queries needing many sources. Returns a detailed response with numbered citations. Significantly slower than other tools (30+ seconds). For quick factual questions, use perplexity_ask instead. For logical analysis and reasoning, use perplexity_reason instead.",
               "inputSchema": {
                 "properties": {
                   "messages": {
                     "description": "Array of conversation messages",
                     "items": {
+                      "additionalProperties": false,
                       "properties": {
                         "content": {
                           "description": "The content of the message",
                           "type": "string"
                         },
                         "role": {
-                          "description": "Role of the message (e.g., system, user, assistant)",
+                          "description": "Role of the message sender",
+                          "enum": [
+                            "system",
+                            "user",
+                            "assistant"
+                          ],
                           "type": "string"
                         }
                       },
@@ -122,6 +213,20 @@
                       "type": "object"
                     },
                     "type": "array"
+                  },
+                  "reasoning_effort": {
+                    "description": "Controls depth of deep research reasoning. Higher values produce more thorough analysis.",
+                    "enum": [
+                      "minimal",
+                      "low",
+                      "medium",
+                      "high"
+                    ],
+                    "type": "string"
+                  },
+                  "strip_thinking": {
+                    "description": "If true, removes \u003cthink\u003e...\u003c/think\u003e tags and their content from the response to save context tokens. Default is false.",
+                    "type": "boolean"
                   }
                 },
                 "required": [
@@ -130,12 +235,51 @@
                 "type": "object"
               },
               "name": "perplexity_research"
+            },
+            {
+              "annotations": {
+                "destructiveHint": false,
+                "idempotentHint": false,
+                "openWorldHint": true,
+                "readOnlyHint": true
+              },
+              "description": "Search the web and return a ranked list of results with titles, URLs, snippets, and dates. Best for: finding specific URLs, checking recent news, verifying facts, discovering sources. Returns formatted results (title, URL, snippet, date) — no AI synthesis. For AI-generated answers with citations, use perplexity_ask instead.",
+              "inputSchema": {
+                "properties": {
+                  "country": {
+                    "description": "ISO 3166-1 alpha-2 country code for regional results (e.g., 'US', 'GB')",
+                    "type": "string"
+                  },
+                  "max_results": {
+                    "description": "Maximum number of results to return (1-20, default: 10)",
+                    "maximum": 20,
+                    "minimum": 1,
+                    "type": "number"
+                  },
+                  "max_tokens_per_page": {
+                    "description": "Maximum tokens to extract per webpage (default: 1024)",
+                    "maximum": 2048,
+                    "minimum": 256,
+                    "type": "number"
+                  },
+                  "query": {
+                    "description": "Search query string",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "query"
+                ],
+                "type": "object"
+              },
+              "name": "perplexity_search"
             }
           ],
           "tools": [
             "perplexity_ask",
             "perplexity_reason",
-            "perplexity_research"
+            "perplexity_research",
+            "perplexity_search"
           ]
         }
       }

--- a/registries/toolhive/servers/perplexity-ask/server.json
+++ b/registries/toolhive/servers/perplexity-ask/server.json
@@ -3,7 +3,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.stacklok": {
-        "docker.io/mcp/perplexity-ask:latest": {
+        "ghcr.io/stacklok/dockyard/npx/perplexity-ask:0.9.0": {
           "metadata": {
             "last_updated": "2026-04-19T03:04:11Z",
             "stars": 2092
@@ -162,7 +162,7 @@
           "name": "PERPLEXITY_API_KEY"
         }
       ],
-      "identifier": "docker.io/mcp/perplexity-ask:latest",
+      "identifier": "ghcr.io/stacklok/dockyard/npx/perplexity-ask:0.9.0",
       "registryType": "oci",
       "transport": {
         "type": "stdio"
@@ -171,7 +171,7 @@
   ],
   "repository": {
     "source": "github",
-    "url": "https://github.com/ppl-ai/modelcontextprotocol"
+    "url": "https://github.com/perplexityai/modelcontextprotocol"
   },
   "title": "Perplexity",
   "version": "1.0.0"

--- a/registries/toolhive/servers/redis/server.json
+++ b/registries/toolhive/servers/redis/server.json
@@ -3,7 +3,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.stacklok": {
-        "docker.io/mcp/redis:latest": {
+        "ghcr.io/stacklok/dockyard/uvx/redis-mcp-server:0.5.0": {
           "metadata": {
             "last_updated": "2026-05-07T03:06:47Z",
             "stars": 504
@@ -1506,7 +1506,7 @@
           "name": "MCP_TRANSPORT"
         }
       ],
-      "identifier": "docker.io/mcp/redis:latest",
+      "identifier": "ghcr.io/stacklok/dockyard/uvx/redis-mcp-server:0.5.0",
       "registryType": "oci",
       "transport": {
         "type": "stdio"

--- a/registries/toolhive/servers/redis/server.json
+++ b/registries/toolhive/servers/redis/server.json
@@ -5,7 +5,7 @@
       "io.github.stacklok": {
         "ghcr.io/stacklok/dockyard/uvx/redis-mcp-server:0.5.0": {
           "metadata": {
-            "last_updated": "2026-05-07T03:06:47Z",
+            "last_updated": "2026-05-29T13:16:12Z",
             "stars": 504
           },
           "overview": "## Redis MCP Server\n\nThe redis MCP server enables LLMs to interact with Redis key-value databases through a set of standardized tools. The server connects to Redis databases and provides MCP tools for basic operations (CRUD operations, database management), data structures (full support for strings, hashes, lists, sets, sorted sets, JSON), vector search functionality, and streams/Pub/Sub features for messaging and time-series data handling.",
@@ -1076,36 +1076,6 @@
             },
             {
               "annotations": {},
-              "description": "Acknowledge entries that were processed by a consumer group.\n\nArgs:\n    key (str): The stream key.\n    group_name (str): The consumer group name.\n    entry_ids (List[str]): Entry IDs to acknowledge.\n\nReturns:\n    str: Confirmation message or an error message.\n",
-              "inputSchema": {
-                "properties": {
-                  "entry_ids": {
-                    "items": {
-                      "type": "string"
-                    },
-                    "title": "Entry Ids",
-                    "type": "array"
-                  },
-                  "group_name": {
-                    "title": "Group Name",
-                    "type": "string"
-                  },
-                  "key": {
-                    "title": "Key",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "key",
-                  "group_name",
-                  "entry_ids"
-                ],
-                "type": "object"
-              },
-              "name": "xack"
-            },
-            {
-              "annotations": {},
               "description": "Add an entry to a Redis stream with an optional expiration time.\n\nArgs:\n    key (str): The stream key.\n    fields (dict): The fields and values for the stream entry.\n    expiration (int, optional): Expiration time in seconds.\n\nReturns:\n    str: The ID of the added entry or an error message.\n",
               "inputSchema": {
                 "properties": {
@@ -1163,60 +1133,6 @@
             },
             {
               "annotations": {},
-              "description": "Create a consumer group for a Redis stream.\n\nArgs:\n    key (str): The stream key.\n    group_name (str): The consumer group name.\n    start_id (str, optional): Stream ID from which the group starts consuming.\n    mkstream (bool, optional): Create the stream if it does not exist.\n\nReturns:\n    str: Confirmation message or an error message.\n",
-              "inputSchema": {
-                "properties": {
-                  "group_name": {
-                    "title": "Group Name",
-                    "type": "string"
-                  },
-                  "key": {
-                    "title": "Key",
-                    "type": "string"
-                  },
-                  "mkstream": {
-                    "default": true,
-                    "title": "Mkstream",
-                    "type": "boolean"
-                  },
-                  "start_id": {
-                    "default": "$",
-                    "title": "Start Id",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "key",
-                  "group_name"
-                ],
-                "type": "object"
-              },
-              "name": "xgroup_create"
-            },
-            {
-              "annotations": {},
-              "description": "Destroy a consumer group for a Redis stream.\n\nArgs:\n    key (str): The stream key.\n    group_name (str): The consumer group name.\n\nReturns:\n    str: Confirmation message or an error message.\n",
-              "inputSchema": {
-                "properties": {
-                  "group_name": {
-                    "title": "Group Name",
-                    "type": "string"
-                  },
-                  "key": {
-                    "title": "Key",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "key",
-                  "group_name"
-                ],
-                "type": "object"
-              },
-              "name": "xgroup_destroy"
-            },
-            {
-              "annotations": {},
               "description": "Read entries from a Redis stream.\n\nArgs:\n    key (str): The stream key.\n    count (int, optional): Number of entries to retrieve.\n\nReturns:\n    str: The retrieved stream entries or an error message.\n",
               "inputSchema": {
                 "properties": {
@@ -1236,55 +1152,6 @@
                 "type": "object"
               },
               "name": "xrange"
-            },
-            {
-              "annotations": {},
-              "description": "Read entries from a Redis stream using a consumer group.\n\nArgs:\n    key (str): The stream key.\n    group_name (str): The consumer group name.\n    consumer_name (str): The consumer name.\n    count (int, optional): Maximum number of entries to retrieve.\n    block_ms (int, optional): Maximum time to block waiting for entries.\n        Use None for a non-blocking read. 0 is rejected because Redis treats\n        BLOCK 0 as an indefinite wait.\n    stream_id (str, optional): Stream ID to read from. Use \"\u003e\" for new messages.\n\nReturns:\n    str: The retrieved stream entries or an error message.\n",
-              "inputSchema": {
-                "properties": {
-                  "block_ms": {
-                    "anyOf": [
-                      {
-                        "type": "integer"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Block Ms"
-                  },
-                  "consumer_name": {
-                    "title": "Consumer Name",
-                    "type": "string"
-                  },
-                  "count": {
-                    "default": 1,
-                    "title": "Count",
-                    "type": "integer"
-                  },
-                  "group_name": {
-                    "title": "Group Name",
-                    "type": "string"
-                  },
-                  "key": {
-                    "title": "Key",
-                    "type": "string"
-                  },
-                  "stream_id": {
-                    "default": "\u003e",
-                    "title": "Stream Id",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "key",
-                  "group_name",
-                  "consumer_name"
-                ],
-                "type": "object"
-              },
-              "name": "xreadgroup"
             },
             {
               "annotations": {},
@@ -1422,13 +1289,9 @@
             "type",
             "unsubscribe",
             "vector_search_hash",
-            "xack",
             "xadd",
             "xdel",
-            "xgroup_create",
-            "xgroup_destroy",
             "xrange",
-            "xreadgroup",
             "zadd",
             "zrange",
             "zrem"

--- a/registries/toolhive/servers/semgrep/server.json
+++ b/registries/toolhive/servers/semgrep/server.json
@@ -3,7 +3,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.stacklok": {
-        "semgrep/semgrep:latest": {
+        "docker.io/semgrep/semgrep:1.164.0": {
           "args": [
             "semgrep",
             "mcp"
@@ -316,7 +316,7 @@
           "name": "SEMGREP_APP_TOKEN"
         }
       ],
-      "identifier": "semgrep/semgrep:latest",
+      "identifier": "docker.io/semgrep/semgrep:1.164.0",
       "registryType": "oci",
       "transport": {
         "type": "stdio"

--- a/registries/toolhive/servers/semgrep/server.json
+++ b/registries/toolhive/servers/semgrep/server.json
@@ -9,7 +9,7 @@
             "mcp"
           ],
           "metadata": {
-            "last_updated": "2026-05-07T03:07:40Z",
+            "last_updated": "2026-05-29T13:16:20Z",
             "stars": 15042
           },
           "overview": "## Semgrep MCP Server\n\nThe semgrep MCP server scans code for security vulnerabilities using Semgrep with 5,000+ semantic analysis rules. This tool provides static security analysis across multiple programming languages, leveraging thousands of semantic rules for identifying vulnerabilities. It enables abstract syntax tree generation, supply chain security scanning, and supports custom rule creation for organization-specific security requirements.",
@@ -80,14 +80,21 @@
               "inputSchema": {
                 "properties": {
                   "autotriage_verdict": {
-                    "default": "VERDICT_TRUE_POSITIVE",
-                    "description": "Autotriage verdict of the issues to filter by.",
-                    "enum": [
-                      "VERDICT_TRUE_POSITIVE",
-                      "VERDICT_FALSE_POSITIVE"
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "VERDICT_TRUE_POSITIVE",
+                          "VERDICT_FALSE_POSITIVE"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
                     ],
-                    "title": "Autotriage Verdict",
-                    "type": "string"
+                    "default": null,
+                    "description": "Autotriage verdict of the issues to filter by. If not provided, findings with any verdict (including unrated) are returned.",
+                    "title": "Autotriage Verdict"
                   },
                   "confidence": {
                     "anyOf": [
@@ -125,6 +132,15 @@
                     "description": "Maximum number of findings to return",
                     "title": "Limit",
                     "type": "integer"
+                  },
+                  "refs": {
+                    "default": [],
+                    "description": "List of git refs (branch names) to filter findings by. If not provided, only findings on the primary branch are returned.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Refs",
+                    "type": "array"
                   },
                   "repos": {
                     "default": [],

--- a/registries/toolhive/servers/sequentialthinking/server.json
+++ b/registries/toolhive/servers/sequentialthinking/server.json
@@ -5,7 +5,7 @@
       "io.github.stacklok": {
         "ghcr.io/stacklok/dockyard/npx/server-sequential-thinking:2025.12.18": {
           "metadata": {
-            "last_updated": "2026-04-19T03:04:11Z",
+            "last_updated": "2026-05-29T13:15:43Z",
             "stars": 84056
           },
           "overview": "## Sequential Thinking MCP Server\n\nThe sequentialthinking MCP server enables dynamic problem-solving with a structured, reflective approach that adapts as understanding deepens. Key capabilities include structured reflective problem-solving, dynamic adaptation during analysis, step-by-step chain-of-thought reasoning, and branching thought processes for comprehensive exploration.",
@@ -33,11 +33,12 @@
           "tool_definitions": [
             {
               "annotations": {},
-              "description": "A detailed tool for dynamic and reflective problem-solving through thoughts.\nThis tool helps analyze problems through a flexible thinking process that can adapt and evolve.\nEach thought can build on, question, or revise previous insights as understanding deepens.\n\nWhen to use this tool:\n- Breaking down complex problems into steps\n- Planning and design with room for revision\n- Analysis that might need course correction\n- Problems where the full scope might not be clear initially\n- Problems that require a multi-step solution\n- Tasks that need to maintain context over multiple steps\n- Situations where irrelevant information needs to be filtered out\n\nKey features:\n- You can adjust total_thoughts up or down as you progress\n- You can question or revise previous thoughts\n- You can add more thoughts even after reaching what seemed like the end\n- You can express uncertainty and explore alternative approaches\n- Not every thought needs to build linearly - you can branch or backtrack\n- Generates a solution hypothesis\n- Verifies the hypothesis based on the Chain of Thought steps\n- Repeats the process until satisfied\n- Provides a correct answer\n\nParameters explained:\n- thought: Your current thinking step, which can include:\n* Regular analytical steps\n* Revisions of previous thoughts\n* Questions about previous decisions\n* Realizations about needing more analysis\n* Changes in approach\n* Hypothesis generation\n* Hypothesis verification\n- next_thought_needed: True if you need more thinking, even if at what seemed like the end\n- thought_number: Current number in sequence (can go beyond initial total if needed)\n- total_thoughts: Current estimate of thoughts needed (can be adjusted up/down)\n- is_revision: A boolean indicating if this thought revises previous thinking\n- revises_thought: If is_revision is true, which thought number is being reconsidered\n- branch_from_thought: If branching, which thought number is the branching point\n- branch_id: Identifier for the current branch (if any)\n- needs_more_thoughts: If reaching end but realizing more thoughts needed\n\nYou should:\n1. Start with an initial estimate of needed thoughts, but be ready to adjust\n2. Feel free to question or revise previous thoughts\n3. Don't hesitate to add more thoughts if needed, even at the \"end\"\n4. Express uncertainty when present\n5. Mark thoughts that revise previous thinking or branch into new paths\n6. Ignore information that is irrelevant to the current step\n7. Generate a solution hypothesis when appropriate\n8. Verify the hypothesis based on the Chain of Thought steps\n9. Repeat the process until satisfied with the solution\n10. Provide a single, ideally correct answer as the final output\n11. Only set next_thought_needed to false when truly done and a satisfactory answer is reached",
+              "description": "A detailed tool for dynamic and reflective problem-solving through thoughts.\nThis tool helps analyze problems through a flexible thinking process that can adapt and evolve.\nEach thought can build on, question, or revise previous insights as understanding deepens.\n\nWhen to use this tool:\n- Breaking down complex problems into steps\n- Planning and design with room for revision\n- Analysis that might need course correction\n- Problems where the full scope might not be clear initially\n- Problems that require a multi-step solution\n- Tasks that need to maintain context over multiple steps\n- Situations where irrelevant information needs to be filtered out\n\nKey features:\n- You can adjust total_thoughts up or down as you progress\n- You can question or revise previous thoughts\n- You can add more thoughts even after reaching what seemed like the end\n- You can express uncertainty and explore alternative approaches\n- Not every thought needs to build linearly - you can branch or backtrack\n- Generates a solution hypothesis\n- Verifies the hypothesis based on the Chain of Thought steps\n- Repeats the process until satisfied\n- Provides a correct answer\n\nParameters explained:\n- thought: Your current thinking step, which can include:\n  * Regular analytical steps\n  * Revisions of previous thoughts\n  * Questions about previous decisions\n  * Realizations about needing more analysis\n  * Changes in approach\n  * Hypothesis generation\n  * Hypothesis verification\n- nextThoughtNeeded: True if you need more thinking, even if at what seemed like the end\n- thoughtNumber: Current number in sequence (can go beyond initial total if needed)\n- totalThoughts: Current estimate of thoughts needed (can be adjusted up/down)\n- isRevision: A boolean indicating if this thought revises previous thinking\n- revisesThought: If is_revision is true, which thought number is being reconsidered\n- branchFromThought: If branching, which thought number is the branching point\n- branchId: Identifier for the current branch (if any)\n- needsMoreThoughts: If reaching end but realizing more thoughts needed\n\nYou should:\n1. Start with an initial estimate of needed thoughts, but be ready to adjust\n2. Feel free to question or revise previous thoughts\n3. Don't hesitate to add more thoughts if needed, even at the \"end\"\n4. Express uncertainty when present\n5. Mark thoughts that revise previous thinking or branch into new paths\n6. Ignore information that is irrelevant to the current step\n7. Generate a solution hypothesis when appropriate\n8. Verify the hypothesis based on the Chain of Thought steps\n9. Repeat the process until satisfied with the solution\n10. Provide a single, ideally correct answer as the final output\n11. Only set nextThoughtNeeded to false when truly done and a satisfactory answer is reached",
               "inputSchema": {
                 "properties": {
                   "branchFromThought": {
                     "description": "Branching point thought number",
+                    "maximum": 9007199254740991,
                     "minimum": 1,
                     "type": "integer"
                   },
@@ -59,6 +60,7 @@
                   },
                   "revisesThought": {
                     "description": "Which thought is being reconsidered",
+                    "maximum": 9007199254740991,
                     "minimum": 1,
                     "type": "integer"
                   },
@@ -67,12 +69,14 @@
                     "type": "string"
                   },
                   "thoughtNumber": {
-                    "description": "Current thought number",
+                    "description": "Current thought number (numeric value, e.g., 1, 2, 3)",
+                    "maximum": 9007199254740991,
                     "minimum": 1,
                     "type": "integer"
                   },
                   "totalThoughts": {
-                    "description": "Estimated total thoughts needed",
+                    "description": "Estimated total thoughts needed (numeric value, e.g., 5, 10)",
+                    "maximum": 9007199254740991,
                     "minimum": 1,
                     "type": "integer"
                   }

--- a/registries/toolhive/servers/sequentialthinking/server.json
+++ b/registries/toolhive/servers/sequentialthinking/server.json
@@ -3,7 +3,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.stacklok": {
-        "docker.io/mcp/sequentialthinking:latest": {
+        "ghcr.io/stacklok/dockyard/npx/server-sequential-thinking:2025.12.18": {
           "metadata": {
             "last_updated": "2026-04-19T03:04:11Z",
             "stars": 84056
@@ -108,7 +108,7 @@
   "name": "io.github.stacklok/sequentialthinking",
   "packages": [
     {
-      "identifier": "docker.io/mcp/sequentialthinking:latest",
+      "identifier": "ghcr.io/stacklok/dockyard/npx/server-sequential-thinking:2025.12.18",
       "registryType": "oci",
       "transport": {
         "type": "stdio"

--- a/registries/toolhive/servers/stripe/server.json
+++ b/registries/toolhive/servers/stripe/server.json
@@ -3,7 +3,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.stacklok": {
-        "docker.io/mcp/stripe:latest": {
+        "ghcr.io/stacklok/dockyard/npx/stripe-mcp:0.3.3": {
           "args": [
             "--tools=all"
           ],
@@ -782,7 +782,7 @@
           "name": "STRIPE_SECRET_KEY"
         }
       ],
-      "identifier": "docker.io/mcp/stripe:latest",
+      "identifier": "ghcr.io/stacklok/dockyard/npx/stripe-mcp:0.3.3",
       "registryType": "oci",
       "transport": {
         "type": "stdio"

--- a/registries/toolhive/servers/time/server.json
+++ b/registries/toolhive/servers/time/server.json
@@ -3,7 +3,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.stacklok": {
-        "docker.io/mcp/time:latest": {
+        "ghcr.io/stacklok/dockyard/uvx/mcp-server-time:2026.1.26": {
           "metadata": {
             "last_updated": "2026-04-18T03:03:09Z",
             "stars": 84011
@@ -95,7 +95,7 @@
   "name": "io.github.stacklok/time",
   "packages": [
     {
-      "identifier": "docker.io/mcp/time:latest",
+      "identifier": "ghcr.io/stacklok/dockyard/uvx/mcp-server-time:2026.1.26",
       "registryType": "oci",
       "transport": {
         "type": "stdio"

--- a/registries/toolhive/servers/time/server.json
+++ b/registries/toolhive/servers/time/server.json
@@ -5,7 +5,7 @@
       "io.github.stacklok": {
         "ghcr.io/stacklok/dockyard/uvx/mcp-server-time:2026.1.26": {
           "metadata": {
-            "last_updated": "2026-04-18T03:03:09Z",
+            "last_updated": "2026-05-29T13:16:13Z",
             "stars": 84011
           },
           "overview": "## Time MCP Server\n\nThe time MCP server provides time information and IANA timezone conversions with auto system timezone detection. The server leverages Python's timezone libraries to deliver current time queries across any IANA timezone with automatic detection of the system's local timezone when none is specified, time conversion capabilities between different timezones, timezone-aware datetime strings formatted in ISO 8601 standard, and Daylight Saving Time indicators. The server exposes two primary tools: get_current_time and convert_time.",
@@ -35,11 +35,11 @@
               "inputSchema": {
                 "properties": {
                   "source_timezone": {
-                    "description": "Source IANA timezone name (e.g., 'America/New_York', 'Europe/London'). Use 'UTC' as local timezone if no source timezone provided by the user.",
+                    "description": "Source IANA timezone name (e.g., 'America/New_York', 'Europe/London'). Use 'Etc/UTC' as local timezone if no source timezone provided by the user.",
                     "type": "string"
                   },
                   "target_timezone": {
-                    "description": "Target IANA timezone name (e.g., 'Asia/Tokyo', 'America/San_Francisco'). Use 'UTC' as local timezone if no target timezone provided by the user.",
+                    "description": "Target IANA timezone name (e.g., 'Asia/Tokyo', 'America/San_Francisco'). Use 'Etc/UTC' as local timezone if no target timezone provided by the user.",
                     "type": "string"
                   },
                   "time": {
@@ -62,7 +62,7 @@
               "inputSchema": {
                 "properties": {
                   "timezone": {
-                    "description": "IANA timezone name (e.g., 'America/New_York', 'Europe/London'). Use 'UTC' as local timezone if no timezone provided by the user.",
+                    "description": "IANA timezone name (e.g., 'America/New_York', 'Europe/London'). Use 'Etc/UTC' as local timezone if no timezone provided by the user.",
                     "type": "string"
                   }
                 },


### PR DESCRIPTION
## Summary

Migrates 10 of the 14 `:latest`-pinned catalog entries to versioned identifiers. This is the catalog-side half of the supply-chain-hygiene work tracked in #1233. The image side already landed in [stacklok/dockyard#663](https://github.com/stacklok/dockyard/pull/663) (8 wrapper images live on `ghcr.io/stacklok/dockyard/...`).

## Group A — dockyard wrappers (8)

| Server | Before | After |
|---|---|---|
| `everything` | `docker.io/mcp/everything:latest` | `ghcr.io/stacklok/dockyard/npx/server-everything:2026.1.26` |
| `memory` | `docker.io/mcp/memory:latest` | `ghcr.io/stacklok/dockyard/npx/server-memory:2026.1.26` |
| `sequentialthinking` | `docker.io/mcp/sequentialthinking:latest` | `ghcr.io/stacklok/dockyard/npx/server-sequential-thinking:2025.12.18` |
| `git` | `docker.io/mcp/git:latest` | `ghcr.io/stacklok/dockyard/uvx/mcp-server-git:2026.1.14` |
| `time` | `docker.io/mcp/time:latest` | `ghcr.io/stacklok/dockyard/uvx/mcp-server-time:2026.1.26` |
| `stripe` | `docker.io/mcp/stripe:latest` | `ghcr.io/stacklok/dockyard/npx/stripe-mcp:0.3.3` |
| `redis` | `docker.io/mcp/redis:latest` | `ghcr.io/stacklok/dockyard/uvx/redis-mcp-server:0.5.0` |
| `perplexity-ask` | `docker.io/mcp/perplexity-ask:latest` | `ghcr.io/stacklok/dockyard/npx/perplexity-ask:0.9.0` |

## Group B — direct vendor-semver bumps (2)

These servers' upstream vendors already publish proper semver on their existing registries; no dockyard wrapper needed.

| Server | Before | After |
|---|---|---|
| `crowdstrike-falcon` | `quay.io/crowdstrike/falcon-mcp:latest` | `quay.io/crowdstrike/falcon-mcp:0.10.0` |
| `semgrep` | `semgrep/semgrep:latest` | `docker.io/semgrep/semgrep:1.164.0` |

## Bonus metadata fix

`perplexity-ask` `repository.url` corrected:
- Before: `https://github.com/ppl-ai/modelcontextprotocol` (stale, no releases ever)
- After: `https://github.com/perplexityai/modelcontextprotocol` (current vendor-maintained repo)

Done in both `official/` and `toolhive/` registry copies.

## Out of scope — deliberately left on `:latest`

The remaining 4 entries pinned to `:latest` are excluded **by design** from this PR:

| Server | Why | Tracking |
|---|---|---|
| `cloud-run-mcp` | `google-proto-files@5.0.0` (DIRECT dep) pulls in `protobufjs@7.5.4` with `GHSA-xq3m-2v4x-88gg` (CRITICAL) + 4 HIGH. `google-proto-files` was deprecated by Google in Dec 2025. Fix requires Google migrating off it in cloud-run-mcp. | upstream issue (to be filed) |
| `firecrawl-mcp` | `@modelcontextprotocol/sdk@1.18.0` pulled in via `firecrawl-fastmcp@1.0.5` (a stale fork of `punkpeye/fastmcp` with no public source repo), with 3 HIGH GHSAs. Fix requires migrating firecrawl-mcp to upstream `fastmcp@4.x`. | upstream issue (to be filed) |
| `sonarqube` | Vendor publishes only Java JAR via GitHub Releases; no npm/PyPI from vendor. Dockyard needs a new `jar/` protocol first (separate work in `stacklok/toolhive` + dockyard). | follow-up RFC |
| `netbird` | Upstream `aantti/mcp-netbird` has 0 tags / 0 releases / no npm publication; repo dormant since 2025-04-16. Being removed entirely in #1239. | #1239 |

Each is documented in #1233.

## Files changed

- **15 source `server.json` files** (5 `toolhive/`-only + 5 in **both** `toolhive/` and `official/`, i.e. 5 + 10 = 15)
- **2 generated blobs** (`pkg/catalog/{official,toolhive}/data/registry-upstream.json`) regenerated locally via `task catalog:build` so the embedded blob in this PR matches the source files (instead of waiting for the nightly auto-PR)

For each `server.json`, the change happens in two places: the `_meta."io.modelcontextprotocol.registry/publisher-provided"."io.github.stacklok"` object **key** AND the `packages[0].identifier` field.

## Cross-repo impact

- `stacklok/stacklok-enterprise-platform` E2E workflow (`.github/workflows/_ui-e2e-checks.yml`) currently does `docker pull docker.io/mcp/everything:latest` as a CI cache warm. After this PR ships, that line should change to `docker pull ghcr.io/stacklok/dockyard/npx/server-everything:2026.1.26`. **Separate PR will follow.**
- `stacklok/stacklok-enterprise-platform` cloud-ui has an MSW mock fixture (`src/mocks/fixtures/registry/registry_registryName_v0_1_servers/get.ts:680`) referencing `semgrep/semgrep:latest`. Will be auto-regenerated by `pnpm generate-client` or manually updated in the same follow-up.

## Refs

- Tracking: #1233
- Dockyard wrappers: stacklok/dockyard#663 (merged)
- Netbird removal: #1239 (parallel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
