### PR TITLE
Add GetXAPI remote MCP server

### DIFF
--- a/registries/toolhive/servers/getxapi-remote/server.json
+++ b/registries/toolhive/servers/getxapi-remote/server.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "io.github.stacklok": {
+        "https://api.getxapi.com/mcp": {
+          "custom_metadata": {
+            "author": "GetXAPI",
+            "homepage": "https://github.com/getxapi/getxapi-mcp",
+            "license": "MIT"
+          },
+          "metadata": {
+            "last_updated": "2026-05-31T00:00:00Z"
+          },
+          "overview": "## GetXAPI Remote MCP Server\n\nGetXAPI's remote MCP server provides Bearer-token authenticated access to X data through Streamable HTTP. It exposes structured tweet search via the `advanced_search` endpoint and related read tools.",
+          "status": "Active",
+          "tags": [
+            "remote",
+            "twitter",
+            "social-media",
+            "data-extraction",
+            "search",
+            "api"
+          ],
+          "tier": "Community",
+          "tools": [
+            "advanced_search"
+          ]
+        }
+      }
+    }
+  },
+  "description": "Remote X data search and read access via GetXAPI",
+  "icons": [
+    {
+      "mimeType": "image/svg+xml",
+      "sizes": [
+        "any"
+      ],
+      "src": "https://getxapi.com/icon.svg"
+    }
+  ],
+  "name": "io.github.stacklok/getxapi-remote",
+  "remotes": [
+    {
+      "headers": [
+        {
+          "description": "GetXAPI API key from your dashboard account page",
+          "isRequired": true,
+          "isSecret": true,
+          "name": "Authorization",
+          "value": "Bearer {GETXAPI_API_KEY}",
+          "variables": {
+            "GETXAPI_API_KEY": {
+              "description": "Your GetXAPI API key",
+              "isSecret": true
+            }
+          }
+        }
+      ],
+      "type": "streamable-http",
+      "url": "https://api.getxapi.com/mcp"
+    }
+  ],
+  "repository": {
+    "source": "github",
+    "url": "https://github.com/getxapi/getxapi-mcp"
+  },
+  "title": "GetXAPI (Remote)",
+  "version": "1.0.0",
+  "websiteUrl": "https://github.com/getxapi/getxapi-mcp"
+}


### PR DESCRIPTION
## Summary

- Add `registries/toolhive/servers/getxapi-remote/server.json` describing the GetXAPI remote MCP server, alongside the Xquik entry in PR #1231.
- Streamable-http transport against `https://api.getxapi.com/mcp` with Bearer auth via `GETXAPI_API_KEY`.
- Read-only X/Twitter search; tweet search via `GET /twitter/tweet/advanced_search`.

## Validation

- `git diff --check` (whitespace)
- JSON parse check
- Shape matches sibling entries in `registries/toolhive/servers/`

## Backward compatibility

Fully backward compatible. New directory, no existing files changed.

## Links

- Endpoint: `GET https://api.getxapi.com/twitter/tweet/advanced_search`
- Auth: Bearer token
- Repo: https://github.com/getxapi/getxapi-mcp
- Wikidata: https://www.wikidata.org/wiki/Q139996278
- Crunchbase: https://www.crunchbase.com/organization/getxapi

I checked existing GetXAPI / TwitterAPI.io / Xquik / TweetClaw / Hermes Tweet code, open PRs, closed PRs, open issues, and closed issues in this repository before opening this PR. No existing GetXAPI submission found.