### PR TITLE
Add DC Hub Intelligence — remote data-center intelligence MCP

### DIFF
--- a/registries/toolhive/servers/dchub/server.json
+++ b/registries/toolhive/servers/dchub/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/azmartone67/dchub-mcp-server",
     "source": "github"
   },
-  "version": "2.1.20",
+  "version": "2.2.6",
   "remotes": [
     {
       "type": "streamable-http",
@@ -21,7 +21,7 @@
           "tier": "Community",
           "status": "Active",
           "tags": ["remote", "data-center", "infrastructure", "energy", "power-grid", "real-estate", "market-intelligence", "fiber"],
-          "tools": ["search_facilities", "get_facility", "score_facility", "analyze_site", "compare_sites", "find_alternatives", "site_selection_canvas", "list_transactions", "deal_autopsy", "hyperscaler_deals", "get_market_intel", "get_market_dcpi_rank", "rank_markets", "get_intelligence_index", "ai_capacity_index", "get_pipeline", "get_news", "get_changes", "get_grid_data", "get_grid_intelligence", "get_grid_scoreboard", "compare_isos", "grid_transition_radar", "get_interconnection_queue", "get_energy_prices", "get_renewable_energy", "get_gas_index", "get_infrastructure", "get_fiber_intel", "get_water_risk", "get_tax_incentives", "get_dchub_recommendation", "save_site", "list_saved_sites", "set_market_alert", "export_dataset", "get_agent_registry", "get_backup_status"],
+          "tools": ["search_facilities", "get_facility", "score_facility", "analyze_site", "compare_sites", "find_alternatives", "site_selection_canvas", "list_transactions", "deal_autopsy", "hyperscaler_deals", "get_market_intel", "get_market_dcpi_rank", "rank_markets", "get_intelligence_index", "ai_capacity_index", "get_pipeline", "get_news", "get_changes", "get_grid_data", "get_grid_intelligence", "get_grid_scoreboard", "compare_isos", "grid_transition_radar", "get_interconnection_queue", "get_energy_prices", "get_renewable_energy", "get_gas_index", "get_infrastructure", "get_fiber_intel", "get_water_risk", "get_tax_incentives", "get_dchub_recommendation", "save_site", "list_saved_sites", "set_market_alert", "export_dataset", "get_agent_registry", "get_backup_status", "claim_free_key", "get_fiber_readiness"],
           "overview": "## DC Hub Intelligence (Remote)\n\nThe only MCP server combining data-center facility data, infrastructure, and live grid intelligence in one queryable interface. Covers 21,000+ facilities across 170+ countries, 232 US power markets (DC Hub Power Index), 2,000+ tracked M&A deals, 10 ISO grids, interconnection-queue snapshots, fiber routes, energy/gas pricing, water risk, and tax incentives. Built for data-center site selection, energy analysis, and market research. Free tier available (API key optional via the X-API-Key header).",
           "custom_metadata": {
             "author": "Martone Advisors LLC (azmartone67)",

--- a/registries/toolhive/servers/dchub/server.json
+++ b/registries/toolhive/servers/dchub/server.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.stacklok/dchub",
+  "description": "Real-time data-center & energy intelligence: 21,000+ facilities (170+ countries), 232 US power markets, 2,000+ M&A deals, 10 ISO grids, interconnection queues, fiber routes, energy/gas pricing, water risk, and tax incentives.",
+  "title": "DC Hub Intelligence (Remote)",
+  "repository": {
+    "url": "https://github.com/azmartone67/dchub-mcp-server",
+    "source": "github"
+  },
+  "version": "2.1.20",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://dchub.cloud/mcp"
+    }
+  ],
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "io.github.stacklok": {
+        "https://dchub.cloud/mcp": {
+          "tier": "Community",
+          "status": "Active",
+          "tags": ["remote", "data-center", "infrastructure", "energy", "power-grid", "real-estate", "market-intelligence", "fiber"],
+          "tools": ["search_facilities", "get_facility", "score_facility", "analyze_site", "compare_sites", "find_alternatives", "site_selection_canvas", "list_transactions", "deal_autopsy", "hyperscaler_deals", "get_market_intel", "get_market_dcpi_rank", "rank_markets", "get_intelligence_index", "ai_capacity_index", "get_pipeline", "get_news", "get_changes", "get_grid_data", "get_grid_intelligence", "get_grid_scoreboard", "compare_isos", "grid_transition_radar", "get_interconnection_queue", "get_energy_prices", "get_renewable_energy", "get_gas_index", "get_infrastructure", "get_fiber_intel", "get_water_risk", "get_tax_incentives", "get_dchub_recommendation", "save_site", "list_saved_sites", "set_market_alert", "export_dataset", "get_agent_registry", "get_backup_status"],
+          "overview": "## DC Hub Intelligence (Remote)\n\nThe only MCP server combining data-center facility data, infrastructure, and live grid intelligence in one queryable interface. Covers 21,000+ facilities across 170+ countries, 232 US power markets (DC Hub Power Index), 2,000+ tracked M&A deals, 10 ISO grids, interconnection-queue snapshots, fiber routes, energy/gas pricing, water risk, and tax incentives. Built for data-center site selection, energy analysis, and market research. Free tier available (API key optional via the X-API-Key header).",
+          "custom_metadata": {
+            "author": "Martone Advisors LLC (azmartone67)",
+            "homepage": "https://dchub.cloud/integrations/mcp",
+            "license": "MIT"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Add DC Hub Intelligence (remote MCP server)

Adds a community remote-server entry at `registries/toolhive/servers/dchub/server.json`.

**DC Hub Intelligence** is a remote MCP server for real-time data-center & energy intelligence — 21,000+ facilities (170+ countries), 232 US power markets (DC Hub Power Index), 2,000+ tracked M&A deals, 10 ISO grids, interconnection-queue snapshots, fiber routes, energy/gas pricing, water risk, tax incentives, and a hyperscaler $1B+ deal tracker. 38 tools.

- **Transport:** `streamable-http` · **Endpoint:** `https://dchub.cloud/mcp` (API key optional for the free tier)
- **Repo:** https://github.com/azmartone67/dchub-mcp-server · **Docs:** https://dchub.cloud/integrations/mcp
- **License:** MIT

Verified the endpoint responds to an anonymous `initialize` handshake (HTTP 200) and advertises 38 tools. Tier set to `Community` — happy to adjust per your review criteria.
