### PR TITLE
Add BuyWhere MCP server to community registry

### DIFF
--- a/registries/community/servers/buywhere-mcp/icon.svg
+++ b/registries/community/servers/buywhere-mcp/icon.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="#10B981"/>
+  <path d="M20 24h4l4 18h16l4-12H26" stroke="#fff" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <circle cx="28" cy="48" r="3" fill="#fff"/>
+  <circle cx="42" cy="48" r="3" fill="#fff"/>
+  <path d="M16 16h6l2 4" stroke="#fff" stroke-width="2" stroke-linecap="round" fill="none"/>
+</svg>

--- a/registries/community/servers/buywhere-mcp/server.json
+++ b/registries/community/servers/buywhere-mcp/server.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.BuyWhere/buywhere-mcp",
-  "title": "BuyWhere MCP",
-  "description": "Real-time product search and cross-border price comparison for AI agents across 50M+ products in 6 markets (SG, MY, TH, US, ID, AU). Connects to FairPrice, Lazada, Shopee, Amazon and 20+ other merchants.",
-  "version": "0.3.11",
+  "title": "BuyWhere MCP Server",
+  "description": "Open-source MCP server for AI agent commerce. Search 50M+ products across 6 markets.",
+  "version": "1.0.4",
   "repository": {
     "url": "https://github.com/BuyWhere/buywhere-mcp",
     "source": "github"
@@ -11,8 +11,8 @@
   "packages": [
     {
       "registryType": "npm",
-      "identifier": "buywhere-mcp-server",
-      "version": "0.3.11",
+      "identifier": "@buywhere/mcp-server",
+      "version": "0.3.7",
       "transport": {
         "type": "stdio"
       },
@@ -27,19 +27,27 @@
       ]
     }
   ],
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://api.buywhere.ai/mcp"
+    }
+  ],
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.BuyWhere": {
         "@buywhere/mcp-server": {
           "metadata": {
-            "last_updated": "2026-06-11T20:00:00Z",
+            "last_updated": "2026-06-12T00:00:00Z",
             "stars": 0
           },
-          "overview": "## BuyWhere MCP Server\n\nReal-time product search and price comparison across 6 markets. Connects AI agents to FairPrice, Lazada, Shopee, Amazon, and 20+ other merchants via MCP.\n\n**Key features:**\n- 50M+ products across SG, MY, TH, US, ID, AU\n- Hybrid FTS + vector search for accurate product matching\n- find_similar tool for cross-merchant price comparison\n- Free API tier (1K requests/month) for individual developers",
+          "overview": "## BuyWhere MCP Server\n\nOpen-source MCP server for AI agent commerce. Search 50M+ products across 6 markets.\n\n**Key features:**\n- 50M+ products across SG, MY, TH, US, ID, AU\n- Hybrid FTS + vector search for accurate product matching\n- find_similar tool for cross-merchant price comparison\n- Free API tier (1K requests/month) for individual developers",
           "permissions": {
             "network": {
               "outbound": {
-                "allow_port": [443]
+                "allow_port": [
+                  443
+                ]
               }
             }
           },

--- a/registries/community/servers/buywhere-mcp/server.json
+++ b/registries/community/servers/buywhere-mcp/server.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.BuyWhere/buywhere-mcp",
+  "title": "BuyWhere MCP",
+  "description": "Real-time product search and cross-border price comparison for AI agents across 50M+ products in 6 markets (SG, MY, TH, US, ID, AU). Connects to FairPrice, Lazada, Shopee, Amazon and 20+ other merchants.",
+  "version": "0.3.11",
+  "repository": {
+    "url": "https://github.com/BuyWhere/buywhere-mcp",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "buywhere-mcp-server",
+      "version": "0.3.11",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "description": "BuyWhere API key used for authenticated product catalog requests.",
+          "isRequired": true,
+          "format": "string",
+          "isSecret": true,
+          "name": "BUYWHERE_API_KEY"
+        }
+      ]
+    }
+  ],
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "io.github.BuyWhere": {
+        "@buywhere/mcp-server": {
+          "metadata": {
+            "last_updated": "2026-06-11T20:00:00Z",
+            "stars": 0
+          },
+          "overview": "## BuyWhere MCP Server\n\nReal-time product search and price comparison across 6 markets. Connects AI agents to FairPrice, Lazada, Shopee, Amazon, and 20+ other merchants via MCP.\n\n**Key features:**\n- 50M+ products across SG, MY, TH, US, ID, AU\n- Hybrid FTS + vector search for accurate product matching\n- find_similar tool for cross-merchant price comparison\n- Free API tier (1K requests/month) for individual developers",
+          "permissions": {
+            "network": {
+              "outbound": {
+                "allow_port": [443]
+              }
+            }
+          },
+          "status": "Active",
+          "tags": [
+            "ecommerce",
+            "product-search",
+            "price-comparison",
+            "mcp",
+            "typescript",
+            "singapore",
+            "southeast-asia"
+          ],
+          "tier": "Community",
+          "tools": [
+            "search_product",
+            "find_similar",
+            "compare_prices"
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Add BuyWhere MCP server to community registry

This PR adds the BuyWhere MCP server to the ToolHive community registry.

### About BuyWhere MCP Server
Real-time product search and cross-border price comparison for AI agents across 50M+ products in 6 markets (SG, MY, TH, US, ID, AU). Connects to FairPrice, Lazada, Shopee, Amazon and 20+ other merchants.

### Details
- **Name:** `io.github.BuyWhere/buywhere-mcp`
- **Version:** 0.3.11
- **NPM:** `@buywhere/mcp-server` (https://www.npmjs.com/package/@buywhere/mcp-server)
- **Official MCP Registry:** `ai.buywhere/buywhere-mcp` (https://registry.modelcontextprotocol.io)
- **GitHub:** https://github.com/BuyWhere/buywhere-mcp
- **License:** MIT
- **Open source:** Yes (https://github.com/BuyWhere/buywhere-mcp)

### Tools exposed
- `search_product` — Search the BuyWhere product catalog
- `find_similar` — Find similar products across merchants (hybrid FTS + vector)
- `compare_prices` — Cross-merchant price comparison

### Files added
- `registries/community/servers/buywhere-mcp/server.json` — Server definition following the MCP ServerJSON schema
- `registries/community/servers/buywhere-mcp/icon.svg` — BuyWhere brand icon (green shopping cart)

### Validation
Server.json follows the official MCP ServerJSON schema (https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json). The server is also already published in the official MCP Registry as `ai.buywhere/buywhere-mcp`.

Happy to make any adjustments to the entry.
