### PR TITLE
chore(ci): switch to official go-task/setup-task action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         continue-on-error: true
 
       - name: Install Task
-        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
+        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
 
       - name: Validate catalog entries
         run: task catalog:validate
@@ -114,7 +114,7 @@ jobs:
           cache: true
 
       - name: Install Task
-        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
+        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
 
       - name: Build registry files
         run: |
@@ -206,7 +206,7 @@ jobs:
           cache: true
 
       - name: Install Task
-        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
+        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
 
       - name: Build catalog files
         run: task catalog:build


### PR DESCRIPTION
## Summary

Switches the `Install Task` step in `.github/workflows/ci.yml` from the third-party `arduino/setup-task` action to the official `go-task/setup-task` action maintained by the upstream Task project.

### Why

- `arduino/setup-task` still runs on Node 20, which is deprecated on GitHub Actions runners (the CI logs already emit a deprecation warning).
- `go-task/setup-task` is the official action from the `go-task` organization and runs on Node 24.
- The official action is a drop-in replacement: same `version` input, defaults to `3.x`.

### What changed

`.github/workflows/ci.yml` — three occurrences of:
```yaml
uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
```
replaced with:
```yaml
uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
```

No input changes — both actions default to Task `3.x`.

### Verification

Pinned to the `v2.1.0` tag commit (`01a4adf`), consistent with the repo's SHA-pinning convention for actions.