### PR TITLE
Fix env-var and network-permission drift in community servers

### DIFF
--- a/registries/toolhive/servers/arxiv-mcp-server/server.json
+++ b/registries/toolhive/servers/arxiv-mcp-server/server.json
@@ -9,7 +9,7 @@
             "/arxiv-papers"
           ],
           "metadata": {
-            "last_updated": "2026-04-27T15:02:03Z",
+            "last_updated": "2026-06-26T19:45:20Z",
             "stars": 2509
           },
           "overview": "## arXiv MCP Server\n\nThe arxiv-mcp-server is a Model Context Protocol (MCP) server that enables AI assistants and agents to programmatically access the arXiv research repository — one of the largest open archives of scientific papers — via a simple MCP interface. It lets AI workflows search for academic papers, download and read their content, and manage collected research, all without switching tools or manually scraping content.",

--- a/registries/toolhive/servers/arxiv-mcp-server/server.json
+++ b/registries/toolhive/servers/arxiv-mcp-server/server.json
@@ -18,7 +18,8 @@
               "outbound": {
                 "allow_host": [
                   "arxiv.org",
-                  "export.arxiv.org"
+                  "export.arxiv.org",
+                  "api.semanticscholar.org"
                 ],
                 "allow_port": [
                   443,

--- a/registries/toolhive/servers/brightdata-mcp/server.json
+++ b/registries/toolhive/servers/brightdata-mcp/server.json
@@ -14,11 +14,13 @@
               "outbound": {
                 "allow_host": [
                   "api.brightdata.com",
-                  "brightdata.com"
+                  "brightdata.com",
+                  "brd.superproxy.io"
                 ],
                 "allow_port": [
                   443,
-                  80
+                  80,
+                  9222
                 ]
               }
             }

--- a/registries/toolhive/servers/magic-mcp/server.json
+++ b/registries/toolhive/servers/magic-mcp/server.json
@@ -14,7 +14,9 @@
               "outbound": {
                 "allow_host": [
                   "21st.dev",
-                  "api.21st.dev"
+                  "api.21st.dev",
+                  "magic.21st.dev",
+                  "api.svgl.app"
                 ],
                 "allow_port": [
                   443,

--- a/registries/toolhive/servers/mcp-neo4j-aura-manager/server.json
+++ b/registries/toolhive/servers/mcp-neo4j-aura-manager/server.json
@@ -14,7 +14,6 @@
               "outbound": {
                 "allow_host": [
                   "api.neo4j.io",
-                  "console.neo4j.io",
                   ".neo4j.io"
                 ],
                 "allow_port": [
@@ -71,18 +70,13 @@
           "description": "Neo4j Aura API client ID",
           "isRequired": true,
           "isSecret": true,
-          "name": "AURA_CLIENT_ID"
+          "name": "NEO4J_AURA_CLIENT_ID"
         },
         {
           "description": "Neo4j Aura API client secret",
           "isRequired": true,
           "isSecret": true,
-          "name": "AURA_CLIENT_SECRET"
-        },
-        {
-          "description": "Neo4j Aura tenant ID",
-          "isSecret": true,
-          "name": "AURA_TENANT_ID"
+          "name": "NEO4J_AURA_CLIENT_SECRET"
         }
       ],
       "identifier": "ghcr.io/stacklok/dockyard/uvx/mcp-neo4j-aura-manager:0.4.8",

--- a/registries/toolhive/servers/mcp-neo4j-aura-manager/server.json
+++ b/registries/toolhive/servers/mcp-neo4j-aura-manager/server.json
@@ -5,7 +5,7 @@
       "io.github.stacklok": {
         "ghcr.io/stacklok/dockyard/uvx/mcp-neo4j-aura-manager:0.4.8": {
           "metadata": {
-            "last_updated": "2026-04-13T03:04:50Z",
+            "last_updated": "2026-06-26T19:45:32Z",
             "stars": 936
           },
           "overview": "## Neo4j Aura Manager MCP Server\n\nThe mcp-neo4j-aura-manager is a Model Context Protocol (MCP) server that enables AI assistants and agents to interact directly with Neo4j Aura, Neo4j's fully managed cloud database service. The server facilitates AI-driven workflows to manage Aura database instances, including their lifecycle, configuration, and operational status. Key capabilities include database visibility, operational awareness, lifecycle management, organizational context, and AI-assisted administration.",
@@ -39,14 +39,336 @@
             "management"
           ],
           "tier": "Community",
+          "tool_definitions": [
+            {
+              "annotations": {
+                "destructiveHint": false,
+                "idempotentHint": true,
+                "openWorldHint": true,
+                "readOnlyHint": false,
+                "title": "Create Instance"
+              },
+              "description": "Create a new Neo4j Aura database instance.",
+              "inputSchema": {
+                "properties": {
+                  "cloud_provider": {
+                    "default": "gcp",
+                    "description": "Cloud provider (gcp, aws, azure)",
+                    "type": "string"
+                  },
+                  "graph_analytics_plugin": {
+                    "default": false,
+                    "description": "Whether to enable the graph analytics plugin",
+                    "type": "boolean"
+                  },
+                  "memory": {
+                    "default": 1,
+                    "description": "Memory allocation in GB",
+                    "type": "integer"
+                  },
+                  "name": {
+                    "description": "Name for the new instance",
+                    "type": "string"
+                  },
+                  "region": {
+                    "default": "us-central1",
+                    "description": "Region for the instance (e.g., 'us-central1')",
+                    "type": "string"
+                  },
+                  "source_instance_id": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "ID of the source instance to clone from"
+                  },
+                  "tenant_id": {
+                    "description": "ID of the tenant/project where the instance will be created",
+                    "type": "string"
+                  },
+                  "type": {
+                    "default": "free-db",
+                    "description": "Instance type (free-db, professional-db, enterprise-db, or business-critical)",
+                    "type": "string"
+                  },
+                  "vector_optimized": {
+                    "default": false,
+                    "description": "Whether the instance is optimized for vector operations",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "tenant_id",
+                  "name"
+                ],
+                "type": "object"
+              },
+              "name": "create_instance"
+            },
+            {
+              "annotations": {
+                "destructiveHint": true,
+                "idempotentHint": true,
+                "openWorldHint": true,
+                "readOnlyHint": false,
+                "title": "Delete Instance"
+              },
+              "description": "Delete a Neo4j Aura database instance.",
+              "inputSchema": {
+                "properties": {
+                  "instance_id": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "instance_id"
+                ],
+                "type": "object"
+              },
+              "name": "delete_instance"
+            },
+            {
+              "annotations": {
+                "destructiveHint": false,
+                "idempotentHint": true,
+                "openWorldHint": true,
+                "readOnlyHint": true,
+                "title": "Get Instance by Name"
+              },
+              "description": "Find a Neo4j Aura instance by name and returns the details including the id.",
+              "inputSchema": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object"
+              },
+              "name": "get_instance_by_name"
+            },
+            {
+              "annotations": {
+                "destructiveHint": false,
+                "idempotentHint": true,
+                "openWorldHint": true,
+                "readOnlyHint": true,
+                "title": "Get Instance Details"
+              },
+              "description": "Get details for one or more Neo4j Aura instances by ID.",
+              "inputSchema": {
+                "properties": {
+                  "instance_ids": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "instance_ids"
+                ],
+                "type": "object"
+              },
+              "name": "get_instance_details"
+            },
+            {
+              "annotations": {
+                "destructiveHint": false,
+                "idempotentHint": true,
+                "openWorldHint": true,
+                "readOnlyHint": true,
+                "title": "Get Tenant Details"
+              },
+              "description": "Get details for a specific Neo4j Aura tenant/project.",
+              "inputSchema": {
+                "properties": {
+                  "tenant_id": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "tenant_id"
+                ],
+                "type": "object"
+              },
+              "name": "get_tenant_details"
+            },
+            {
+              "annotations": {
+                "destructiveHint": false,
+                "idempotentHint": true,
+                "openWorldHint": true,
+                "readOnlyHint": true,
+                "title": "List Instances"
+              },
+              "description": "List all Neo4j Aura database instances.",
+              "inputSchema": {
+                "properties": {},
+                "required": [],
+                "type": "object"
+              },
+              "name": "list_instances"
+            },
+            {
+              "annotations": {
+                "destructiveHint": false,
+                "idempotentHint": true,
+                "openWorldHint": true,
+                "readOnlyHint": true,
+                "title": "List Tenants"
+              },
+              "description": "List all Neo4j Aura tenants/projects.",
+              "inputSchema": {
+                "properties": {},
+                "required": [],
+                "type": "object"
+              },
+              "name": "list_tenants"
+            },
+            {
+              "annotations": {
+                "destructiveHint": false,
+                "idempotentHint": true,
+                "openWorldHint": true,
+                "readOnlyHint": false,
+                "title": "Pause Instance"
+              },
+              "description": "Pause a Neo4j Aura database instance.",
+              "inputSchema": {
+                "properties": {
+                  "instance_id": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "instance_id"
+                ],
+                "type": "object"
+              },
+              "name": "pause_instance"
+            },
+            {
+              "annotations": {
+                "destructiveHint": false,
+                "idempotentHint": true,
+                "openWorldHint": true,
+                "readOnlyHint": false,
+                "title": "Resume Instance"
+              },
+              "description": "Resume a paused Neo4j Aura database instance.",
+              "inputSchema": {
+                "properties": {
+                  "instance_id": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "instance_id"
+                ],
+                "type": "object"
+              },
+              "name": "resume_instance"
+            },
+            {
+              "annotations": {
+                "destructiveHint": true,
+                "idempotentHint": true,
+                "openWorldHint": true,
+                "readOnlyHint": false,
+                "title": "Update Instance Memory"
+              },
+              "description": "Update the memory allocation of a Neo4j Aura instance.",
+              "inputSchema": {
+                "properties": {
+                  "instance_id": {
+                    "type": "string"
+                  },
+                  "memory": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "instance_id",
+                  "memory"
+                ],
+                "type": "object"
+              },
+              "name": "update_instance_memory"
+            },
+            {
+              "annotations": {
+                "destructiveHint": true,
+                "idempotentHint": true,
+                "openWorldHint": true,
+                "readOnlyHint": false,
+                "title": "Update Instance Name"
+              },
+              "description": "Update the name of a Neo4j Aura instance.",
+              "inputSchema": {
+                "properties": {
+                  "instance_id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "instance_id",
+                  "name"
+                ],
+                "type": "object"
+              },
+              "name": "update_instance_name"
+            },
+            {
+              "annotations": {
+                "destructiveHint": true,
+                "idempotentHint": true,
+                "openWorldHint": true,
+                "readOnlyHint": false,
+                "title": "Update Instance Vector Optimization"
+              },
+              "description": "Update the vector optimization setting of a Neo4j Aura instance.",
+              "inputSchema": {
+                "properties": {
+                  "instance_id": {
+                    "type": "string"
+                  },
+                  "vector_optimized": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "instance_id",
+                  "vector_optimized"
+                ],
+                "type": "object"
+              },
+              "name": "update_instance_vector_optimization"
+            }
+          ],
           "tools": [
-            "list_instances",
             "create_instance",
             "delete_instance",
-            "get_instance",
-            "update_instance",
-            "scale_instance",
-            "enable_features"
+            "get_instance_by_name",
+            "get_instance_details",
+            "get_tenant_details",
+            "list_instances",
+            "list_tenants",
+            "pause_instance",
+            "resume_instance",
+            "update_instance_memory",
+            "update_instance_name",
+            "update_instance_vector_optimization"
           ]
         }
       }

--- a/registries/toolhive/servers/mcp-neo4j-memory/server.json
+++ b/registries/toolhive/servers/mcp-neo4j-memory/server.json
@@ -82,6 +82,11 @@
           "description": "Neo4j database password",
           "isSecret": true,
           "name": "NEO4J_PASSWORD"
+        },
+        {
+          "default": "neo4j",
+          "description": "Neo4j database name",
+          "name": "NEO4J_DATABASE"
         }
       ],
       "identifier": "ghcr.io/stacklok/dockyard/uvx/mcp-neo4j-memory:0.4.5",

--- a/registries/toolhive/servers/memory/server.json
+++ b/registries/toolhive/servers/memory/server.json
@@ -11,11 +11,7 @@
           "overview": "## Memory MCP Server\n\nThe memory MCP server provides AI assistants with persistent, long-term memory across interactions. It allows AI workflows to maintain context and knowledge beyond individual conversations, supporting personalization and enabling continuity in assistant interactions. The system works by running as an MCP service that manages persistent storage, handling indexing and retrieval so AI clients can access historical context during reasoning tasks — enabling assistants to develop awareness of user preferences and prior decisions over extended periods.",
           "permissions": {
             "network": {
-              "outbound": {
-                "allow_port": [
-                  443
-                ]
-              }
+              "outbound": {}
             }
           },
           "status": "Active",

--- a/registries/toolhive/servers/memory/server.json
+++ b/registries/toolhive/servers/memory/server.json
@@ -5,7 +5,7 @@
       "io.github.stacklok": {
         "ghcr.io/stacklok/dockyard/npx/server-memory:2026.1.26": {
           "metadata": {
-            "last_updated": "2026-05-29T13:15:41Z",
+            "last_updated": "2026-06-26T19:44:53Z",
             "stars": 85231
           },
           "overview": "## Memory MCP Server\n\nThe memory MCP server provides AI assistants with persistent, long-term memory across interactions. It allows AI workflows to maintain context and knowledge beyond individual conversations, supporting personalization and enabling continuity in assistant interactions. The system works by running as an MCP service that manages persistent storage, handling indexing and retrieval so AI clients can access historical context during reasoning tasks — enabling assistants to develop awareness of user preferences and prior decisions over extended periods.",

--- a/registries/toolhive/servers/uyuni/server.json
+++ b/registries/toolhive/servers/uyuni/server.json
@@ -100,6 +100,16 @@
         {
           "description": "Enable write tools for state-changing operations (default: false)",
           "name": "UYUNI_MCP_WRITE_TOOLS_ENABLED"
+        },
+        {
+          "description": "SSH private key used by the add_system tool to bootstrap new systems into Uyuni",
+          "isSecret": true,
+          "name": "UYUNI_SSH_PRIV_KEY"
+        },
+        {
+          "description": "Passphrase for UYUNI_SSH_PRIV_KEY when the key is encrypted",
+          "isSecret": true,
+          "name": "UYUNI_SSH_PRIV_KEY_PASS"
         }
       ],
       "identifier": "ghcr.io/uyuni-project/mcp-server-uyuni:0.5.2",


### PR DESCRIPTION
## What

Fixes config drift found by a `catalog-audit` sweep of the Community tier. **Every change was verified against the upstream source before applying.** Scope is limited to high-confidence, mechanical fixes; judgment calls (e.g. ida-pro's host-networking model, redfish's missing permissions block, gitlab self-hosted scoping) were left out for maintainer input.

### Network permissions
- **arxiv-mcp-server** - allow `api.semanticscholar.org`. The `citation_graph` tool calls it (`tools/citation_graph.py`) but it wasn't in `allow_host`, so that tool was blocked.
- **magic-mcp** - allow `magic.21st.dev` and `api.svgl.app`. The HTTP client (`utils/http-client.ts`) and logo-search tool (`tools/logo-search.ts`) target these; only `21st.dev`/`api.21st.dev` were allowed.
- **brightdata-mcp** - allow `brd.superproxy.io` and port `9222`. The browser tools connect over WebSocket (`browser_tools.js`); was blocked.
- **memory** - drop `allow_port: [443]`; the server makes no outbound calls (local knowledge-graph store).
- **mcp-neo4j-aura-manager** - drop unused `console.neo4j.io`.

### Environment variables
- **mcp-neo4j-aura-manager** - rename `AURA_CLIENT_ID`/`AURA_CLIENT_SECRET` to `NEO4J_AURA_CLIENT_ID`/`NEO4J_AURA_CLIENT_SECRET`. Upstream reads the `NEO4J_AURA_*` names (`__init__.py:19,21`), so credentials passed under the declared names never reached the server. Also drop `AURA_TENANT_ID` (not an env var upstream; `tenant_id` is a tool parameter).
- **mcp-neo4j-memory** - add `NEO4J_DATABASE` (read by upstream `utils.py:75`; sibling `mcp-neo4j-cypher` already declares it).
- **uyuni** - add `UYUNI_SSH_PRIV_KEY` and `UYUNI_SSH_PRIV_KEY_PASS` (used by the `add_system` tool).

## Validation

`task catalog:validate` passes (all 110 toolhive servers + 129 skills valid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)