### PR TITLE
Update repository URLs for relocated upstream projects

### DIFF
--- a/registries/toolhive/servers/azure/server.json
+++ b/registries/toolhive/servers/azure/server.json
@@ -2287,7 +2287,7 @@
   ],
   "repository": {
     "source": "github",
-    "url": "https://github.com/Azure/azure-mcp"
+    "url": "https://github.com/microsoft/mcp"
   },
   "title": "Azure",
   "version": "1.0.0"

--- a/registries/toolhive/servers/azure/server.json
+++ b/registries/toolhive/servers/azure/server.json
@@ -5,7 +5,7 @@
       "io.github.stacklok": {
         "mcr.microsoft.com/azure-sdk/azure-mcp:2.0.4": {
           "metadata": {
-            "last_updated": "2026-06-25T04:21:16Z",
+            "last_updated": "2026-06-26T20:32:52Z",
             "stars": 1206
           },
           "overview": "## Azure MCP Server\n\nThe azure MCP server is a Model Context Protocol (MCP) server that enables AI assistants and agents to interact directly with Microsoft Azure resources and APIs through a unified, AI-friendly interface. It allows natural-language workflows to explore, query, and manage Azure infrastructure and services without requiring custom SDK integration or manual portal usage. This server is well suited for cloud operations, infrastructure exploration, troubleshooting, and automation scenarios where Azure context needs to be embedded directly into AI-driven workflows.",

--- a/registries/toolhive/servers/semgrep-remote/server.json
+++ b/registries/toolhive/servers/semgrep-remote/server.json
@@ -59,7 +59,7 @@
   ],
   "repository": {
     "source": "github",
-    "url": "https://github.com/semgrep/mcp"
+    "url": "https://github.com/semgrep/semgrep"
   },
   "title": "Semgrep (Remote)",
   "version": "1.0.0"


### PR DESCRIPTION
## What

A `catalog-audit` sweep of the Official tier flagged two entries whose `repository.url` points at an **archived** upstream that has since moved. Both fixes are just the repo link; the actual artifacts are unaffected.

- **azure** - `Azure/azure-mcp` is archived; the project moved into the **`microsoft/mcp`** monorepo. The image (`mcr.microsoft.com/azure-sdk/azure-mcp`) still resolves and is unchanged.
- **semgrep-remote** - `semgrep/mcp` is archived; the server moved into the main **`semgrep/semgrep`** repo (`cli/src/semgrep/mcp`). The remote endpoint (`mcp.semgrep.ai`) is unchanged.

Both new targets are confirmed live (not archived). `task catalog:validate` passes.

Not included (handled separately): **excalidraw** (image never published to dockyard - removal PR) and **mcp-server-box** (migrated to a hosted remote server - separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)