### PR TITLE
Add missing connector auth env vars to graphlit

### DIFF
--- a/registries/official/servers/graphlit/server.json
+++ b/registries/official/servers/graphlit/server.json
@@ -5,7 +5,7 @@
       "io.github.stacklok": {
         "ghcr.io/stacklok/dockyard/npx/graphlit-mcp-server:1.0.20260112001": {
           "metadata": {
-            "last_updated": "2026-06-26T21:25:31Z",
+            "last_updated": "2026-06-26T21:29:38Z",
             "stars": 375
           },
           "overview": "## Graphlit MCP Server\n\nThe graphlit MCP server is a Model Context Protocol (MCP) server that enables AI assistants and agents to interact directly with Graphlit, a platform for ingesting, processing, organizing, and querying unstructured content using knowledge graphs and embeddings. It allows AI-driven workflows to load documents, media, and web content into Graphlit and then reason over that content using structured queries — without building custom ingestion or retrieval pipelines. This server is especially useful for knowledge management, content intelligence, retrieval-augmented generation (RAG), and research workflows that span large, heterogeneous content collections.",

--- a/registries/official/servers/graphlit/server.json
+++ b/registries/official/servers/graphlit/server.json
@@ -5,8 +5,8 @@
       "io.github.stacklok": {
         "ghcr.io/stacklok/dockyard/npx/graphlit-mcp-server:1.0.20260112001": {
           "metadata": {
-            "last_updated": "2026-05-29T03:21:49Z",
-            "stars": 376
+            "last_updated": "2026-06-26T21:25:31Z",
+            "stars": 375
           },
           "overview": "## Graphlit MCP Server\n\nThe graphlit MCP server is a Model Context Protocol (MCP) server that enables AI assistants and agents to interact directly with Graphlit, a platform for ingesting, processing, organizing, and querying unstructured content using knowledge graphs and embeddings. It allows AI-driven workflows to load documents, media, and web content into Graphlit and then reason over that content using structured queries — without building custom ingestion or retrieval pipelines. This server is especially useful for knowledge management, content intelligence, retrieval-augmented generation (RAG), and research workflows that span large, heterogeneous content collections.",
           "permissions": {
@@ -2178,6 +2178,132 @@
           "description": "Notion API key for Notion integration",
           "isSecret": true,
           "name": "NOTION_API_KEY"
+        },
+        {
+          "description": "Box OAuth client ID for Box content ingestion",
+          "name": "BOX_CLIENT_ID"
+        },
+        {
+          "description": "Box OAuth client secret for Box content ingestion",
+          "isSecret": true,
+          "name": "BOX_CLIENT_SECRET"
+        },
+        {
+          "description": "Box OAuth redirect URI for Box content ingestion",
+          "name": "BOX_REDIRECT_URI"
+        },
+        {
+          "description": "Box OAuth refresh token for Box content ingestion",
+          "isSecret": true,
+          "name": "BOX_REFRESH_TOKEN"
+        },
+        {
+          "description": "Dropbox app key for Dropbox content ingestion",
+          "isSecret": true,
+          "name": "DROPBOX_APP_KEY"
+        },
+        {
+          "description": "Dropbox app secret for Dropbox content ingestion",
+          "isSecret": true,
+          "name": "DROPBOX_APP_SECRET"
+        },
+        {
+          "description": "Dropbox OAuth refresh token for Dropbox content ingestion",
+          "isSecret": true,
+          "name": "DROPBOX_REFRESH_TOKEN"
+        },
+        {
+          "description": "Google Drive OAuth client ID for Google Drive content ingestion",
+          "name": "GOOGLE_DRIVE_CLIENT_ID"
+        },
+        {
+          "description": "Google Drive OAuth client secret for Google Drive content ingestion",
+          "isSecret": true,
+          "name": "GOOGLE_DRIVE_CLIENT_SECRET"
+        },
+        {
+          "description": "Google Drive folder ID for Google Drive content ingestion",
+          "name": "GOOGLE_DRIVE_FOLDER_ID"
+        },
+        {
+          "description": "Google Drive OAuth refresh token for Google Drive content ingestion",
+          "isSecret": true,
+          "name": "GOOGLE_DRIVE_REFRESH_TOKEN"
+        },
+        {
+          "description": "Google Drive service account JSON for Google Drive content ingestion",
+          "isSecret": true,
+          "name": "GOOGLE_DRIVE_SERVICE_ACCOUNT_JSON"
+        },
+        {
+          "description": "Microsoft Teams OAuth client ID for Microsoft Teams content ingestion",
+          "name": "MICROSOFT_TEAMS_CLIENT_ID"
+        },
+        {
+          "description": "Microsoft Teams OAuth client secret for Microsoft Teams content ingestion",
+          "isSecret": true,
+          "name": "MICROSOFT_TEAMS_CLIENT_SECRET"
+        },
+        {
+          "description": "Microsoft Teams OAuth refresh token for Microsoft Teams content ingestion",
+          "isSecret": true,
+          "name": "MICROSOFT_TEAMS_REFRESH_TOKEN"
+        },
+        {
+          "description": "OneDrive OAuth client ID for OneDrive content ingestion",
+          "name": "ONEDRIVE_CLIENT_ID"
+        },
+        {
+          "description": "OneDrive OAuth client secret for OneDrive content ingestion",
+          "isSecret": true,
+          "name": "ONEDRIVE_CLIENT_SECRET"
+        },
+        {
+          "description": "OneDrive folder ID for OneDrive content ingestion",
+          "name": "ONEDRIVE_FOLDER_ID"
+        },
+        {
+          "description": "OneDrive OAuth refresh token for OneDrive content ingestion",
+          "isSecret": true,
+          "name": "ONEDRIVE_REFRESH_TOKEN"
+        },
+        {
+          "description": "SharePoint account name for SharePoint content ingestion",
+          "name": "SHAREPOINT_ACCOUNT_NAME"
+        },
+        {
+          "description": "SharePoint OAuth client ID for SharePoint content ingestion",
+          "name": "SHAREPOINT_CLIENT_ID"
+        },
+        {
+          "description": "SharePoint OAuth client secret for SharePoint content ingestion",
+          "isSecret": true,
+          "name": "SHAREPOINT_CLIENT_SECRET"
+        },
+        {
+          "description": "SharePoint OAuth refresh token for SharePoint content ingestion",
+          "isSecret": true,
+          "name": "SHAREPOINT_REFRESH_TOKEN"
+        },
+        {
+          "description": "Twitter/X access token key for Twitter/X content ingestion",
+          "isSecret": true,
+          "name": "TWITTER_ACCESS_TOKEN_KEY"
+        },
+        {
+          "description": "Twitter/X access token secret for Twitter/X content ingestion",
+          "isSecret": true,
+          "name": "TWITTER_ACCESS_TOKEN_SECRET"
+        },
+        {
+          "description": "Twitter/X consumer API key for Twitter/X content ingestion",
+          "isSecret": true,
+          "name": "TWITTER_CONSUMER_API_KEY"
+        },
+        {
+          "description": "Twitter/X consumer API secret for Twitter/X content ingestion",
+          "isSecret": true,
+          "name": "TWITTER_CONSUMER_API_SECRET"
         }
       ],
       "identifier": "ghcr.io/stacklok/dockyard/npx/graphlit-mcp-server:1.0.20260112001",

--- a/registries/toolhive/servers/graphlit/server.json
+++ b/registries/toolhive/servers/graphlit/server.json
@@ -5,7 +5,7 @@
       "io.github.stacklok": {
         "ghcr.io/stacklok/dockyard/npx/graphlit-mcp-server:1.0.20260112001": {
           "metadata": {
-            "last_updated": "2026-05-06T20:56:32Z",
+            "last_updated": "2026-06-26T21:25:31Z",
             "stars": 375
           },
           "overview": "## Graphlit MCP Server\n\nThe graphlit MCP server is a Model Context Protocol (MCP) server that enables AI assistants and agents to interact directly with Graphlit, a platform for ingesting, processing, organizing, and querying unstructured content using knowledge graphs and embeddings. It allows AI-driven workflows to load documents, media, and web content into Graphlit and then reason over that content using structured queries — without building custom ingestion or retrieval pipelines. This server is especially useful for knowledge management, content intelligence, retrieval-augmented generation (RAG), and research workflows that span large, heterogeneous content collections.",

--- a/registries/toolhive/servers/graphlit/server.json
+++ b/registries/toolhive/servers/graphlit/server.json
@@ -5,7 +5,7 @@
       "io.github.stacklok": {
         "ghcr.io/stacklok/dockyard/npx/graphlit-mcp-server:1.0.20260112001": {
           "metadata": {
-            "last_updated": "2026-06-26T21:25:31Z",
+            "last_updated": "2026-06-26T21:29:29Z",
             "stars": 375
           },
           "overview": "## Graphlit MCP Server\n\nThe graphlit MCP server is a Model Context Protocol (MCP) server that enables AI assistants and agents to interact directly with Graphlit, a platform for ingesting, processing, organizing, and querying unstructured content using knowledge graphs and embeddings. It allows AI-driven workflows to load documents, media, and web content into Graphlit and then reason over that content using structured queries — without building custom ingestion or retrieval pipelines. This server is especially useful for knowledge management, content intelligence, retrieval-augmented generation (RAG), and research workflows that span large, heterogeneous content collections.",

--- a/registries/toolhive/servers/graphlit/server.json
+++ b/registries/toolhive/servers/graphlit/server.json
@@ -2178,6 +2178,132 @@
           "description": "Notion API key for Notion integration",
           "isSecret": true,
           "name": "NOTION_API_KEY"
+        },
+        {
+          "description": "Box OAuth client ID for Box content ingestion",
+          "name": "BOX_CLIENT_ID"
+        },
+        {
+          "description": "Box OAuth client secret for Box content ingestion",
+          "isSecret": true,
+          "name": "BOX_CLIENT_SECRET"
+        },
+        {
+          "description": "Box OAuth redirect URI for Box content ingestion",
+          "name": "BOX_REDIRECT_URI"
+        },
+        {
+          "description": "Box OAuth refresh token for Box content ingestion",
+          "isSecret": true,
+          "name": "BOX_REFRESH_TOKEN"
+        },
+        {
+          "description": "Dropbox app key for Dropbox content ingestion",
+          "isSecret": true,
+          "name": "DROPBOX_APP_KEY"
+        },
+        {
+          "description": "Dropbox app secret for Dropbox content ingestion",
+          "isSecret": true,
+          "name": "DROPBOX_APP_SECRET"
+        },
+        {
+          "description": "Dropbox OAuth refresh token for Dropbox content ingestion",
+          "isSecret": true,
+          "name": "DROPBOX_REFRESH_TOKEN"
+        },
+        {
+          "description": "Google Drive OAuth client ID for Google Drive content ingestion",
+          "name": "GOOGLE_DRIVE_CLIENT_ID"
+        },
+        {
+          "description": "Google Drive OAuth client secret for Google Drive content ingestion",
+          "isSecret": true,
+          "name": "GOOGLE_DRIVE_CLIENT_SECRET"
+        },
+        {
+          "description": "Google Drive folder ID for Google Drive content ingestion",
+          "name": "GOOGLE_DRIVE_FOLDER_ID"
+        },
+        {
+          "description": "Google Drive OAuth refresh token for Google Drive content ingestion",
+          "isSecret": true,
+          "name": "GOOGLE_DRIVE_REFRESH_TOKEN"
+        },
+        {
+          "description": "Google Drive service account JSON for Google Drive content ingestion",
+          "isSecret": true,
+          "name": "GOOGLE_DRIVE_SERVICE_ACCOUNT_JSON"
+        },
+        {
+          "description": "Microsoft Teams OAuth client ID for Microsoft Teams content ingestion",
+          "name": "MICROSOFT_TEAMS_CLIENT_ID"
+        },
+        {
+          "description": "Microsoft Teams OAuth client secret for Microsoft Teams content ingestion",
+          "isSecret": true,
+          "name": "MICROSOFT_TEAMS_CLIENT_SECRET"
+        },
+        {
+          "description": "Microsoft Teams OAuth refresh token for Microsoft Teams content ingestion",
+          "isSecret": true,
+          "name": "MICROSOFT_TEAMS_REFRESH_TOKEN"
+        },
+        {
+          "description": "OneDrive OAuth client ID for OneDrive content ingestion",
+          "name": "ONEDRIVE_CLIENT_ID"
+        },
+        {
+          "description": "OneDrive OAuth client secret for OneDrive content ingestion",
+          "isSecret": true,
+          "name": "ONEDRIVE_CLIENT_SECRET"
+        },
+        {
+          "description": "OneDrive folder ID for OneDrive content ingestion",
+          "name": "ONEDRIVE_FOLDER_ID"
+        },
+        {
+          "description": "OneDrive OAuth refresh token for OneDrive content ingestion",
+          "isSecret": true,
+          "name": "ONEDRIVE_REFRESH_TOKEN"
+        },
+        {
+          "description": "SharePoint account name for SharePoint content ingestion",
+          "name": "SHAREPOINT_ACCOUNT_NAME"
+        },
+        {
+          "description": "SharePoint OAuth client ID for SharePoint content ingestion",
+          "name": "SHAREPOINT_CLIENT_ID"
+        },
+        {
+          "description": "SharePoint OAuth client secret for SharePoint content ingestion",
+          "isSecret": true,
+          "name": "SHAREPOINT_CLIENT_SECRET"
+        },
+        {
+          "description": "SharePoint OAuth refresh token for SharePoint content ingestion",
+          "isSecret": true,
+          "name": "SHAREPOINT_REFRESH_TOKEN"
+        },
+        {
+          "description": "Twitter/X access token key for Twitter/X content ingestion",
+          "isSecret": true,
+          "name": "TWITTER_ACCESS_TOKEN_KEY"
+        },
+        {
+          "description": "Twitter/X access token secret for Twitter/X content ingestion",
+          "isSecret": true,
+          "name": "TWITTER_ACCESS_TOKEN_SECRET"
+        },
+        {
+          "description": "Twitter/X consumer API key for Twitter/X content ingestion",
+          "isSecret": true,
+          "name": "TWITTER_CONSUMER_API_KEY"
+        },
+        {
+          "description": "Twitter/X consumer API secret for Twitter/X content ingestion",
+          "isSecret": true,
+          "name": "TWITTER_CONSUMER_API_SECRET"
         }
       ],
       "identifier": "ghcr.io/stacklok/dockyard/npx/graphlit-mcp-server:1.0.20260112001",


### PR DESCRIPTION
## What

The `catalog-audit` Official-tier sweep found `graphlit` declared only 14 of the connector credentials its source actually reads (`tools.ts` / `.env.example`). This adds the remaining **27**, verified against the upstream `.env.example` (the audit's draft list named some vars that don't exist upstream, e.g. `MICROSOFT_EMAIL_*` - those were dropped).

Added connectors: **Box** (4), **Dropbox** (3), **Google Drive** (5), **Microsoft Teams** (3), **OneDrive** (4), **SharePoint** (4), and the **Twitter/X** OAuth1 keys (4).

`isSecret` follows the entry's existing convention: client secrets, refresh tokens, app keys/secrets, and service-account JSON are secret; client IDs, redirect URIs, folder IDs, and account names are not.

`task catalog:validate` passes (graphlit now declares 41 env vars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)