### PR TITLE
Fix network permission gaps ahead of desktop isolation rollout

### DIFF
--- a/registries/toolhive/servers/gitlab/server.json
+++ b/registries/toolhive/servers/gitlab/server.json
@@ -13,6 +13,7 @@
             "network": {
               "outbound": {
                 "allow_host": [
+                  "gitlab.com",
                   ".gitlab.com",
                   ".gitlab-static.net",
                   ".gitlab.io",

--- a/registries/toolhive/servers/mcp-redfish/server.json
+++ b/registries/toolhive/servers/mcp-redfish/server.json
@@ -17,6 +17,16 @@
             "hardware",
             "server-management"
           ],
+          "permissions": {
+            "network": {
+              "outbound": {
+                "allow_port": [
+                  443
+                ],
+                "insecure_allow_all": true
+              }
+            }
+          },
           "tier": "Community",
           "tool_definitions": [
             {

--- a/registries/toolhive/servers/mcp-redfish/server.json
+++ b/registries/toolhive/servers/mcp-redfish/server.json
@@ -5,18 +5,10 @@
       "io.github.stacklok": {
         "ghcr.io/nokia/mcp-redfish:0.3.7": {
           "metadata": {
-            "last_updated": "2026-04-23T14:50:59Z",
+            "last_updated": "2026-06-29T14:06:24Z",
             "stars": 6
           },
           "overview": "## Redfish MCP Server\n\nThe mcp-redfish server is a Model Context Protocol (MCP) server that enables AI assistants and agents to interact directly with systems that expose the Redfish API, the industry-standard RESTful interface for out-of-band hardware management. It allows AI-driven workflows to inspect server hardware, firmware, power state, and health information without switching tools or manually navigating vendor-specific management consoles. This server is especially useful for data center operations, hardware monitoring, infrastructure troubleshooting, and AI-assisted systems management workflows.",
-          "status": "Active",
-          "tags": [
-            "infrastructure",
-            "redfish",
-            "api",
-            "hardware",
-            "server-management"
-          ],
           "permissions": {
             "network": {
               "outbound": {
@@ -27,6 +19,14 @@
               }
             }
           },
+          "status": "Active",
+          "tags": [
+            "infrastructure",
+            "redfish",
+            "api",
+            "hardware",
+            "server-management"
+          ],
           "tier": "Community",
           "tool_definitions": [
             {

--- a/registries/toolhive/servers/redhat-linux/server.json
+++ b/registries/toolhive/servers/redhat-linux/server.json
@@ -19,6 +19,16 @@
             "troubleshooting",
             "networking"
           ],
+          "permissions": {
+            "network": {
+              "outbound": {
+                "allow_port": [
+                  22
+                ],
+                "insecure_allow_all": true
+              }
+            }
+          },
           "tier": "Official",
           "tool_definitions": [
             {

--- a/registries/toolhive/servers/redhat-linux/server.json
+++ b/registries/toolhive/servers/redhat-linux/server.json
@@ -5,20 +5,10 @@
       "io.github.stacklok": {
         "quay.io/redhat-services-prod/rhel-lightspeed-tenant/linux-mcp-server:1.4.1": {
           "metadata": {
-            "last_updated": "2026-04-13T21:10:32Z",
+            "last_updated": "2026-06-29T14:06:57Z",
             "stars": 203
           },
           "overview": "## Red Hat Linux MCP Server\n\nThe redhat-linux MCP server provides read-only Linux sysadmin, diagnostics, and troubleshooting optimized for RHEL-based systems. This server delivers comprehensive Linux system diagnostics through real-time monitoring of CPU, memory, disk, and network metrics; process and service management with status and log access; network diagnostics including active connections and listening ports; and file system exploration with configurable path restrictions. All capabilities operate in read-only mode via SSH-based remote execution with secure key-based authentication, preventing system modifications.",
-          "status": "Active",
-          "tags": [
-            "linux",
-            "diagnostics",
-            "sysadmin",
-            "rhel",
-            "monitoring",
-            "troubleshooting",
-            "networking"
-          ],
           "permissions": {
             "network": {
               "outbound": {
@@ -29,6 +19,16 @@
               }
             }
           },
+          "status": "Active",
+          "tags": [
+            "linux",
+            "diagnostics",
+            "sysadmin",
+            "rhel",
+            "monitoring",
+            "troubleshooting",
+            "networking"
+          ],
           "tier": "Official",
           "tool_definitions": [
             {

--- a/registries/toolhive/servers/sentry/server.json
+++ b/registries/toolhive/servers/sentry/server.json
@@ -5,7 +5,7 @@
       "io.github.stacklok": {
         "ghcr.io/stacklok/dockyard/npx/sentry-mcp-server:0.33.0": {
           "metadata": {
-            "last_updated": "2026-06-26T21:53:05Z",
+            "last_updated": "2026-06-29T14:06:19Z",
             "stars": 619
           },
           "overview": "## Sentry MCP Server\n\nThe sentry MCP server is a Model Context Protocol (MCP) service for human-in-the-loop coding agents and developer workflow debugging. The server enables comprehensive Sentry project and organization management, real-time error tracking with event search and issue monitoring, AI-powered issue analysis through Sentry Seer integration, and integrated documentation search for platform guidance.",

--- a/registries/toolhive/servers/sentry/server.json
+++ b/registries/toolhive/servers/sentry/server.json
@@ -13,6 +13,7 @@
             "network": {
               "outbound": {
                 "allow_host": [
+                  "sentry.io",
                   ".sentry.io"
                 ],
                 "allow_port": [

--- a/registries/toolhive/servers/slack-mcp-server/server.json
+++ b/registries/toolhive/servers/slack-mcp-server/server.json
@@ -13,6 +13,7 @@
             "network": {
               "outbound": {
                 "allow_host": [
+                  "slack.com",
                   ".slack.com",
                   ".slack-edge.com"
                 ],

--- a/registries/toolhive/servers/toolhive-doc-mcp/server.json
+++ b/registries/toolhive/servers/toolhive-doc-mcp/server.json
@@ -27,6 +27,11 @@
             "support",
             "toolhive"
           ],
+          "permissions": {
+            "network": {
+              "outbound": {}
+            }
+          },
           "tier": "Official",
           "tool_definitions": [
             {


### PR DESCRIPTION
## Summary

Focused audit of network permissions ahead of enabling isolation by default in the ToolHive desktop app. Two categories of gaps found and fixed:

**Missing permissions on container entries** (would break entirely with isolation enabled):

- `mcp-redfish`: add `insecure_allow_all` + port 443 hint — Redfish endpoints are user-defined via `REDFISH_HOSTS`
- `redhat-linux`: add `insecure_allow_all` + port 22 hint — server is SSH-only (confirmed by upstream docs and tool definitions)
- `toolhive-doc-mcp`: add empty outbound profile — fully self-contained with an embedded SQLite vector DB; the optional `REFRESH_ENABLED` feature is off by default and its network targets can't be expressed with sufficient specificity at the registry level

**Apex domain missing from wildcard-only host lists** (Squid's `.example.com` syntax covers subdomains but not the apex itself):

- `sentry`: add `sentry.io` — Sentry REST API base is `sentry.io/api/0/`
- `slack-mcp-server`: add `slack.com` — Slack Web API is at `slack.com/api/`
- `gitlab`: add `gitlab.com` — default `GITLAB_API_URL` is `https://gitlab.com/api/v4`