### PR TITLE
Fix registry verification commands to use upstream format

### DIFF
--- a/.claude/skills/add-mcp-server/SKILL.md
+++ b/.claude/skills/add-mcp-server/SKILL.md
@@ -161,8 +161,7 @@ task catalog:validate
 task catalog:build
 
 # Verify entry in output
-jq '.servers["<name>"]' build/toolhive/registry.json          # containers
-jq '.remote_servers["<name>"]' build/toolhive/registry.json   # remotes
+jq '.data.servers[] | select(.name == "io.github.stacklok/<name>")' build/toolhive/registry-upstream.json
 ```
 
 ## Reference Examples

--- a/.claude/skills/mcp-review/SKILL.md
+++ b/.claude/skills/mcp-review/SKILL.md
@@ -243,6 +243,5 @@ A `Required` miss is REQUEST_CHANGES or REJECT. `Expected` misses are called out
 ```bash
 task catalog:validate                                             # Validate all entries
 task catalog:build                                                # Build registry
-jq '.servers["<name>"]' build/toolhive/registry.json              # Check container entry
-jq '.remote_servers["<name>"]' build/toolhive/registry.json       # Check remote entry
+jq '.data.servers[] | select(.name == "io.github.stacklok/<name>")' build/toolhive/registry-upstream.json
 ```

--- a/docs/adding-entries-llm.md
+++ b/docs/adding-entries-llm.md
@@ -809,11 +809,7 @@ This compiles all entries into the registry and verifies there are no conflicts 
 ### 3. Verify Entry
 
 ```bash
-# For container servers:
-jq '.servers["<server-name>"]' build/toolhive/registry.json
-
-# For remote servers:
-jq '.remote_servers["<server-name>"]' build/toolhive/registry.json
+jq '.data.servers[] | select(.name == "io.github.stacklok/<server-name>")' build/toolhive/registry-upstream.json
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Update jq verification commands in `docs/adding-entries-llm.md`, `.claude/skills/add-mcp-server/SKILL.md`, and `.claude/skills/mcp-review/SKILL.md` to reference `registry-upstream.json` instead of the legacy `registry.json`
- Switch from the old `.servers["<name>"]` / `.remote_servers["<name>"]` key format to `.data.servers[] | select(.name == "io.github.stacklok/<name>")` which matches the upstream registry schema

## Test plan

- [x] Verified `jq '.data.servers[] | select(.name == "io.github.stacklok/github")' build/toolhive/registry-upstream.json` returns the expected entry
- [x] No remaining references to `registry.json` or `registry-legacy.json` in any `.md` files