### PR TITLE
Auto-create catalog entries for missing dockyard skills

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -79,8 +79,9 @@ jobs:
       - name: Sync dockyard-sourced skills
         env:
           DOCKYARD_REF: ${{ github.event.inputs.dockyard-ref || 'main' }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          /tmp/catalog sync-skills --all --dockyard-ref "$DOCKYARD_REF" -v
+          /tmp/catalog sync-skills --all --add-missing --dockyard-ref "$DOCKYARD_REF" -v
 
       - name: Validate after sync
         run: /tmp/catalog validate -v
@@ -88,13 +89,16 @@ jobs:
       - name: Check for changes
         id: check-changes
         run: |
-          if git diff --quiet; then
+          # Stage before diffing so newly created skill entries (untracked
+          # files) count as changes too.
+          git add registries/
+          if git diff --cached --quiet; then
             echo "No changes detected"
             echo "changed=false" >> $GITHUB_OUTPUT
           else
             echo "Changes detected"
             echo "changed=true" >> $GITHUB_OUTPUT
-            git diff --stat
+            git diff --cached --stat
           fi
 
       - name: Commit and open or update PR
@@ -104,7 +108,6 @@ jobs:
         run: |
           BRANCH="catalog-sync-skills"
 
-          git add -u registries/
           git commit -m "chore: sync skills with dockyard"
           git push -f origin "$BRANCH"
 
@@ -127,6 +130,13 @@ jobs:
           rewrites both the OCI tag (`packages[].identifier`) and the upstream
           git ref (`packages[].ref`) so the two stay in lockstep with whatever
           dockyard last published.
+
+          It also creates catalog entries for dockyard skills that have none
+          yet. Auto-created entries have a title derived from the skill name
+          and may use a generic placeholder `icon.svg` (flagged in the sync
+          output) — reviewers should polish titles and swap placeholder icons
+          before merging. Skills that must not be onboarded can be listed in
+          `registries/<registry>/skills/.sync-skills-ignore`.
 
           ---
           *This is an automated PR created by the daily skill sync workflow.*

--- a/cmd/catalog/sync_skills.go
+++ b/cmd/catalog/sync_skills.go
@@ -22,17 +22,24 @@ const (
 	defaultDockyardBaseURL = "https://raw.githubusercontent.com/stacklok/dockyard"
 
 	statusUpdated = "updated"
+	statusCreated = "created"
 	statusNoop    = "noop"
 	statusSkipped = "skipped"
 	statusMissing = "missing"
 	statusError   = "error"
+
+	// opCreate marks results produced by the --add-missing create path so
+	// the summary can report creations separately from updates.
+	opCreate = "create"
 )
 
 var (
-	syncSkillsAll      bool
-	syncSkillsDryRun   bool
-	syncSkillsDockyard string
-	syncSkillsBaseURL  string
+	syncSkillsAll        bool
+	syncSkillsAddMissing bool
+	syncSkillsDryRun     bool
+	syncSkillsDockyard   string
+	syncSkillsBaseURL    string
+	syncSkillsAPIURL     string
 )
 
 var syncSkillsCmd = &cobra.Command{
@@ -44,8 +51,10 @@ git ref with the corresponding skills/<name>/spec.yaml in
 github.com/stacklok/dockyard.
 
 Modes:
-  catalog sync-skills <skill.json>   Sync a single file
-  catalog sync-skills --all          Sync every dockyard-sourced skill`,
+  catalog sync-skills <skill.json>            Sync a single file
+  catalog sync-skills --all                   Sync every dockyard-sourced skill
+  catalog sync-skills --all --add-missing     Also create entries for dockyard
+                                              skills absent from the catalog`,
 	Args: validateSyncSkillsArgs,
 	RunE: runSyncSkills,
 }
@@ -54,6 +63,10 @@ func init() {
 	syncSkillsCmd.Flags().BoolVar(
 		&syncSkillsAll, "all", false,
 		"Sync all dockyard-sourced skills under the registries directory",
+	)
+	syncSkillsCmd.Flags().BoolVar(
+		&syncSkillsAddMissing, "add-missing", false,
+		"Create catalog entries for dockyard skills that have none (requires --all)",
 	)
 	syncSkillsCmd.Flags().BoolVarP(
 		&syncSkillsDryRun, "dry-run", "d", false,
@@ -67,6 +80,10 @@ func init() {
 		&syncSkillsBaseURL, "dockyard-base-url", defaultDockyardBaseURL,
 		"Base URL for dockyard raw content (mainly for tests)",
 	)
+	syncSkillsCmd.Flags().StringVar(
+		&syncSkillsAPIURL, "dockyard-api-url", defaultDockyardAPIBaseURL,
+		"Base URL for the dockyard GitHub API (mainly for tests)",
+	)
 }
 
 func validateSyncSkillsArgs(_ *cobra.Command, args []string) error {
@@ -75,6 +92,9 @@ func validateSyncSkillsArgs(_ *cobra.Command, args []string) error {
 	}
 	if !syncSkillsAll && len(args) == 0 {
 		return fmt.Errorf("requires a skill.json path or --all")
+	}
+	if syncSkillsAddMissing && !syncSkillsAll {
+		return fmt.Errorf("--add-missing requires --all")
 	}
 	if len(args) > 1 {
 		return fmt.Errorf("accepts at most 1 arg(s), received %d", len(args))
@@ -87,15 +107,19 @@ func validateSyncSkillsArgs(_ *cobra.Command, args []string) error {
 // in parallel.
 type syncOptions struct {
 	BaseURL     string
+	APIBaseURL  string
 	DockyardRef string
 	DryRun      bool
+	AddMissing  bool
+	GitHubToken string
 	HTTP        *http.Client
 }
 
 // dockyardSpec mirrors the relevant subset of dockyard's skills/<name>/spec.yaml.
 type dockyardSpec struct {
 	Metadata struct {
-		Name string `yaml:"name"`
+		Name        string `yaml:"name"`
+		Description string `yaml:"description"`
 	} `yaml:"metadata"`
 	Spec struct {
 		Repository string `yaml:"repository"`
@@ -110,6 +134,9 @@ type syncResult struct {
 	Path      string
 	SkillName string
 	Status    string
+	// Op distinguishes create-mode results (opCreate) from the default
+	// update path, so summaries can count the two separately.
+	Op        string
 	Detail    string
 	IDBefore  string
 	IDAfter   string
@@ -123,8 +150,11 @@ type syncResult struct {
 func defaultSyncOptions() syncOptions {
 	return syncOptions{
 		BaseURL:     syncSkillsBaseURL,
+		APIBaseURL:  syncSkillsAPIURL,
 		DockyardRef: syncSkillsDockyard,
 		DryRun:      syncSkillsDryRun,
+		AddMissing:  syncSkillsAddMissing,
+		GitHubToken: os.Getenv("GITHUB_TOKEN"),
 		HTTP:        &http.Client{Timeout: 15 * time.Second},
 	}
 }
@@ -148,7 +178,7 @@ func runSyncSkillsAll(ctx context.Context, opts syncOptions, root string) error 
 	if err != nil {
 		return err
 	}
-	if len(paths) == 0 {
+	if len(paths) == 0 && !opts.AddMissing {
 		fmt.Println("No dockyard-sourced skills found")
 		return nil
 	}
@@ -158,6 +188,14 @@ func runSyncSkillsAll(ctx context.Context, opts syncOptions, root string) error 
 	results := make([]syncResult, 0, len(paths))
 	for _, p := range paths {
 		results = append(results, syncOneSkill(ctx, opts, p))
+	}
+
+	if opts.AddMissing {
+		created, err := createMissingSkills(ctx, opts, root)
+		if err != nil {
+			return err
+		}
+		results = append(results, created...)
 	}
 
 	printSyncSummary(results)
@@ -445,9 +483,14 @@ func printSyncResult(r syncResult, single bool) {
 	case statusUpdated:
 		fmt.Printf("UPDATED  %s (%s)\n", r.Path, r.SkillName)
 		printDelta(r)
+	case statusCreated:
+		fmt.Printf("CREATED  %s (%s): %s\n", r.Path, r.SkillName, r.Detail)
 	case statusNoop:
 		if r.Planned {
 			fmt.Printf("DRY-RUN  %s (%s)\n", r.Path, r.SkillName)
+			if r.Detail != "" {
+				fmt.Printf("  %s\n", r.Detail)
+			}
 			printDelta(r)
 			return
 		}
@@ -476,22 +519,27 @@ func printSyncSummary(results []syncResult) {
 	for _, r := range results {
 		printSyncResult(r, false)
 	}
-	planned := 0
+	plannedUpdate := 0
+	plannedCreate := 0
 	noop := 0
 	for _, r := range results {
 		if r.Status != statusNoop {
 			continue
 		}
-		if r.Planned {
-			planned++
-		} else {
+		switch {
+		case r.Planned && r.Op == opCreate:
+			plannedCreate++
+		case r.Planned:
+			plannedUpdate++
+		default:
 			noop++
 		}
 	}
 	fmt.Println()
-	if planned > 0 {
-		fmt.Printf("Summary: %d would-update, %d noop, %d skipped, %d missing, %d error (of %d) [dry run]\n",
-			planned,
+	if plannedUpdate > 0 || plannedCreate > 0 {
+		fmt.Printf("Summary: %d would-update, %d would-create, %d noop, %d skipped, %d missing, %d error (of %d) [dry run]\n",
+			plannedUpdate,
+			plannedCreate,
 			noop,
 			countByStatus(results, statusSkipped),
 			countByStatus(results, statusMissing),
@@ -500,8 +548,9 @@ func printSyncSummary(results []syncResult) {
 		)
 		return
 	}
-	fmt.Printf("Summary: %d updated, %d noop, %d skipped, %d missing, %d error (of %d)\n",
+	fmt.Printf("Summary: %d updated, %d created, %d noop, %d skipped, %d missing, %d error (of %d)\n",
 		countByStatus(results, statusUpdated),
+		countByStatus(results, statusCreated),
 		noop,
 		countByStatus(results, statusSkipped),
 		countByStatus(results, statusMissing),

--- a/cmd/catalog/sync_skills_create.go
+++ b/cmd/catalog/sync_skills_create.go
@@ -1,0 +1,355 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/stacklok/toolhive-catalog/internal/skilljson"
+)
+
+const (
+	// defaultDockyardAPIBaseURL is the GitHub REST API base for the dockyard
+	// repository, used to enumerate published skills.
+	defaultDockyardAPIBaseURL = "https://api.github.com/repos/stacklok/dockyard"
+
+	// defaultSkillNamespace is the namespace used by every catalog skill entry.
+	defaultSkillNamespace = "io.github.stacklok"
+
+	// syncIgnoreFile lists dockyard skill names (one per line, # comments)
+	// that must never be auto-onboarded into a registry's skills directory.
+	syncIgnoreFile = ".sync-skills-ignore"
+)
+
+// placeholderIconSVG is written for new entries when no sibling skill shares
+// the upstream repository. It matches the 24x24 stroke style of existing
+// catalog icons and is intended to be replaced during PR review.
+const placeholderIconSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" ` +
+	`stroke="#6b7280" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">` +
+	`<rect x="3" y="3" width="18" height="18" rx="4"/><path d="M12 8v8M8 12h8"/></svg>` + "\n"
+
+// contentsEntry is the subset of the GitHub contents API response needed to
+// enumerate dockyard's skills directory.
+type contentsEntry struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+// listDockyardSkillNames enumerates the skill directories in dockyard's
+// skills/ folder at the configured ref via the GitHub contents API.
+func listDockyardSkillNames(ctx context.Context, opts syncOptions) ([]string, error) {
+	listURL := fmt.Sprintf(
+		"%s/contents/skills?ref=%s",
+		strings.TrimRight(opts.APIBaseURL, "/"),
+		url.QueryEscape(opts.DockyardRef),
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, listURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	if opts.GitHubToken != "" {
+		req.Header.Set("Authorization", "Bearer "+opts.GitHubToken)
+	}
+	resp, err := opts.HTTP.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch %s: %w", listURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil, fmt.Errorf("unexpected status %d fetching %s", resp.StatusCode, listURL)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+	var entries []contentsEntry
+	if err := json.Unmarshal(body, &entries); err != nil {
+		return nil, fmt.Errorf("failed to parse contents listing: %w", err)
+	}
+
+	var names []string
+	for _, e := range entries {
+		if e.Type == "dir" && e.Name != "" {
+			names = append(names, e.Name)
+		}
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// createMissingSkills creates catalog entries for every dockyard skill that
+// has no directory under a registry's skills/ subdir and is not listed in
+// that registry's ignore file. Only registries that already carry at least
+// one dockyard-sourced skill participate — a registry with an empty (or
+// dockyard-free) skills directory has not opted into dockyard syncing.
+// A listing failure is fatal: the caller should surface it rather than
+// silently skip onboarding.
+func createMissingSkills(ctx context.Context, opts syncOptions, root string) ([]syncResult, error) {
+	dockyardNames, err := listDockyardSkillNames(ctx, opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list dockyard skills: %w", err)
+	}
+
+	regs, err := os.ReadDir(root)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read registries directory %s: %w", root, err)
+	}
+
+	var results []syncResult
+	for _, reg := range regs {
+		if !reg.IsDir() || strings.HasPrefix(reg.Name(), ".") {
+			continue
+		}
+		skillsDir := filepath.Join(root, reg.Name(), skillsSubdir)
+		dockyardSourced, err := dockyardSkillsInRegistry(skillsDir)
+		if err != nil {
+			return nil, err
+		}
+		if len(dockyardSourced) == 0 {
+			// Registry has no dockyard-sourced skills (or no skills/ subdir
+			// at all); nothing to onboard into.
+			continue
+		}
+		existing, err := existingSkillDirs(skillsDir)
+		if err != nil {
+			return nil, err
+		}
+		ignored, err := loadSyncIgnore(skillsDir)
+		if err != nil {
+			return nil, err
+		}
+		for _, name := range dockyardNames {
+			if existing[name] || ignored[name] {
+				continue
+			}
+			results = append(results, createSkillEntry(ctx, opts, skillsDir, name))
+		}
+	}
+	return results, nil
+}
+
+// createSkillEntry fetches the dockyard spec for name and writes a new
+// skills/<name>/ directory with skill.json and icon.svg. Failures are
+// reported via the returned syncResult, never a panic.
+func createSkillEntry(ctx context.Context, opts syncOptions, skillsDir, name string) syncResult {
+	dir := filepath.Join(skillsDir, name)
+	res := syncResult{
+		Path:      filepath.Join(dir, "skill.json"),
+		SkillName: name,
+		Op:        opCreate,
+	}
+
+	spec, err := fetchDockyardSpec(ctx, opts, name)
+	if err != nil {
+		return errorResult(res, err.Error())
+	}
+
+	skill, err := buildNewSkill(name, spec)
+	if err != nil {
+		return errorResult(res, err.Error())
+	}
+	data, err := skilljson.MarshalNewSkill(skill)
+	if err != nil {
+		return errorResult(res, err.Error())
+	}
+
+	icon, iconDetail, err := findSiblingIcon(skillsDir, spec.Spec.Repository)
+	if err != nil {
+		return errorResult(res, err.Error())
+	}
+	res.Detail = iconDetail
+	res.IDAfter = skill.Packages[0].Identifier
+	res.RefAfter = spec.Spec.Ref
+
+	if opts.DryRun {
+		res.Status = statusNoop
+		res.Detail = "[DRY RUN] would create (" + iconDetail + ")"
+		res.Planned = true
+		return res
+	}
+
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return errorResult(res, fmt.Sprintf("failed to create %s: %s", dir, err))
+	}
+	if err := writeEntryFiles(dir, data, icon); err != nil {
+		// Remove the partially written entry so a failed run does not leave
+		// a directory that later runs would treat as an existing skill.
+		_ = os.RemoveAll(dir)
+		return errorResult(res, err.Error())
+	}
+
+	res.Status = statusCreated
+	return res
+}
+
+func writeEntryFiles(dir string, skillJSON, icon []byte) error {
+	skillPath := filepath.Join(dir, "skill.json")
+	if err := os.WriteFile(skillPath, skillJSON, 0600); err != nil {
+		return fmt.Errorf("failed to write %s: %w", skillPath, err)
+	}
+	iconPath := filepath.Join(dir, "icon.svg")
+	if err := os.WriteFile(iconPath, icon, 0600); err != nil {
+		return fmt.Errorf("failed to write %s: %w", iconPath, err)
+	}
+	return nil
+}
+
+// buildNewSkill maps a dockyard spec.yaml onto a catalog skill.json entry.
+func buildNewSkill(name string, spec *dockyardSpec) (skilljson.NewSkill, error) {
+	switch {
+	case spec.Spec.Version == "":
+		return skilljson.NewSkill{}, fmt.Errorf("dockyard spec.yaml for %s is missing spec.version", name)
+	case spec.Spec.Repository == "":
+		return skilljson.NewSkill{}, fmt.Errorf("dockyard spec.yaml for %s is missing spec.repository", name)
+	case spec.Spec.Ref == "":
+		return skilljson.NewSkill{}, fmt.Errorf("dockyard spec.yaml for %s is missing spec.ref", name)
+	case spec.Metadata.Description == "":
+		return skilljson.NewSkill{}, fmt.Errorf("dockyard spec.yaml for %s is missing metadata.description", name)
+	}
+
+	return skilljson.NewSkill{
+		Namespace:   defaultSkillNamespace,
+		Name:        name,
+		Title:       deriveTitle(name),
+		Description: spec.Metadata.Description,
+		Version:     spec.Spec.Version,
+		Status:      "active",
+		Repository: skilljson.Repository{
+			URL:  spec.Spec.Repository,
+			Type: skilljson.RegistryTypeGit,
+		},
+		Icons: []skilljson.Icon{
+			{Src: "icon.svg", Type: "image/svg+xml"},
+		},
+		Packages: []skilljson.NewPackage{
+			{
+				RegistryType: "oci",
+				Identifier:   skilljson.DockyardSkillPrefix + name + ":" + spec.Spec.Version,
+			},
+			{
+				RegistryType: skilljson.RegistryTypeGit,
+				URL:          spec.Spec.Repository,
+				Ref:          spec.Spec.Ref,
+				Subfolder:    spec.Spec.Path,
+			},
+		},
+	}, nil
+}
+
+// titleAcronyms are lowercase words that render fully uppercased in derived
+// titles instead of title case.
+var titleAcronyms = map[string]bool{
+	"ai": true, "api": true, "aws": true, "cd": true, "ci": true,
+	"cli": true, "css": true, "gcp": true, "html": true, "http": true,
+	"json": true, "md": true, "rca": true, "sdk": true, "sql": true,
+	"tdd": true, "ui": true, "url": true, "yaml": true,
+}
+
+// deriveTitle turns a kebab-case skill name into a human-readable title,
+// e.g. "vercel-cli-with-tokens" -> "Vercel CLI With Tokens". Results are
+// polished by reviewers in the onboarding PR.
+func deriveTitle(name string) string {
+	words := strings.Split(name, "-")
+	for i, w := range words {
+		switch {
+		case w == "":
+			continue
+		case titleAcronyms[w]:
+			words[i] = strings.ToUpper(w)
+		default:
+			words[i] = strings.ToUpper(w[:1]) + w[1:]
+		}
+	}
+	return strings.Join(words, " ")
+}
+
+// findSiblingIcon returns the icon.svg bytes of the first existing skill
+// (in sorted directory order) whose upstream repository matches repoURL.
+// When no sibling matches, the generic placeholder icon is returned along
+// with a detail string asking for review.
+func findSiblingIcon(skillsDir, repoURL string) ([]byte, string, error) {
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []byte(placeholderIconSVG), "placeholder icon — needs review", nil
+		}
+		return nil, "", fmt.Errorf("failed to read %s: %w", skillsDir, err)
+	}
+	for _, e := range entries {
+		if !e.IsDir() || strings.HasPrefix(e.Name(), ".") {
+			continue
+		}
+		sf, err := skilljson.Load(filepath.Join(skillsDir, e.Name(), "skill.json"))
+		if err != nil {
+			continue
+		}
+		if sf.Skill.Repository == nil || !repoURLsMatch(sf.Skill.Repository.URL, repoURL) {
+			continue
+		}
+		icon, err := os.ReadFile(filepath.Join(skillsDir, e.Name(), "icon.svg")) // #nosec G304 - registry directory walk
+		if err != nil {
+			continue
+		}
+		return icon, "icon copied from " + e.Name(), nil
+	}
+	return []byte(placeholderIconSVG), "placeholder icon — needs review", nil
+}
+
+// loadSyncIgnore reads the per-registry ignore file. A missing file is not
+// an error and yields an empty set.
+func loadSyncIgnore(skillsDir string) (map[string]bool, error) {
+	path := filepath.Join(skillsDir, syncIgnoreFile)
+	f, err := os.Open(path) // #nosec G304 - registry directory walk
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]bool{}, nil
+		}
+		return nil, fmt.Errorf("failed to read %s: %w", path, err)
+	}
+	defer f.Close()
+
+	ignored := map[string]bool{}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		ignored[line] = true
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read %s: %w", path, err)
+	}
+	return ignored, nil
+}
+
+// existingSkillDirs returns the set of skill directory names under
+// skillsDir, or nil (no error) when the registry has no skills/ subdir.
+func existingSkillDirs(skillsDir string) (map[string]bool, error) {
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read %s: %w", skillsDir, err)
+	}
+	existing := map[string]bool{}
+	for _, e := range entries {
+		if e.IsDir() && !strings.HasPrefix(e.Name(), ".") {
+			existing[e.Name()] = true
+		}
+	}
+	return existing, nil
+}

--- a/cmd/catalog/sync_skills_create.go
+++ b/cmd/catalog/sync_skills_create.go
@@ -153,6 +153,17 @@ func createSkillEntry(ctx context.Context, opts syncOptions, skillsDir, name str
 
 	spec, err := fetchDockyardSpec(ctx, opts, name)
 	if err != nil {
+		// A directory listed under dockyard's skills/ that has no fetchable
+		// spec.yaml (mid-publish, a shared/template dir, a transient 404) is
+		// skipped rather than failing the whole run — matching the
+		// single-skill path in loadDockyardSpec. A create error would
+		// otherwise abort the entire sync, including legitimate tag/ref
+		// updates for other skills.
+		if isNotFoundErr(err) {
+			res.Status = statusMissing
+			res.Detail = "not present in dockyard"
+			return res
+		}
 		return errorResult(res, err.Error())
 	}
 
@@ -169,13 +180,17 @@ func createSkillEntry(ctx context.Context, opts syncOptions, skillsDir, name str
 	if err != nil {
 		return errorResult(res, err.Error())
 	}
-	res.Detail = iconDetail
+	// Dockyard's spec.yaml carries no license, so generated entries never
+	// have one — flag it alongside the icon so reviewers fill it in before
+	// merging (every hand-written catalog skill has a license).
+	detail := iconDetail + "; license needs review"
+	res.Detail = detail
 	res.IDAfter = skill.Packages[0].Identifier
 	res.RefAfter = spec.Spec.Ref
 
 	if opts.DryRun {
 		res.Status = statusNoop
-		res.Detail = "[DRY RUN] would create (" + iconDetail + ")"
+		res.Detail = "[DRY RUN] would create (" + detail + ")"
 		res.Planned = true
 		return res
 	}

--- a/cmd/catalog/sync_skills_create_test.go
+++ b/cmd/catalog/sync_skills_create_test.go
@@ -1,0 +1,409 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const fixtureIconSVG = `<svg xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="10"/></svg>
+`
+
+const newSkillName = "new-skill"
+
+// seedRegistry creates a registry root containing one existing
+// dockyard-sourced skill (security-review) with an icon, and returns the
+// root and its skills directory.
+func seedRegistry(t *testing.T) (root, skillsDir string) {
+	t.Helper()
+	root = t.TempDir()
+	skillsDir = filepath.Join(root, "toolhive", "skills")
+	writeEntry(t, skillsDir, securityReview, fixtureSkillJSON, fixtureIconSVG)
+	return root, skillsDir
+}
+
+func writeEntry(t *testing.T, skillsDir, name, skillJSON, icon string) {
+	t.Helper()
+	dir := filepath.Join(skillsDir, name)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "skill.json"), []byte(skillJSON), 0600); err != nil {
+		t.Fatalf("write skill.json: %v", err)
+	}
+	if icon != "" {
+		if err := os.WriteFile(filepath.Join(dir, "icon.svg"), []byte(icon), 0600); err != nil {
+			t.Fatalf("write icon.svg: %v", err)
+		}
+	}
+}
+
+func TestCreateMissingSkills_CreatesEntry(t *testing.T) {
+	t.Parallel()
+	srv := fakeDockyard(t, map[string]string{
+		securityReview: dockyardSpecYAML(
+			"https://github.com/getsentry/skills",
+			originalRef, "skills/security-review", "0.1.0",
+		),
+		newSkillName: dockyardSpecYAML(
+			fixtureRepoURL, bumpedRef, "skills/new-skill", "0.2.0",
+		),
+	})
+
+	root, skillsDir := seedRegistry(t)
+	results, err := createMissingSkills(context.Background(), optsFor(srv, false), root)
+	if err != nil {
+		t.Fatalf("createMissingSkills: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d (%+v)", len(results), results)
+	}
+	res := results[0]
+	if res.Status != statusCreated || res.Op != opCreate {
+		t.Fatalf("expected created/create, got %s/%s (%s)", res.Status, res.Op, res.Detail)
+	}
+	if !strings.Contains(res.Detail, "placeholder icon") {
+		t.Errorf("expected placeholder icon detail, got %q", res.Detail)
+	}
+
+	const wantSkillJSON = `{
+  "namespace": "io.github.stacklok",
+  "name": "new-skill",
+  "title": "New Skill",
+  "description": "test",
+  "version": "0.2.0",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/foo/bar",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/new-skill:0.2.0"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/foo/bar",
+      "ref": "f2cff985bcec174fcd096db65a23f06ec9bdde29",
+      "subfolder": "skills/new-skill"
+    }
+  ]
+}
+`
+	got, err := os.ReadFile(filepath.Join(skillsDir, newSkillName, "skill.json"))
+	if err != nil {
+		t.Fatalf("read created skill.json: %v", err)
+	}
+	if string(got) != wantSkillJSON {
+		t.Errorf("skill.json mismatch:\ngot:\n%s\nwant:\n%s", got, wantSkillJSON)
+	}
+	icon, err := os.ReadFile(filepath.Join(skillsDir, newSkillName, "icon.svg"))
+	if err != nil {
+		t.Fatalf("read created icon.svg: %v", err)
+	}
+	if string(icon) != placeholderIconSVG {
+		t.Errorf("expected placeholder icon, got:\n%s", icon)
+	}
+}
+
+func TestCreateMissingSkills_CopiesSiblingIcon(t *testing.T) {
+	t.Parallel()
+	srv := fakeDockyard(t, map[string]string{
+		securityReview: dockyardSpecYAML(
+			"https://github.com/getsentry/skills",
+			originalRef, "skills/security-review", "0.1.0",
+		),
+		"agents-md": dockyardSpecYAML(
+			"https://github.com/getsentry/skills",
+			bumpedRef, "skills/agents-md", "0.1.1",
+		),
+	})
+
+	root, skillsDir := seedRegistry(t)
+	results, err := createMissingSkills(context.Background(), optsFor(srv, false), root)
+	if err != nil {
+		t.Fatalf("createMissingSkills: %v", err)
+	}
+	if len(results) != 1 || results[0].Status != statusCreated {
+		t.Fatalf("expected 1 created result, got %+v", results)
+	}
+	if want := "icon copied from " + securityReview; results[0].Detail != want {
+		t.Errorf("expected detail %q, got %q", want, results[0].Detail)
+	}
+	icon, err := os.ReadFile(filepath.Join(skillsDir, "agents-md", "icon.svg"))
+	if err != nil {
+		t.Fatalf("read created icon.svg: %v", err)
+	}
+	if string(icon) != fixtureIconSVG {
+		t.Errorf("expected sibling icon copied, got:\n%s", icon)
+	}
+}
+
+func TestFindSiblingIcon_FirstSortedWins(t *testing.T) {
+	t.Parallel()
+	skillsDir := filepath.Join(t.TempDir(), "skills")
+	secondIcon := strings.Replace(fixtureIconSVG, "circle", "rect", 1)
+	otherSkill := strings.Replace(fixtureSkillJSON, `"name": "security-review"`, `"name": "a-first"`, 1)
+	writeEntry(t, skillsDir, "security-review", fixtureSkillJSON, fixtureIconSVG)
+	writeEntry(t, skillsDir, "a-first", otherSkill, secondIcon)
+
+	icon, detail, err := findSiblingIcon(skillsDir, "https://github.com/getsentry/skills")
+	if err != nil {
+		t.Fatalf("findSiblingIcon: %v", err)
+	}
+	if string(icon) != secondIcon {
+		t.Errorf("expected icon from alphabetically first sibling, got:\n%s", icon)
+	}
+	if detail != "icon copied from a-first" {
+		t.Errorf("unexpected detail %q", detail)
+	}
+}
+
+func TestCreateMissingSkills_SkipsExistingDir(t *testing.T) {
+	t.Parallel()
+	// Dockyard's code-review is a different skill from the catalog-hosted
+	// code-review entry; an existing directory must never be overwritten.
+	srv := fakeDockyard(t, map[string]string{
+		"code-review": dockyardSpecYAML(
+			"https://github.com/getsentry/skills",
+			bumpedRef, "skills/code-review", "0.1.0",
+		),
+	})
+
+	// The registry participates in dockyard syncing via security-review.
+	root, skillsDir := seedRegistry(t)
+	writeEntry(t, skillsDir, "code-review", fixtureNonDockyardSkillJSON, fixtureIconSVG)
+	before, _ := os.ReadFile(filepath.Join(skillsDir, "code-review", "skill.json"))
+
+	results, err := createMissingSkills(context.Background(), optsFor(srv, false), root)
+	if err != nil {
+		t.Fatalf("createMissingSkills: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected no results, got %+v", results)
+	}
+	after, _ := os.ReadFile(filepath.Join(skillsDir, "code-review", "skill.json"))
+	if string(before) != string(after) {
+		t.Errorf("existing entry was modified")
+	}
+}
+
+func TestCreateMissingSkills_SkipsNonParticipatingRegistry(t *testing.T) {
+	t.Parallel()
+	srv := fakeDockyard(t, map[string]string{
+		newSkillName: dockyardSpecYAML(
+			fixtureRepoURL, bumpedRef, "skills/new-skill", "0.2.0",
+		),
+	})
+
+	// One registry with no dockyard-sourced skills and one with an empty
+	// skills directory: neither has opted into dockyard syncing, so no
+	// entries are onboarded.
+	root := t.TempDir()
+	writeEntry(t, filepath.Join(root, "toolhive", "skills"), "code-review", fixtureNonDockyardSkillJSON, fixtureIconSVG)
+	if err := os.MkdirAll(filepath.Join(root, "official", "skills"), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	results, err := createMissingSkills(context.Background(), optsFor(srv, false), root)
+	if err != nil {
+		t.Fatalf("createMissingSkills: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected no results, got %+v", results)
+	}
+	for _, reg := range []string{"toolhive", "official"} {
+		if _, err := os.Stat(filepath.Join(root, reg, "skills", newSkillName)); !os.IsNotExist(err) {
+			t.Errorf("skill was created in non-participating registry %s", reg)
+		}
+	}
+}
+
+func TestCreateMissingSkills_DryRunWritesNothing(t *testing.T) {
+	t.Parallel()
+	srv := fakeDockyard(t, map[string]string{
+		newSkillName: dockyardSpecYAML(
+			fixtureRepoURL, bumpedRef, "skills/new-skill", "0.2.0",
+		),
+	})
+
+	root, skillsDir := seedRegistry(t)
+	results, err := createMissingSkills(context.Background(), optsFor(srv, true), root)
+	if err != nil {
+		t.Fatalf("createMissingSkills: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %+v", results)
+	}
+	res := results[0]
+	if res.Status != statusNoop || !res.Planned || res.Op != opCreate {
+		t.Fatalf("expected planned noop create, got %+v", res)
+	}
+	if !strings.Contains(res.Detail, "would create") {
+		t.Errorf("expected would-create detail, got %q", res.Detail)
+	}
+	if _, err := os.Stat(filepath.Join(skillsDir, newSkillName)); !os.IsNotExist(err) {
+		t.Errorf("dry-run created a directory on disk")
+	}
+}
+
+func TestCreateMissingSkills_IgnoreFile(t *testing.T) {
+	t.Parallel()
+	srv := fakeDockyard(t, map[string]string{
+		"unwanted-skill": dockyardSpecYAML(
+			fixtureRepoURL, bumpedRef, "skills/unwanted-skill", "0.2.0",
+		),
+	})
+
+	root, skillsDir := seedRegistry(t)
+	ignore := "# consolidated upstream; catalog keeps split entries\nunwanted-skill\n"
+	if err := os.WriteFile(filepath.Join(skillsDir, syncIgnoreFile), []byte(ignore), 0600); err != nil {
+		t.Fatalf("write ignore file: %v", err)
+	}
+
+	results, err := createMissingSkills(context.Background(), optsFor(srv, false), root)
+	if err != nil {
+		t.Fatalf("createMissingSkills: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected ignored skill to be skipped, got %+v", results)
+	}
+	if _, err := os.Stat(filepath.Join(skillsDir, "unwanted-skill")); !os.IsNotExist(err) {
+		t.Errorf("ignored skill was created")
+	}
+}
+
+func TestCreateSkillEntry_MissingVersionErrors(t *testing.T) {
+	t.Parallel()
+	srv := fakeDockyard(t, map[string]string{
+		newSkillName: dockyardSpecYAML(
+			fixtureRepoURL, bumpedRef, "skills/new-skill", "",
+		),
+	})
+
+	_, skillsDir := seedRegistry(t)
+	res := createSkillEntry(context.Background(), optsFor(srv, false), skillsDir, newSkillName)
+	if res.Status != statusError {
+		t.Fatalf("expected error, got %s (%s)", res.Status, res.Detail)
+	}
+	if !strings.Contains(res.Detail, "spec.version") {
+		t.Errorf("expected spec.version in detail, got %q", res.Detail)
+	}
+	if _, err := os.Stat(filepath.Join(skillsDir, newSkillName)); !os.IsNotExist(err) {
+		t.Errorf("failed create left a directory behind")
+	}
+}
+
+func TestCreateThenSyncIsNoop(t *testing.T) {
+	t.Parallel()
+	srv := fakeDockyard(t, map[string]string{
+		newSkillName: dockyardSpecYAML(
+			fixtureRepoURL, bumpedRef, "skills/new-skill", "0.2.0",
+		),
+	})
+
+	root, skillsDir := seedRegistry(t)
+	opts := optsFor(srv, false)
+	if _, err := createMissingSkills(context.Background(), opts, root); err != nil {
+		t.Fatalf("createMissingSkills: %v", err)
+	}
+
+	path := filepath.Join(skillsDir, newSkillName, "skill.json")
+	res := syncOneSkill(context.Background(), opts, path)
+	if res.Status != statusNoop {
+		t.Fatalf("expected noop after create, got %s (%s)", res.Status, res.Detail)
+	}
+}
+
+func TestListDockyardSkillNames_AuthHeader(t *testing.T) {
+	t.Parallel()
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"name":"foo","type":"dir"}]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	opts := syncOptions{
+		APIBaseURL:  srv.URL,
+		DockyardRef: "main",
+		HTTP:        srv.Client(),
+	}
+	names, err := listDockyardSkillNames(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("listDockyardSkillNames: %v", err)
+	}
+	if len(names) != 1 || names[0] != "foo" {
+		t.Errorf("unexpected names %v", names)
+	}
+	if gotAuth != "" {
+		t.Errorf("expected no Authorization header without token, got %q", gotAuth)
+	}
+
+	opts.GitHubToken = "test-token"
+	if _, err := listDockyardSkillNames(context.Background(), opts); err != nil {
+		t.Fatalf("listDockyardSkillNames with token: %v", err)
+	}
+	if gotAuth != "Bearer test-token" {
+		t.Errorf("expected bearer token header, got %q", gotAuth)
+	}
+}
+
+func TestListDockyardSkillNames_FiltersFiles(t *testing.T) {
+	t.Parallel()
+	srv := fakeDockyard(t, map[string]string{
+		"b-skill": "",
+		"a-skill": "",
+	})
+	names, err := listDockyardSkillNames(context.Background(), optsFor(srv, false))
+	if err != nil {
+		t.Fatalf("listDockyardSkillNames: %v", err)
+	}
+	// README.md ("type":"file") must be filtered; names come back sorted.
+	if len(names) != 2 || names[0] != "a-skill" || names[1] != "b-skill" {
+		t.Errorf("unexpected names %v", names)
+	}
+}
+
+func TestDeriveTitle(t *testing.T) {
+	t.Parallel()
+	cases := []struct{ in, want string }{
+		{"tdd", "TDD"},
+		{newSkillName, "New Skill"},
+		{"vercel-cli-with-tokens", "Vercel CLI With Tokens"},
+		{"dd-llmo-eval-trace-rca", "Dd Llmo Eval Trace RCA"},
+		{"obsidian-markdown", "Obsidian Markdown"},
+		{"json-canvas", "JSON Canvas"},
+	}
+	for _, tc := range cases {
+		if got := deriveTitle(tc.in); got != tc.want {
+			t.Errorf("deriveTitle(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestAddMissingRequiresAll(t *testing.T) {
+	t.Parallel()
+	syncSkillsAddMissing = true
+	syncSkillsAll = false
+	t.Cleanup(func() {
+		syncSkillsAddMissing = false
+		syncSkillsAll = false
+	})
+	err := validateSyncSkillsArgs(nil, []string{"some/skill.json"})
+	if err == nil || !strings.Contains(err.Error(), "--add-missing requires --all") {
+		t.Fatalf("expected --add-missing requires --all error, got %v", err)
+	}
+}

--- a/cmd/catalog/sync_skills_create_test.go
+++ b/cmd/catalog/sync_skills_create_test.go
@@ -138,7 +138,7 @@ func TestCreateMissingSkills_CopiesSiblingIcon(t *testing.T) {
 	if len(results) != 1 || results[0].Status != statusCreated {
 		t.Fatalf("expected 1 created result, got %+v", results)
 	}
-	if want := "icon copied from " + securityReview; results[0].Detail != want {
+	if want := "icon copied from " + securityReview + "; license needs review"; results[0].Detail != want {
 		t.Errorf("expected detail %q, got %q", want, results[0].Detail)
 	}
 	icon, err := os.ReadFile(filepath.Join(skillsDir, "agents-md", "icon.svg"))
@@ -302,6 +302,23 @@ func TestCreateSkillEntry_MissingVersionErrors(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(skillsDir, newSkillName)); !os.IsNotExist(err) {
 		t.Errorf("failed create left a directory behind")
+	}
+}
+
+func TestCreateSkillEntry_MissingSpecIsNonFatal(t *testing.T) {
+	t.Parallel()
+	// fakeDockyard 404s any name absent from its specs map, mimicking a
+	// dockyard skills/ dir with no fetchable spec.yaml. This must be skipped
+	// (missing), not turned into a fatal error that aborts the whole sync.
+	srv := fakeDockyard(t, map[string]string{})
+
+	_, skillsDir := seedRegistry(t)
+	res := createSkillEntry(context.Background(), optsFor(srv, false), skillsDir, "no-such-skill")
+	if res.Status != statusMissing {
+		t.Fatalf("expected missing, got %s (%s)", res.Status, res.Detail)
+	}
+	if _, err := os.Stat(filepath.Join(skillsDir, "no-such-skill")); !os.IsNotExist(err) {
+		t.Errorf("missing skill left a directory behind")
 	}
 }
 

--- a/cmd/catalog/sync_skills_test.go
+++ b/cmd/catalog/sync_skills_test.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -86,6 +88,8 @@ spec:
 
 // fakeDockyard returns an httptest.Server that serves spec.yaml files for the
 // given map of skill name -> body. Skills missing from the map yield 404.
+// It also serves a GitHub-contents-style directory listing of the map keys
+// at /api/contents/skills (plus one file entry, which callers must filter).
 func fakeDockyard(t *testing.T, specs map[string]string) *httptest.Server {
 	t.Helper()
 	mux := http.NewServeMux()
@@ -105,6 +109,19 @@ func fakeDockyard(t *testing.T, specs map[string]string) *httptest.Server {
 		w.Header().Set("Content-Type", "text/plain")
 		_, _ = w.Write([]byte(body))
 	})
+	mux.HandleFunc("/api/contents/skills", func(w http.ResponseWriter, _ *http.Request) {
+		names := make([]string, 0, len(specs))
+		for name := range specs {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		entries := []contentsEntry{{Name: "README.md", Type: "file"}}
+		for _, name := range names {
+			entries = append(entries, contentsEntry{Name: name, Type: "dir"})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(entries)
+	})
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 	return srv
@@ -113,6 +130,7 @@ func fakeDockyard(t *testing.T, specs map[string]string) *httptest.Server {
 func optsFor(srv *httptest.Server, dryRun bool) syncOptions {
 	return syncOptions{
 		BaseURL:     srv.URL,
+		APIBaseURL:  srv.URL + "/api",
 		DockyardRef: "main",
 		DryRun:      dryRun,
 		HTTP:        srv.Client(),

--- a/internal/skilljson/serialize.go
+++ b/internal/skilljson/serialize.go
@@ -1,0 +1,58 @@
+package skilljson
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// NewSkill describes a skill.json to be created from scratch. The struct
+// field order matches the conventional key order of existing entries under
+// registries/<reg>/skills/ so generated files look hand-written.
+type NewSkill struct {
+	Namespace   string       `json:"namespace"`
+	Name        string       `json:"name"`
+	Title       string       `json:"title"`
+	Description string       `json:"description"`
+	Version     string       `json:"version"`
+	Status      string       `json:"status"`
+	Repository  Repository   `json:"repository"`
+	Icons       []Icon       `json:"icons"`
+	Packages    []NewPackage `json:"packages"`
+}
+
+// Repository is the upstream source repository of a skill.
+type Repository struct {
+	URL  string `json:"url"`
+	Type string `json:"type"`
+}
+
+// Icon is a single icon reference in a skill.json.
+type Icon struct {
+	Src  string `json:"src"`
+	Type string `json:"type"`
+}
+
+// NewPackage is a package entry of a generated skill.json. OCI packages set
+// Identifier; git packages set URL, Ref, and Subfolder.
+type NewPackage struct {
+	RegistryType string `json:"registryType"`
+	Identifier   string `json:"identifier,omitempty"`
+	URL          string `json:"url,omitempty"`
+	Ref          string `json:"ref,omitempty"`
+	Subfolder    string `json:"subfolder,omitempty"`
+}
+
+// MarshalNewSkill renders a NewSkill in the on-disk skill.json convention:
+// two-space indentation, no HTML escaping (descriptions may contain raw
+// < or &), and a trailing newline.
+func MarshalNewSkill(s NewSkill) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(s); err != nil {
+		return nil, fmt.Errorf("failed to marshal skill %q: %w", s.Name, err)
+	}
+	return buf.Bytes(), nil
+}

--- a/internal/skilljson/serialize_test.go
+++ b/internal/skilljson/serialize_test.go
@@ -1,0 +1,116 @@
+package skilljson
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func testNewSkill() NewSkill {
+	return NewSkill{
+		Namespace:   "io.github.stacklok",
+		Name:        "tdd",
+		Title:       "TDD",
+		Description: "Test-driven development with a red-green-refactor loop — use when writing code & tests.",
+		Version:     "0.1.1",
+		Status:      "active",
+		Repository: Repository{
+			URL:  "https://github.com/mattpocock/skills",
+			Type: RegistryTypeGit,
+		},
+		Icons: []Icon{
+			{Src: "icon.svg", Type: "image/svg+xml"},
+		},
+		Packages: []NewPackage{
+			{
+				RegistryType: "oci",
+				Identifier:   DockyardSkillPrefix + "tdd:0.1.1",
+			},
+			{
+				RegistryType: RegistryTypeGit,
+				URL:          "https://github.com/mattpocock/skills",
+				Ref:          "f304057d61d3df3c9fd992ac2b6e3833cb9325fb",
+				Subfolder:    "skills/engineering/tdd",
+			},
+		},
+	}
+}
+
+func TestMarshalNewSkillGolden(t *testing.T) {
+	t.Parallel()
+	const want = `{
+  "namespace": "io.github.stacklok",
+  "name": "tdd",
+  "title": "TDD",
+  "description": "Test-driven development with a red-green-refactor loop — use when writing code & tests.",
+  "version": "0.1.1",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/mattpocock/skills",
+    "type": "git"
+  },
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/stacklok/dockyard/skills/tdd:0.1.1"
+    },
+    {
+      "registryType": "git",
+      "url": "https://github.com/mattpocock/skills",
+      "ref": "f304057d61d3df3c9fd992ac2b6e3833cb9325fb",
+      "subfolder": "skills/engineering/tdd"
+    }
+  ]
+}
+`
+	got, err := MarshalNewSkill(testNewSkill())
+	if err != nil {
+		t.Fatalf("MarshalNewSkill: %v", err)
+	}
+	if string(got) != want {
+		t.Errorf("output mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestMarshalNewSkillNoHTMLEscaping(t *testing.T) {
+	t.Parallel()
+	s := testNewSkill()
+	s.Description = "under 60 lines <target>, minimal & high-signal"
+	got, err := MarshalNewSkill(s)
+	if err != nil {
+		t.Fatalf("MarshalNewSkill: %v", err)
+	}
+	if want := `"under 60 lines <target>, minimal & high-signal"`; !strings.Contains(string(got), want) {
+		t.Errorf("expected raw %s in output, got:\n%s", want, got)
+	}
+}
+
+func TestMarshalNewSkillRoundTrip(t *testing.T) {
+	t.Parallel()
+	data, err := MarshalNewSkill(testNewSkill())
+	if err != nil {
+		t.Fatalf("MarshalNewSkill: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "skill.json")
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	sf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	idx, name, tag := sf.DockyardOCIPackage()
+	if idx != 0 || name != "tdd" || tag != "0.1.1" {
+		t.Errorf("DockyardOCIPackage = (%d, %q, %q), want (0, tdd, 0.1.1)", idx, name, tag)
+	}
+	if gitIdx := sf.GitPackage(); gitIdx != 1 {
+		t.Errorf("GitPackage = %d, want 1", gitIdx)
+	}
+}

--- a/internal/skilljson/skilljson.go
+++ b/internal/skilljson/skilljson.go
@@ -18,6 +18,9 @@ import (
 // the stacklok/dockyard pipeline.
 const DockyardSkillPrefix = "ghcr.io/stacklok/dockyard/skills/"
 
+// RegistryTypeGit is the package registryType value for git-sourced packages.
+const RegistryTypeGit = "git"
+
 // SkillFile represents a loaded skill.json with both its parsed structure
 // and its original bytes for round-trip fidelity.
 type SkillFile struct {
@@ -73,7 +76,7 @@ func (sf *SkillFile) DockyardOCIPackage() (idx int, skillName, currentTag string
 // GitPackage returns the index of the first git package, or -1 if none.
 func (sf *SkillFile) GitPackage() int {
 	for i, p := range sf.Skill.Packages {
-		if p.RegistryType == "git" {
+		if p.RegistryType == RegistryTypeGit {
 			return i
 		}
 	}


### PR DESCRIPTION
## Summary

Dockyard packages and publishes 150 skills, but the catalog only had 129 entries — 35 published skills were never onboarded and so never reached ToolHive Studio (which serves skills from the catalog via the registry API). The only existing automation, the weekly `sync-skills` workflow, only aligns the OCI tag and git ref of skills that **already** have a catalog entry; nothing ever created new ones, so a new dockyard skill would silently never surface downstream.

This PR adds an `--add-missing` mode to `catalog sync-skills` that enumerates dockyard's skills, diffs them against each registry's `skills/` directory, and generates the missing `skill.json` + `icon.svg` entries — wired into the existing weekly auto-PR workflow so a human still reviews before merge.

- `catalog sync-skills --all --add-missing` lists dockyard's `skills/` directory via the GitHub contents API and creates an entry for every name with no existing catalog directory.
- New entries reuse a sibling skill's icon when another catalog entry shares the same upstream repository, otherwise a placeholder icon is written and flagged `needs review` in the sync output.
- Titles are derived from the skill name (e.g. `vercel-cli-with-tokens` → "Vercel CLI With Tokens"); `license` is left for reviewers to fill in.
- Existing directories are never overwritten — dockyard publishes a `code-review` skill that is a *different* entry from the catalog's existing catalog-hosted `code-review`, so "missing" is computed as dockyard names minus existing directories, never as a content diff.
- Only registries that already carry at least one dockyard-sourced skill participate (the `official` registry has an empty `skills/` directory and has not opted in).
- A per-registry `.sync-skills-ignore` file (one skill name per line, `#` comments) can durably exclude a dockyard skill from auto-onboarding.
- Fixed two latent bugs in `sync-skills.yml`: `git add -u` doesn't stage new files, and `git diff --quiet` ignores untracked files — a create-only run would previously report "no changes" and silently never open a PR.

## Changes

| File | Change |
|---|---|
| `internal/skilljson/serialize.go` | New `NewSkill` type + `MarshalNewSkill`, matching the on-disk skill.json convention (field order, indentation, no HTML escaping) |
| `internal/skilljson/skilljson.go` | Added `RegistryTypeGit` constant |
| `cmd/catalog/sync_skills_create.go` | New create-mode logic: dockyard listing, missing-skill diff, sibling icon lookup, title derivation, ignore file |
| `cmd/catalog/sync_skills.go` | `--add-missing`/`--dockyard-api-url` flags, `created` status, updated summary reporting |
| `.github/workflows/sync-skills.yml` | Enable `--add-missing`, fix change-detection to catch untracked files, update PR body |
| `cmd/catalog/sync_skills_create_test.go`, `cmd/catalog/sync_skills_test.go`, `internal/skilljson/serialize_test.go` | New and extended unit tests |

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Test plan

- [x] Unit tests pass (`go test -race ./...`)
- [x] Linting passes (`golangci-lint run --allow-parallel-runners ./...`)
- [x] Manual testing performed

Manual testing details:
- `catalog sync-skills --all --add-missing --dry-run` against the live `stacklok/dockyard` repo reported exactly 35 would-create entries.
- A live (non-dry-run) run against the working tree created all 35 entries with 0 errors; `catalog validate` passed (164 valid skills); spot-checked `tdd` (correct title, git ref, OCI tag) and confirmed Datadog/Firebase skills correctly picked up sibling icons.
- Re-running `--add-missing` afterward reported 0 created / all noop, confirming idempotence and that the generated skill.json round-trips through the existing byte-level tag/ref updater.
- Reverted the generated entries before committing so this PR only contains the tooling change — the next scheduled/dispatched workflow run will create and PR the 35 entries for review.
- Confirmed plain `sync-skills --all` (no flag) output is unchanged aside from the new summary column.

## Special notes for reviewers

This PR does not add any new skill entries itself — it only changes the sync tooling. The 35 missing dockyard skills will be proposed via the normal `catalog-sync-skills` automated PR on the next scheduled run (or via `workflow_dispatch`), where reviewers can review/adjust auto-generated titles and swap any placeholder icons before merging.

Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NYJALZQEcySvcaaFUAVBBG)_