### PR TITLE
fix: update grafana MCP server to 0.17.2 and force stdio transport

### DIFF
--- a/registries/official/servers/grafana/server.json
+++ b/registries/official/servers/grafana/server.json
@@ -3,18 +3,19 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.stacklok": {
-        "docker.io/grafana/mcp-grafana:0.17.0": {
+        "docker.io/grafana/mcp-grafana:0.17.2": {
+          "args": [
+            "--transport",
+            "stdio"
+          ],
           "metadata": {
-            "last_updated": "2026-04-24T03:04:34Z",
-            "stars": 2900
+            "last_updated": "2026-07-15T23:57:12Z",
+            "stars": 3239
           },
-          "overview": "## Grafana MCP Server\n\nThe grafana MCP server is a Model Context Protocol (MCP) server that enables AI assistants and agents to interact directly with Grafana dashboards, data sources, and observability resources through a structured, AI-friendly interface. It allows AI-driven workflows to explore metrics, logs, alerts, and dashboards without switching tools or manually navigating the Grafana UI. This server is ideal for observability, incident response, performance analysis, and operational workflows where real-time telemetry and monitoring context are essential.",
+          "overview": "## Grafana MCP Server\n\nThe grafana MCP server is a Model Context Protocol (MCP) server that enables AI assistants and agents to interact directly with Grafana dashboards, data sources, and observability resources through a structured, AI-friendly interface. It allows AI-driven workflows to explore metrics, logs, alerts, and dashboards without switching tools or manually navigating the Grafana UI. This server is ideal for observability, incident response, performance analysis, and operational workflows where real-time telemetry and monitoring context are essential.\n\n**Note:** the upstream container's entrypoint defaults to the SSE transport, so this entry passes `--transport stdio` via its registry args to force stdio mode. If you run this server with your own custom arguments (`thv run ... -- \u003cyour args\u003e`), those arguments replace the registry defaults, so be sure to include `--transport stdio` yourself or the server will silently fall back to SSE.",
           "permissions": {
             "network": {
               "outbound": {
-                "allow_port": [
-                  443
-                ],
                 "insecure_allow_all": true
               }
             }
@@ -40,20 +41,2644 @@
             "oncall"
           ],
           "tier": "Official",
+          "tool_definitions": [
+            {
+              "annotations": {
+                "title": "Add activity to incident"
+              },
+              "description": "Add a note (userNote activity) to an existing incident's timeline using its ID. The note body can include URLs which will be attached as context. Use this to add context to an incident.",
+              "inputSchema": {
+                "properties": {
+                  "body": {
+                    "description": "The body of the activity. URLs will be parsed and attached as context",
+                    "type": "string"
+                  },
+                  "eventTime": {
+                    "description": "The time that the activity occurred. If not provided, the current time will be used",
+                    "type": "string"
+                  },
+                  "incidentId": {
+                    "description": "The ID of the incident to add the activity to",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "incidentId",
+                  "body"
+                ],
+                "type": "object"
+              },
+              "name": "add_activity_to_incident"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Manage alerting routing"
+              },
+              "description": "Manage Grafana alerting routing configuration, including notification policies, contact points and time intervals.\n\nNotification policies define how alerts are grouped, routed, and which contact points receive them.\nTime intervals define active/mute periods for alert notifications.\n\nWhen to use:\n- Understanding how alerts are routed to contact points/receivers\n- Debugging why an alert went to a specific receiver\n- Checking grouping, timing, or mute interval settings\n\nWhen NOT to use:\n- Checking alert rule configuration or state (use alerting_manage_rules)",
+              "inputSchema": {
+                "properties": {
+                  "contact_point_title": {
+                    "description": "Title of the contact point to retrieve (required for get_contact_point operation)",
+                    "type": "string"
+                  },
+                  "datasource_uid": {
+                    "description": "Optional: UID of an Alertmanager-compatible datasource to query for receivers. If omitted, returns Grafana-managed contact points. Only used with get_contact_points.",
+                    "type": "string"
+                  },
+                  "limit": {
+                    "description": "The maximum number of results to return. Default is 100. Only used with get_contact_points.",
+                    "type": "integer"
+                  },
+                  "name": {
+                    "description": "Filter contact points by name (exact match). Only used with get_contact_points.",
+                    "type": "string"
+                  },
+                  "operation": {
+                    "description": "The operation to perform: 'get_notification_policies' to retrieve the notification policy tree, 'get_contact_points' to list all contact points, 'get_contact_point' to get a specific contact point by name, 'get_time_intervals' to list all time intervals, 'get_time_interval' to get a specific time interval by name",
+                    "enum": [
+                      "get_notification_policies",
+                      "get_contact_points",
+                      "get_contact_point",
+                      "get_time_intervals",
+                      "get_time_interval"
+                    ],
+                    "type": "string"
+                  },
+                  "time_interval_name": {
+                    "description": "Name of the time interval to retrieve (required for get_time_interval operation)",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "operation"
+                ],
+                "type": "object"
+              },
+              "name": "alerting_manage_routing"
+            },
+            {
+              "annotations": {
+                "destructiveHint": true,
+                "title": "Manage alert rules"
+              },
+              "description": "Manage Grafana alert rules with full CRUD capabilities and filtering.\n\nWhen to use:\n- Understanding why an alert is or isn't firing\n- Auditing alert rule configuration (queries, conditions, labels, notification settings)\n- Finding alert rules by state, folder, group, or name\n- Creating, updating, or deleting alert rules\n- Comparing rule versions to see what changed\n\nWhen NOT to use:\n- Checking how alerts are routed to receivers (use alerting_manage_routing)",
+              "inputSchema": {
+                "properties": {
+                  "annotations": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Optional annotations for the alert rule",
+                    "type": "object"
+                  },
+                  "condition": {
+                    "description": "The query condition identifier, e.g. 'A', 'B' (required for 'create', 'update')",
+                    "type": "string"
+                  },
+                  "data": {
+                    "description": "Array of alert query objects (required for 'create'/'update'). Each object has: datasourceUid (string, required), model (object with expr for data queries or type/expression/conditions for expressions), refId (string, auto-assigned if omitted), relativeTimeRange ({from, to} in seconds, defaults to {from:600,to:0}). For server-side expressions use datasourceUid '__expr__'. Example: [{datasourceUid: 'prometheus', model: {expr: 'up == 0'}}, {datasourceUid: '__expr__', model: {type: 'threshold', expression: 'A', conditions: [{evaluator: {type: 'gt', params: [0]}}]}}]",
+                    "items": {
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "datasource_uid": {
+                    "description": "Optional: UID of a Prometheus or Loki datasource to query for datasource-managed alert rules (for 'list' operation)",
+                    "type": "string"
+                  },
+                  "disable_provenance": {
+                    "description": "If true, the alert remains editable in the Grafana UI (sets X-Disable-Provenance header). Defaults to true.",
+                    "type": "boolean"
+                  },
+                  "exec_err_state": {
+                    "description": "State on execution error: NoData, Alerting, OK (required for 'create', 'update')",
+                    "type": "string"
+                  },
+                  "folder_uid": {
+                    "description": "The folder UID. For 'list': filter by exact folder UID (mutually exclusive with search_folder). For 'create'/'update': the folder to store the rule in (required).",
+                    "type": "string"
+                  },
+                  "for": {
+                    "description": "Duration before alert fires, e.g. '5m' (required for 'create', 'update')",
+                    "type": "string"
+                  },
+                  "is_paused": {
+                    "description": "If true, the alert rule remains inactive, Default is false",
+                    "type": "boolean"
+                  },
+                  "keep_firing_for": {
+                    "description": "Enables continous firing of alert for specified time even when condition is no longer met. Default is 0 (resolves immediately)",
+                    "type": "string"
+                  },
+                  "label_selectors": {
+                    "description": "Prometheus-style selectors to filter alert rules by labels. Each string is a selector e.g. '{severity=\"critical\", team=~\"backend.*\"}'. All selectors must match (AND).",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "labels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Optional labels for the alert rule",
+                    "type": "object"
+                  },
+                  "limit_alerts": {
+                    "description": "Limit alert instances per rule. For list: 0 omits alerts. For get: \u003c=0 defaults to 200. Max 200.",
+                    "type": "integer"
+                  },
+                  "matchers": {
+                    "description": "Label matchers to filter alert instances. Each string is a Prometheus-style matcher e.g. 'severity=\"critical\"', 'env!=\"dev\"', 'team=~\"backend.*\"'. Requires Grafana 12.4+.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "missing_series_evals_to_resolve": {
+                    "description": "Consecutive evaluation intervals with no data required to mark the alert as resolved. Default is 2.",
+                    "type": "integer"
+                  },
+                  "no_data_state": {
+                    "description": "State when no data: NoData, Alerting, OK (required for 'create', 'update')",
+                    "type": "string"
+                  },
+                  "notification_settings": {
+                    "description": "Notification settings object. Fields: receiver (string, required), groupBy ([]string), groupWait/groupInterval/repeatInterval (duration strings), muteTimeIntervals/activeTimeIntervals ([]string).",
+                    "type": "object"
+                  },
+                  "operation": {
+                    "description": "The operation to perform: 'list', 'get', 'versions', 'create', 'update', or 'delete'. To create a rule, use operation 'create' and provide all required fields in a single call. To update a rule, first use 'get' to retrieve its full configuration, then 'update' with all required fields plus your changes.",
+                    "enum": [
+                      "list",
+                      "get",
+                      "versions",
+                      "create",
+                      "update",
+                      "delete"
+                    ],
+                    "type": "string"
+                  },
+                  "org_id": {
+                    "description": "The organization ID (required for 'create', 'update')",
+                    "type": "integer"
+                  },
+                  "record": {
+                    "description": "Recording rule config. Fields: from (string, required - ref ID e.g. 'A'), metric (string, required - metric name), targetDatasourceUid (string, optional).",
+                    "type": "object"
+                  },
+                  "rule_group": {
+                    "description": "The rule group name (required for 'create', 'update')",
+                    "type": "string"
+                  },
+                  "rule_limit": {
+                    "default": 200,
+                    "description": "Maximum number of rules to return (default 200, max 200). Requires Grafana 12.4+ (for 'list' operation)",
+                    "type": "integer"
+                  },
+                  "rule_type": {
+                    "description": "Filter by rule type (for 'list' operation)",
+                    "enum": [
+                      "alerting",
+                      "recording"
+                    ],
+                    "type": "string"
+                  },
+                  "rule_uid": {
+                    "description": "The UID of the alert rule (required for 'get', 'versions', 'update', 'delete'; optional for 'create')",
+                    "type": "string"
+                  },
+                  "search_folder": {
+                    "description": "Search folders by path using partial matching (for 'list' operation). Requires Grafana 12.4+. Mutually exclusive with folder_uid.",
+                    "type": "string"
+                  },
+                  "search_rule_name": {
+                    "description": "Search alert rule names/titles using partial matching. Requires Grafana 12.4+ (for 'list' operation)",
+                    "type": "string"
+                  },
+                  "states": {
+                    "description": "Filter by alert state: firing, pending, normal, recovering, nodata, error (for 'list' operation)",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "title": {
+                    "description": "The title of the alert rule (required for 'create', 'update')",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "operation"
+                ],
+                "type": "object"
+              },
+              "name": "alerting_manage_rules"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Analyze Loki label strategy"
+              },
+              "description": "Audits a Loki label strategy and optionally diagnoses query performance. Returns per-label verdicts, missing base labels, normalisation issues, and a recommended set. Pass datasourceUid for live cardinality or labels for static scoring; both may be combined.",
+              "inputSchema": {
+                "properties": {
+                  "datasourceUid": {
+                    "description": "Datasource UID (live mode).",
+                    "type": "string"
+                  },
+                  "endRfc3339": {
+                    "type": "string"
+                  },
+                  "expectedBaseLabels": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "labels": {
+                    "description": "Caller-supplied labels (static mode).",
+                    "items": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "sampleValues": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "unbounded": {
+                          "type": "boolean"
+                        },
+                        "uniqueValues": {
+                          "type": "integer"
+                        },
+                        "usedInQueries": {
+                          "type": "string"
+                        },
+                        "valueKind": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "maxLabels": {
+                    "type": "integer"
+                  },
+                  "perfMetrics": {
+                    "description": "Runtime metrics; presence triggers perf diagnosis.",
+                    "properties": {
+                      "cacheChunkReqs": {
+                        "type": "integer"
+                      },
+                      "chunkRefsFetchTimeSec": {
+                        "type": "number"
+                      },
+                      "executionTimeSec": {
+                        "type": "number"
+                      },
+                      "postFilterLines": {
+                        "type": "integer"
+                      },
+                      "queueTimeSec": {
+                        "type": "number"
+                      },
+                      "storeChunksDownloadTimeSec": {
+                        "type": "number"
+                      },
+                      "totalBytes": {
+                        "type": "integer"
+                      },
+                      "totalLines": {
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "selector": {
+                    "description": "Optional LogQL selector for stats / perf diagnosis.",
+                    "type": "string"
+                  },
+                  "startRfc3339": {
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "analyze_loki_labels"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Check datasources health"
+              },
+              "description": "Check datasource health. Filter by type or UIDs; omit both to check all.",
+              "inputSchema": {
+                "properties": {
+                  "offset": {
+                    "default": 0,
+                    "description": "Number to skip for pagination",
+                    "type": "integer"
+                  },
+                  "type": {
+                    "description": "Plugin type filter; omit to check all",
+                    "type": "string"
+                  },
+                  "uids": {
+                    "description": "UIDs to check",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "check_datasources_health"
+            },
+            {
+              "annotations": {
+                "idempotentHint": false,
+                "title": "Create Annotation"
+              },
+              "description": "Create a new annotation on a dashboard or panel. Set format to 'graphite' and provide 'what' for Graphite-format annotations.",
+              "inputSchema": {
+                "properties": {
+                  "dashboardUid": {
+                    "description": "Dashboard UID",
+                    "type": "string"
+                  },
+                  "data": {
+                    "description": "Optional JSON payload",
+                    "type": "object"
+                  },
+                  "format": {
+                    "description": "Set to 'graphite' to create a Graphite-format annotation",
+                    "enum": [
+                      "graphite"
+                    ],
+                    "type": "string"
+                  },
+                  "graphiteData": {
+                    "description": "Optional string payload for Graphite format",
+                    "type": "string"
+                  },
+                  "panelId": {
+                    "description": "Panel ID",
+                    "type": "integer"
+                  },
+                  "tags": {
+                    "description": "Optional list of tags",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "text": {
+                    "description": "Annotation text (required unless format is graphite)",
+                    "type": "string"
+                  },
+                  "time": {
+                    "description": "Start time epoch ms",
+                    "type": "integer"
+                  },
+                  "timeEnd": {
+                    "description": "End time epoch ms",
+                    "type": "integer"
+                  },
+                  "what": {
+                    "description": "Annotation text for Graphite format (required when format is graphite)",
+                    "type": "string"
+                  },
+                  "when": {
+                    "description": "Epoch ms timestamp for Graphite format",
+                    "type": "integer"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "create_annotation"
+            },
+            {
+              "annotations": {
+                "idempotentHint": false,
+                "readOnlyHint": false,
+                "title": "Create datasource"
+              },
+              "description": "Create a datasource. If type is ambiguous, call search_plugin_information first; install the plugin if needed. IMPORTANT: always call this tool twice. First call: provide only the type — the tool returns a field schema. After receiving the schema, you MUST ask the user for every required field value explicitly; do not infer or use defaults without user confirmation. Second call: provide the type, the display name in the top-level name argument, schemaReviewed=true, and the fields map populated with values confirmed by the user. Never handle credentials — remind the user to rotate any detected. Returns UID, health check, and a config page link. ",
+              "inputSchema": {
+                "properties": {
+                  "access": {
+                    "description": "How Grafana should access the datasource (proxy or direct)",
+                    "type": "string"
+                  },
+                  "basicAuth": {
+                    "description": "Whether Grafana should use basic auth",
+                    "type": "boolean"
+                  },
+                  "database": {
+                    "description": "Optional database name",
+                    "type": "string"
+                  },
+                  "fields": {
+                    "description": "Datasource field values to provision, keyed by field key from the schema returned on the first call. The server uses each field's target (root or jsonData) to place values correctly in the YAML. Example: {\"url\": \"http://prometheus:9090\", \"httpMethod\": \"POST\"}.",
+                    "type": "object"
+                  },
+                  "isDefault": {
+                    "description": "Whether this should become the default datasource",
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "description": "Datasource display name",
+                    "type": "string"
+                  },
+                  "schemaReviewed": {
+                    "description": "Set to true on the second call to confirm you reviewed the schema and collected values from the user.",
+                    "type": "boolean"
+                  },
+                  "type": {
+                    "description": "Grafana datasource plugin type, for example prometheus",
+                    "type": "string"
+                  },
+                  "url": {
+                    "description": "Datasource base URL when required by the plugin",
+                    "type": "string"
+                  },
+                  "withCredentials": {
+                    "description": "Whether Grafana should forward credentials such as cookies",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "name",
+                  "type"
+                ],
+                "type": "object"
+              },
+              "name": "create_datasource"
+            },
+            {
+              "annotations": {
+                "idempotentHint": false,
+                "title": "Create folder"
+              },
+              "description": "Create a Grafana folder. Provide a title and optional UID. Returns the created folder.",
+              "inputSchema": {
+                "properties": {
+                  "parentUid": {
+                    "description": "Optional parent folder UID. If set, the folder will be created under this parent.",
+                    "type": "string"
+                  },
+                  "title": {
+                    "description": "The title of the folder.",
+                    "type": "string"
+                  },
+                  "uid": {
+                    "description": "Optional folder UID. If omitted, Grafana will generate one.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "title"
+                ],
+                "type": "object"
+              },
+              "name": "create_folder"
+            },
+            {
+              "annotations": {
+                "title": "Create incident"
+              },
+              "description": "Create a new Grafana incident. Requires title, severity, and room prefix. Allows setting status and labels. This tool should be used judiciously and sparingly, and only after confirmation from the user, as it may notify or alarm lots of people.",
+              "inputSchema": {
+                "properties": {
+                  "attachCaption": {
+                    "description": "The caption of the attachment",
+                    "type": "string"
+                  },
+                  "attachUrl": {
+                    "description": "The URL of the attachment",
+                    "type": "string"
+                  },
+                  "isDrill": {
+                    "description": "Whether the incident is a drill incident",
+                    "type": "boolean"
+                  },
+                  "labels": {
+                    "description": "The labels to add to the incident",
+                    "items": {
+                      "properties": {
+                        "colorHex": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "key": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "roomPrefix": {
+                    "description": "The prefix of the room to create the incident in",
+                    "type": "string"
+                  },
+                  "severity": {
+                    "description": "The severity of the incident",
+                    "type": "string"
+                  },
+                  "status": {
+                    "description": "The status of the incident",
+                    "type": "string"
+                  },
+                  "title": {
+                    "description": "The title of the incident",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "title",
+                  "severity",
+                  "roomPrefix"
+                ],
+                "type": "object"
+              },
+              "name": "create_incident"
+            },
+            {
+              "annotations": {
+                "idempotentHint": false,
+                "title": "Create snapshot"
+              },
+              "description": "Create a Grafana snapshot from a full dashboard payload. Supports optional expiration and external snapshot fields.",
+              "inputSchema": {
+                "properties": {
+                  "dashboard": {
+                    "description": "Complete dashboard model to snapshot (as returned by Grafana dashboard APIs)",
+                    "type": "object"
+                  },
+                  "deleteKey": {
+                    "description": "Secret key for deleting external snapshots. Required when external is true",
+                    "type": "string"
+                  },
+                  "expires": {
+                    "description": "Snapshot expiration in seconds (e.g. 3600 for 1 hour)",
+                    "type": "integer"
+                  },
+                  "external": {
+                    "description": "Store snapshot on external server. Requires key and deleteKey when true",
+                    "type": "boolean"
+                  },
+                  "key": {
+                    "description": "Custom snapshot key. Required when external is true",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Optional snapshot name",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "dashboard"
+                ],
+                "type": "object"
+              },
+              "name": "create_snapshot"
+            },
+            {
+              "annotations": {
+                "destructiveHint": true,
+                "idempotentHint": false,
+                "title": "Delete snapshot"
+              },
+              "description": "Delete a Grafana snapshot by snapshot key.",
+              "inputSchema": {
+                "properties": {
+                  "key": {
+                    "description": "Snapshot key to delete",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "key"
+                ],
+                "type": "object"
+              },
+              "name": "delete_snapshot"
+            },
+            {
+              "annotations": {
+                "readOnlyHint": true,
+                "title": "Find error patterns in logs"
+              },
+              "description": "Searches Loki logs for elevated error patterns compared to the last day's average, waits for the analysis to complete, and returns the results including any patterns found.",
+              "inputSchema": {
+                "properties": {
+                  "end": {
+                    "description": "End time for the investigation. Defaults to now if not specified.",
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "labels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Labels to scope the analysis",
+                    "type": "object"
+                  },
+                  "name": {
+                    "description": "The name of the investigation",
+                    "type": "string"
+                  },
+                  "start": {
+                    "description": "Start time for the investigation. Defaults to 30 minutes ago if not specified.",
+                    "format": "date-time",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "labels"
+                ],
+                "type": "object"
+              },
+              "name": "find_error_pattern_logs"
+            },
+            {
+              "annotations": {
+                "readOnlyHint": true,
+                "title": "Find slow requests"
+              },
+              "description": "Searches relevant Tempo datasources for slow requests, waits for the analysis to complete, and returns the results.",
+              "inputSchema": {
+                "properties": {
+                  "end": {
+                    "description": "End time for the investigation. Defaults to now if not specified.",
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "labels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Labels to scope the analysis",
+                    "type": "object"
+                  },
+                  "name": {
+                    "description": "The name of the investigation",
+                    "type": "string"
+                  },
+                  "start": {
+                    "description": "Start time for the investigation. Defaults to 30 minutes ago if not specified.",
+                    "format": "date-time",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "labels"
+                ],
+                "type": "object"
+              },
+              "name": "find_slow_requests"
+            },
+            {
+              "annotations": {
+                "idempotentHint": false,
+                "title": "Generate navigation deeplink"
+              },
+              "description": "Generate deeplink URLs for Grafana resources. Supports dashboards (requires dashboardUid or provisioningPreview), panels (requires dashboardUid or provisioningPreview, plus panelId), and Explore queries (requires datasourceUid and optionally queries). For dashboard and panel links, provisioningPreview points at a dashboard staged on a provisioning repository branch (e.g. a git-sync PR preview). For explore links, the time range and queries are embedded inside the Grafana explore state. Set shorten=true to also attempt a /goto/\u003cuid\u003e short URL; if shortening fails, the full deeplink is returned.",
+              "inputSchema": {
+                "properties": {
+                  "dashboardUid": {
+                    "description": "Dashboard UID (for stored dashboards). Mutually exclusive with provisioningPreview for dashboard and panel types.",
+                    "type": "string"
+                  },
+                  "datasourceUid": {
+                    "description": "Datasource UID (required for explore type)",
+                    "type": "string"
+                  },
+                  "panelId": {
+                    "description": "Panel ID (required for panel type)",
+                    "type": "integer"
+                  },
+                  "provisioningPreview": {
+                    "description": "Identifies a dashboard staged on a provisioning repository branch (e.g. a git-sync PR preview). Mutually exclusive with dashboardUid for dashboard and panel types.",
+                    "properties": {
+                      "path": {
+                        "description": "Path to the dashboard file within the repository, relative to its root.",
+                        "type": "string"
+                      },
+                      "pullRequestUrl": {
+                        "description": "Upstream pull request URL to surface in Grafana's preview banner.",
+                        "type": "string"
+                      },
+                      "ref": {
+                        "description": "Branch or commit SHA. Defaults to the repository's main branch when omitted.",
+                        "type": "string"
+                      },
+                      "repo": {
+                        "description": "Provisioning repository slug. List repositories via list_provisioning_repositories if unknown.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "repo",
+                      "path"
+                    ],
+                    "type": "object"
+                  },
+                  "queries": {
+                    "description": "List of query objects for explore links (e.g. [{\"refId\":\"A\",\"expr\":\"up\"}])",
+                    "items": {
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "queryParams": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Additional URL query parameters (for dashboard/panel types)",
+                    "type": "object"
+                  },
+                  "resourceType": {
+                    "description": "Type of resource: dashboard, panel, or explore",
+                    "type": "string"
+                  },
+                  "shorten": {
+                    "description": "If true, try to shorten the generated URL to /goto/\u003cuid\u003e. If shortening fails, return the original deeplink.",
+                    "type": "boolean"
+                  },
+                  "timeRange": {
+                    "description": "Time range for the link",
+                    "properties": {
+                      "from": {
+                        "description": "Start time (e.g., 'now-1h')",
+                        "type": "string"
+                      },
+                      "to": {
+                        "description": "End time (e.g., 'now')",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "resourceType"
+                ],
+                "type": "object"
+              },
+              "name": "generate_deeplink"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get IRM alert group"
+              },
+              "description": "Get a specific alert group from Grafana OnCall by its ID. Returns the full alert group details.",
+              "inputSchema": {
+                "properties": {
+                  "alertGroupId": {
+                    "description": "The ID of the alert group to retrieve",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "alertGroupId"
+                ],
+                "type": "object"
+              },
+              "name": "get_alert_group"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get Annotation Tags"
+              },
+              "description": "Returns annotation tags with optional filtering by tag name. Only the provided filters are applied.",
+              "inputSchema": {
+                "properties": {
+                  "limit": {
+                    "description": "Max results, default 100",
+                    "type": "string"
+                  },
+                  "tag": {
+                    "description": "Optional filter by tag name",
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "get_annotation_tags"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get Annotations"
+              },
+              "description": "Fetch Grafana annotations using filters such as dashboard UID, time range and tags.",
+              "inputSchema": {
+                "properties": {
+                  "alertUid": {
+                    "description": "Filter by alert UID",
+                    "type": "string"
+                  },
+                  "dashboardUid": {
+                    "description": "Filter by dashboard UID",
+                    "type": "string"
+                  },
+                  "from": {
+                    "description": "Epoch ms start time",
+                    "type": "integer"
+                  },
+                  "limit": {
+                    "description": "Max results default 100",
+                    "type": "integer"
+                  },
+                  "matchAny": {
+                    "description": "If true, match any tag (OR). If false, match all tags (AND). Default: false",
+                    "type": "boolean"
+                  },
+                  "panelId": {
+                    "description": "Filter by panel ID",
+                    "type": "integer"
+                  },
+                  "tags": {
+                    "description": "Filter by tags. Multiple tags allowed; use matchAny to control AND/OR logic",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "to": {
+                    "description": "Epoch ms end time",
+                    "type": "integer"
+                  },
+                  "type": {
+                    "description": "annotation or alert",
+                    "type": "string"
+                  },
+                  "userId": {
+                    "description": "Filter by creator user ID",
+                    "type": "integer"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "get_annotations"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get assertions summary"
+              },
+              "description": "Get assertion summary for a given entity with its type, name, env, site, namespace, and a time range",
+              "inputSchema": {
+                "properties": {
+                  "endTime": {
+                    "description": "The end time in RFC3339 format (e.g. 2024-01-01T00:00:00Z) or relative format (e.g. now)",
+                    "type": "string"
+                  },
+                  "entityName": {
+                    "description": "The name of the entity to list",
+                    "type": "string"
+                  },
+                  "entityType": {
+                    "description": "The type of the entity to list (e.g. Service, Node, Pod, etc.)",
+                    "type": "string"
+                  },
+                  "env": {
+                    "description": "The env of the entity to list",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "The namespace of the entity to list",
+                    "type": "string"
+                  },
+                  "site": {
+                    "description": "The site of the entity to list",
+                    "type": "string"
+                  },
+                  "startTime": {
+                    "description": "The start time in RFC3339 format (e.g. 2024-01-01T00:00:00Z) or relative format (e.g. now-1h)",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "startTime",
+                  "endTime"
+                ],
+                "type": "object"
+              },
+              "name": "get_assertions"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get current on-call users"
+              },
+              "description": "Get the list of users currently on-call for a specific Grafana OnCall schedule ID. Returns the schedule ID, name, and a list of detailed user objects for those currently on call.",
+              "inputSchema": {
+                "properties": {
+                  "scheduleId": {
+                    "description": "The ID of the schedule to get current on-call users for",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "scheduleId"
+                ],
+                "type": "object"
+              },
+              "name": "get_current_oncall_users"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get dashboard details"
+              },
+              "description": "Retrieves the complete dashboard, including panels, variables, and settings, for a specific dashboard identified by its UID. The response includes 'apiVersion' and 'isV2': when 'isV2' is true the dashboard uses the v2 schema (panels live under 'elements' keyed by name, arranged by 'layout'; variables under 'variables'), otherwise it is classic v1 ('panels[]' with 'templating.list'). WARNING: Large dashboards can consume significant context window space. Consider using get_dashboard_summary for overview or get_dashboard_property for specific data instead.",
+              "inputSchema": {
+                "properties": {
+                  "uid": {
+                    "description": "The UID of the dashboard",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "uid"
+                ],
+                "type": "object"
+              },
+              "name": "get_dashboard_by_uid"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get dashboard panel queries"
+              },
+              "description": "Retrieve panel queries from a Grafana dashboard. Supports all datasource types (Prometheus, Loki, CloudWatch, SQL, etc.) and row-nested panels. Optionally filter to a specific panel by ID with `panelId`. Optionally provide `variables` for template variable substitution, which populates `processedQuery` and `requiredVariables` fields. Returns an array of objects with fields: title, query (raw expression), datasource (object with uid and type), and optionally processedQuery, refId, and requiredVariables.",
+              "inputSchema": {
+                "properties": {
+                  "panelId": {
+                    "description": "Optional panel ID to filter to a specific panel",
+                    "type": "integer"
+                  },
+                  "uid": {
+                    "description": "The UID of the dashboard",
+                    "type": "string"
+                  },
+                  "variables": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Optional variable substitutions (e.g., {\"job\": \"api-server\"})",
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "uid"
+                ],
+                "type": "object"
+              },
+              "name": "get_dashboard_panel_queries"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get dashboard property"
+              },
+              "description": "Get specific parts of a dashboard using JSONPath expressions to minimize context window usage. JSONPath targets the dashboard's native schema. Classic v1 paths: '$.title' (title)\\, '$.panels[*].title' (all panel titles)\\, '$.panels[0]' (first panel)\\, '$.templating.list' (variables)\\, '$.annotations.list' (saved dashboard annotation queries/definitions)\\, '$.tags' (tags)\\, '$.panels[*].targets[*].expr' (all queries). v2 dashboards (see isV2 from get_dashboard_by_uid) use different paths: '$.title'\\, '$.elements' (panels\\, keyed by name)\\, '$.variables' (variables)\\, '$.annotations'. Use this instead of get_dashboard_by_uid when you only need specific dashboard properties.",
+              "inputSchema": {
+                "properties": {
+                  "jsonPath": {
+                    "description": "JSONPath expression to extract specific data (e.g., '$.panels[0].title' for first panel title, '$.panels[*].title' for all panel titles, '$.templating.list' for variables, '$.annotations.list' for saved dashboard annotation queries/definitions)",
+                    "type": "string"
+                  },
+                  "uid": {
+                    "description": "The UID of the dashboard",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "uid",
+                  "jsonPath"
+                ],
+                "type": "object"
+              },
+              "name": "get_dashboard_property"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get dashboard summary"
+              },
+              "description": "Get a compact summary of a dashboard including title\\, panel count\\, panel types\\, variables\\, and other metadata without the full JSON. Use this for dashboard overview and planning modifications without consuming large context windows.",
+              "inputSchema": {
+                "properties": {
+                  "uid": {
+                    "description": "The UID of the dashboard",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "uid"
+                ],
+                "type": "object"
+              },
+              "name": "get_dashboard_summary"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get datasource"
+              },
+              "description": "Retrieves detailed information about a specific datasource by UID or name. Returns the full datasource model, including name, type, URL, access settings, JSON data, and secure JSON field status. Provide either uid or name; uid takes priority if both are given.",
+              "inputSchema": {
+                "properties": {
+                  "name": {
+                    "description": "The name of the datasource. Used if UID is not provided.",
+                    "type": "string"
+                  },
+                  "uid": {
+                    "description": "The UID of the datasource. If provided, takes priority over name.",
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "get_datasource"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get incident details"
+              },
+              "description": "Get a single incident by ID. Returns the full incident details including title, status, severity, labels, timestamps, and other metadata.",
+              "inputSchema": {
+                "properties": {
+                  "id": {
+                    "description": "The ID of the incident to retrieve",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "type": "object"
+              },
+              "name": "get_incident"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get OnCall shift"
+              },
+              "description": "Get detailed information for a specific Grafana OnCall shift using its ID. A shift represents a designated time period within a schedule when users are actively on-call. Returns the full shift details.",
+              "inputSchema": {
+                "properties": {
+                  "shiftId": {
+                    "description": "The ID of the shift to get details for",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "shiftId"
+                ],
+                "type": "object"
+              },
+              "name": "get_oncall_shift"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get panel or dashboard image"
+              },
+              "description": "Render a Grafana dashboard panel or full dashboard as a PNG image. Returns the image as base64 encoded data. Requires the Grafana Image Renderer service to be installed. Either dashboardUid (for stored dashboards) or provisioningPreview (for dashboards staged on a provisioning repository branch, e.g. a git-sync PR) must be supplied. Use this for generating visual snapshots of dashboards for reports, alerts, or presentations.",
+              "inputSchema": {
+                "properties": {
+                  "dashboardUid": {
+                    "description": "The UID of a stored dashboard containing the panel. Required unless provisioningPreview is provided.",
+                    "type": "string"
+                  },
+                  "height": {
+                    "description": "Height of the rendered image in pixels. Defaults to 500",
+                    "type": "integer"
+                  },
+                  "panelId": {
+                    "description": "The ID of the panel to render. If omitted, the entire dashboard is rendered",
+                    "type": "integer"
+                  },
+                  "provisioningPreview": {
+                    "description": "Render a dashboard from a provisioning repository branch (e.g. a git-sync PR preview). Mutually exclusive with dashboardUid.",
+                    "properties": {
+                      "path": {
+                        "description": "Path to the dashboard file within the repository, relative to its root.",
+                        "type": "string"
+                      },
+                      "ref": {
+                        "description": "Branch or commit SHA to render from. Defaults to the repository's main branch when omitted.",
+                        "type": "string"
+                      },
+                      "repo": {
+                        "description": "Provisioning repository slug. List repositories via /apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories if unknown.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "repo",
+                      "path"
+                    ],
+                    "type": "object"
+                  },
+                  "scale": {
+                    "description": "Scale factor for the image (1-3). Defaults to 1",
+                    "type": "integer"
+                  },
+                  "theme": {
+                    "description": "Theme for the rendered image: light or dark. Defaults to dark",
+                    "type": "string"
+                  },
+                  "timeRange": {
+                    "description": "Time range for the rendered image",
+                    "properties": {
+                      "from": {
+                        "description": "Start time (e.g., 'now-1h', '2024-01-01T00:00:00Z')",
+                        "type": "string"
+                      },
+                      "to": {
+                        "description": "End time (e.g., 'now', '2024-01-01T12:00:00Z')",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "timeout": {
+                    "description": "Rendering timeout in seconds. Defaults to 60",
+                    "type": "integer"
+                  },
+                  "variables": {
+                    "additionalProperties": {
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      ]
+                    },
+                    "description": "Dashboard variables to apply. Values can be a single string or an array of strings for multi-value variables (e.g., {\"var-datasource\": \"prometheus\", \"var-instance\": [\"server1\", \"server2\"]})",
+                    "type": "object"
+                  },
+                  "width": {
+                    "description": "Width of the rendered image in pixels. Defaults to 1000",
+                    "type": "integer"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "get_panel_image"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get plugin"
+              },
+              "description": "Check whether a Grafana plugin is installed and retrieve its details (name, version, type, enabled status). Returns installed=false when the plugin is not found. Use install_plugin when a plugin is not installed to install plugin after confirming this action with the user.",
+              "inputSchema": {
+                "properties": {
+                  "pluginId": {
+                    "description": "The plugin ID to check (e.g. 'prometheus', 'grafana-piechart-panel', 'grafana-oncall-app')",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "pluginId"
+                ],
+                "type": "object"
+              },
+              "name": "get_plugin"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get Sift analysis"
+              },
+              "description": "Retrieves a specific analysis from an investigation by its UUID. The investigation ID and analysis ID should be provided as strings in UUID format.",
+              "inputSchema": {
+                "properties": {
+                  "analysisId": {
+                    "description": "The UUID of the specific analysis to retrieve",
+                    "type": "string"
+                  },
+                  "investigationId": {
+                    "description": "The UUID of the investigation as a string (e.g. '02adab7c-bf5b-45f2-9459-d71a2c29e11b')",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "investigationId",
+                  "analysisId"
+                ],
+                "type": "object"
+              },
+              "name": "get_sift_analysis"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get Sift investigation"
+              },
+              "description": "Retrieves an existing Sift investigation by its UUID. The ID should be provided as a string in UUID format (e.g. '02adab7c-bf5b-45f2-9459-d71a2c29e11b').",
+              "inputSchema": {
+                "properties": {
+                  "id": {
+                    "description": "The UUID of the investigation as a string (e.g. '02adab7c-bf5b-45f2-9459-d71a2c29e11b')",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "type": "object"
+              },
+              "name": "get_sift_investigation"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get snapshot"
+              },
+              "description": "Get a Grafana snapshot by key, including snapshot metadata and dashboard payload.",
+              "inputSchema": {
+                "properties": {
+                  "key": {
+                    "description": "Snapshot key to retrieve",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "key"
+                ],
+                "type": "object"
+              },
+              "name": "get_snapshot"
+            },
+            {
+              "annotations": {
+                "title": "Grafana API request"
+              },
+              "description": "Make an authenticated HTTP request to the Grafana API. Similar to 'gh api' for GitHub. Supports any Grafana API endpoint with optional jq-style response filtering. Use this for API endpoints that don't have a dedicated tool.",
+              "inputSchema": {
+                "properties": {
+                  "body": {
+                    "description": "Request body (JSON string). Used with POST, PUT, and PATCH requests.",
+                    "type": "string"
+                  },
+                  "endpoint": {
+                    "description": "The API path relative to the Grafana base URL (e.g. '/api/org', '/api/dashboards/uid/abc123'). Must start with '/'.",
+                    "type": "string"
+                  },
+                  "headers": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Additional HTTP headers to include in the request.",
+                    "type": "object"
+                  },
+                  "jq": {
+                    "description": "A jq expression to filter or transform the JSON response (e.g. '.dashboards[] | .title').",
+                    "type": "string"
+                  },
+                  "method": {
+                    "description": "HTTP method. Defaults to GET",
+                    "enum": [
+                      "GET",
+                      "POST",
+                      "PUT",
+                      "PATCH",
+                      "DELETE"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "endpoint"
+                ],
+                "type": "object"
+              },
+              "name": "grafana_api_request"
+            },
+            {
+              "annotations": {
+                "destructiveHint": true,
+                "idempotentHint": false,
+                "readOnlyHint": false,
+                "title": "Install plugin"
+              },
+              "description": "Install a Grafana plugin by its plugin ID. If the version is not already confirmed with the user, omit it — the tool will look up the latest version and return it for confirmation before installing.",
+              "inputSchema": {
+                "properties": {
+                  "pluginId": {
+                    "description": "The plugin ID to install (e.g. 'grafana-image-renderer', 'grafana-piechart-panel')",
+                    "type": "string"
+                  },
+                  "version": {
+                    "description": "The exact version to install. Must be confirmed with the user before calling — if unknown, omit this field to look up the latest version first.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "pluginId"
+                ],
+                "type": "object"
+              },
+              "name": "install_plugin"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List IRM alert groups"
+              },
+              "description": "List alert groups from Grafana OnCall with filtering options. Supports filtering by alert group ID, route ID, integration ID, state (new, acknowledged, resolved, silenced), team ID, time range, labels, and name. For time ranges, use format '{start}_{end}' ISO 8601 timestamp range (e.g., '2025-01-19T00:00:00_2025-01-19T23:59:59' for a specific day). For labels, use format 'key:value' (e.g., ['env:prod', 'severity:high']). Returns a list of alert group objects with their details. Supports pagination.",
+              "inputSchema": {
+                "properties": {
+                  "id": {
+                    "description": "Filter by specific alert group ID",
+                    "type": "string"
+                  },
+                  "integrationId": {
+                    "description": "Filter by integration ID",
+                    "type": "string"
+                  },
+                  "labels": {
+                    "description": "Filter by labels in format key:value (e.g., ['env:prod', 'severity:high'])",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "description": "Filter by alert group name",
+                    "type": "string"
+                  },
+                  "page": {
+                    "description": "The page number to return",
+                    "type": "integer"
+                  },
+                  "routeId": {
+                    "description": "Filter by route ID",
+                    "type": "string"
+                  },
+                  "startedAt": {
+                    "description": "Filter by time range in format '{start}_{end}' ISO 8601 timestamp range (UTC assumed, no timezone indicator needed) (e.g., '2025-01-19T00:00:00_2025-01-19T23:59:59')",
+                    "type": "string"
+                  },
+                  "state": {
+                    "description": "Filter by alert group state (one of: new, acknowledged, resolved, silenced)",
+                    "type": "string"
+                  },
+                  "teamId": {
+                    "description": "Filter by team ID",
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "list_alert_groups"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List datasources"
+              },
+              "description": "List all configured datasources in Grafana. Use this to discover available datasources and their UIDs. Supports filtering by type and pagination.",
+              "inputSchema": {
+                "properties": {
+                  "limit": {
+                    "default": 50,
+                    "description": "Maximum number of datasources to return (max 100)",
+                    "type": "integer"
+                  },
+                  "offset": {
+                    "default": 0,
+                    "description": "Number of datasources to skip for pagination",
+                    "type": "integer"
+                  },
+                  "type": {
+                    "description": "The type of datasources to search for. For example, 'prometheus', 'loki', 'tempo', etc...",
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "list_datasources"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List incidents"
+              },
+              "description": "List Grafana incidents. Allows filtering by status ('active', 'resolved') and optionally including drill incidents. Returns a preview list with basic details.",
+              "inputSchema": {
+                "properties": {
+                  "drill": {
+                    "description": "Whether to include drill incidents",
+                    "type": "boolean"
+                  },
+                  "limit": {
+                    "default": 10,
+                    "description": "The maximum number of incidents to return",
+                    "type": "integer"
+                  },
+                  "status": {
+                    "description": "The status of the incidents to include. Valid values: 'active', 'resolved'",
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "list_incidents"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List Loki label names"
+              },
+              "description": "Lists all available label/field names (keys) found in logs within a specified Loki or VictoriaLogs datasource and time range. Returns a list of unique label strings (e.g., `[\"app\", \"env\", \"pod\"]`). If the time range is not provided, it defaults to the last hour.",
+              "inputSchema": {
+                "properties": {
+                  "datasourceUid": {
+                    "description": "The UID of the datasource to query",
+                    "type": "string"
+                  },
+                  "endRfc3339": {
+                    "description": "Optionally, the end time of the query in RFC3339 format or relative time (e.g. 'now') (defaults to now)",
+                    "type": "string"
+                  },
+                  "startRfc3339": {
+                    "description": "Optionally, the start time of the query in RFC3339 format or relative time (e.g. 'now-1h') (defaults to 1 hour ago)",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "datasourceUid"
+                ],
+                "type": "object"
+              },
+              "name": "list_loki_label_names"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List Loki label values"
+              },
+              "description": "Retrieves all unique values associated with a specific `labelName` within a Loki or VictoriaLogs datasource and time range. Returns a list of string values (e.g., for `labelName=\"env\"`, might return `[\"prod\", \"staging\", \"dev\"]`). Useful for discovering filter options. Defaults to the last hour if the time range is omitted.",
+              "inputSchema": {
+                "properties": {
+                  "datasourceUid": {
+                    "description": "The UID of the datasource to query",
+                    "type": "string"
+                  },
+                  "endRfc3339": {
+                    "description": "Optionally, the end time of the query in RFC3339 format or relative time (e.g. 'now') (defaults to now)",
+                    "type": "string"
+                  },
+                  "labelName": {
+                    "description": "The name of the label to retrieve values for (e.g. 'app', 'env', 'pod')",
+                    "type": "string"
+                  },
+                  "startRfc3339": {
+                    "description": "Optionally, the start time of the query in RFC3339 format or relative time (e.g. 'now-1h') (defaults to 1 hour ago)",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "datasourceUid",
+                  "labelName"
+                ],
+                "type": "object"
+              },
+              "name": "list_loki_label_values"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List OnCall schedules"
+              },
+              "description": "List Grafana OnCall schedules, optionally filtering by team ID. If a specific schedule ID is provided, retrieves details for only that schedule. Returns a list of schedule summaries including ID, name, team ID, timezone, and shift IDs. Supports pagination.",
+              "inputSchema": {
+                "properties": {
+                  "page": {
+                    "description": "The page number to return (1-based)",
+                    "type": "integer"
+                  },
+                  "scheduleId": {
+                    "description": "The ID of the schedule to get details for. If provided, returns only that schedule's details",
+                    "type": "string"
+                  },
+                  "teamId": {
+                    "description": "The ID of the team to list schedules for",
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "list_oncall_schedules"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List OnCall teams"
+              },
+              "description": "List teams configured in Grafana OnCall. Returns a list of team objects with their details. Supports pagination.",
+              "inputSchema": {
+                "properties": {
+                  "page": {
+                    "description": "The page number to return",
+                    "type": "integer"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "list_oncall_teams"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List OnCall users"
+              },
+              "description": "List users from Grafana OnCall. These are OnCall users (separate from Grafana users). Can retrieve all users in the OnCall directory, a specific user by ID, or filter by username. Returns a list of user objects with their details. Supports pagination.",
+              "inputSchema": {
+                "properties": {
+                  "page": {
+                    "description": "The page number to return",
+                    "type": "integer"
+                  },
+                  "userId": {
+                    "description": "The ID of the user to get details for. If provided, returns only that user's details",
+                    "type": "string"
+                  },
+                  "username": {
+                    "description": "The username to filter users by. If provided, returns only the user matching this username",
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "list_oncall_users"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List Prometheus label names"
+              },
+              "description": "List label names in a PromQL-compatible datasource (Prometheus, Thanos, Mimir, Cloud Monitoring, etc.). Allows filtering by series selectors and time range.",
+              "inputSchema": {
+                "properties": {
+                  "datasourceUid": {
+                    "description": "The UID of the datasource to query",
+                    "type": "string"
+                  },
+                  "endRfc3339": {
+                    "description": "Optionally, the end time of the time range to filter the results by. Supports RFC3339 or relative time (e.g. 'now')",
+                    "type": "string"
+                  },
+                  "limit": {
+                    "default": 100,
+                    "description": "Optionally, the maximum number of results to return",
+                    "type": "integer"
+                  },
+                  "matches": {
+                    "description": "Optionally, a list of label matchers to filter the results by",
+                    "items": {
+                      "properties": {
+                        "filters": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "description": "The name of the label to match against",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "One of the '=' or '!=' or '=~' or '!~'",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "The value to match against",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value",
+                              "type"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "projectName": {
+                    "description": "GCP project name to query (Cloud Monitoring datasources only). Overrides or substitutes the defaultProject configured on the datasource.",
+                    "type": "string"
+                  },
+                  "startRfc3339": {
+                    "description": "Optionally, the start time of the time range to filter the results by. Supports RFC3339 or relative time (e.g. 'now-1h')",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "datasourceUid"
+                ],
+                "type": "object"
+              },
+              "name": "list_prometheus_label_names"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List Prometheus label values"
+              },
+              "description": "Use after list_prometheus_metric_names to find label values for filtering queries. Gets the values for a specific label name in a PromQL-compatible datasource (Prometheus, Thanos, Mimir, Cloud Monitoring, etc.). Allows filtering by series selectors and time range.",
+              "inputSchema": {
+                "properties": {
+                  "datasourceUid": {
+                    "description": "The UID of the datasource to query",
+                    "type": "string"
+                  },
+                  "endRfc3339": {
+                    "description": "Optionally, the end time of the query. Supports RFC3339 or relative time (e.g. 'now')",
+                    "type": "string"
+                  },
+                  "labelName": {
+                    "description": "The name of the label to query",
+                    "type": "string"
+                  },
+                  "limit": {
+                    "default": 100,
+                    "description": "Optionally, the maximum number of results to return",
+                    "type": "integer"
+                  },
+                  "matches": {
+                    "description": "Optionally, a list of selectors to filter the results by",
+                    "items": {
+                      "properties": {
+                        "filters": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "description": "The name of the label to match against",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "One of the '=' or '!=' or '=~' or '!~'",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "The value to match against",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value",
+                              "type"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "projectName": {
+                    "description": "GCP project name to query (Cloud Monitoring datasources only). Overrides or substitutes the defaultProject configured on the datasource.",
+                    "type": "string"
+                  },
+                  "startRfc3339": {
+                    "description": "Optionally, the start time of the query. Supports RFC3339 or relative time (e.g. 'now-1h')",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "datasourceUid",
+                  "labelName"
+                ],
+                "type": "object"
+              },
+              "name": "list_prometheus_label_values"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List Prometheus metric metadata"
+              },
+              "description": "List Prometheus metric metadata. Returns metadata about metrics currently scraped from targets. Note: This endpoint is experimental.",
+              "inputSchema": {
+                "properties": {
+                  "datasourceUid": {
+                    "description": "The UID of the datasource to query",
+                    "type": "string"
+                  },
+                  "limit": {
+                    "default": 10,
+                    "description": "The maximum number of metrics to return",
+                    "type": "integer"
+                  },
+                  "limitPerMetric": {
+                    "description": "The maximum number of metrics to return per metric",
+                    "type": "integer"
+                  },
+                  "metric": {
+                    "description": "The metric to query",
+                    "type": "string"
+                  },
+                  "projectName": {
+                    "description": "GCP project name to query (Cloud Monitoring datasources only). Overrides or substitutes the defaultProject configured on the datasource.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "datasourceUid"
+                ],
+                "type": "object"
+              },
+              "name": "list_prometheus_metric_metadata"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List Prometheus metric names"
+              },
+              "description": "DISCOVERY: Call this first to find available metrics before querying. Lists metric names in a PromQL-compatible datasource (Prometheus, Thanos, Mimir, Cloud Monitoring, etc.). Retrieves all metric names and filters them using the provided regex. Supports pagination and an optional time range to restrict results to metrics active within that window.",
+              "inputSchema": {
+                "properties": {
+                  "datasourceUid": {
+                    "description": "The UID of the datasource to query",
+                    "type": "string"
+                  },
+                  "endRfc3339": {
+                    "description": "Optionally, the end time of the time range to filter the results by. Supports RFC3339 or relative time (e.g. 'now')",
+                    "type": "string"
+                  },
+                  "limit": {
+                    "default": 10,
+                    "description": "The maximum number of results to return",
+                    "type": "integer"
+                  },
+                  "page": {
+                    "default": 1,
+                    "description": "The page number to return",
+                    "type": "integer"
+                  },
+                  "projectName": {
+                    "description": "GCP project name to query (Cloud Monitoring datasources only). Overrides or substitutes the defaultProject configured on the datasource.",
+                    "type": "string"
+                  },
+                  "regex": {
+                    "description": "The regex to match against the metric names",
+                    "type": "string"
+                  },
+                  "startRfc3339": {
+                    "description": "Optionally, the start time of the time range to filter the results by. Supports RFC3339 or relative time (e.g. 'now-1h')",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "datasourceUid"
+                ],
+                "type": "object"
+              },
+              "name": "list_prometheus_metric_names"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List provisioning repositories"
+              },
+              "description": "List provisioning repositories (e.g. git-sync sources) configured for this Grafana instance. Returns each repository's slug along with its source URL, branch, path, sync state, and health. Use the returned `name` as the `repo` argument when rendering a not-yet-applied dashboard preview via get_panel_image's provisioningPreview parameter.",
+              "inputSchema": {
+                "properties": {
+                  "namespace": {
+                    "description": "Kubernetes-style namespace to list repositories from. Defaults to 'default' which matches single-tenant Grafana deployments.",
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "list_provisioning_repositories"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List Pyroscope label names"
+              },
+              "description": "\nLists all available label names (keys) found in profiles within a specified Pyroscope datasource, time range, and\noptional label matchers. Label matchers are typically used to qualify a service name ({service_name=\"foo\"}). Returns a\nlist of unique label strings (e.g., [\"app\", \"env\", \"pod\"]). Label names with double underscores (e.g. __name__) are\ninternal and rarely useful to users. If the time range is not provided, it defaults to the last hour.\n",
+              "inputSchema": {
+                "properties": {
+                  "data_source_uid": {
+                    "description": "The UID of the datasource to query",
+                    "type": "string"
+                  },
+                  "end_rfc_3339": {
+                    "description": "Optionally, the end time of the query in RFC3339 format or relative time (e.g. 'now') (defaults to now)",
+                    "type": "string"
+                  },
+                  "matchers": {
+                    "type": "string"
+                  },
+                  "start_rfc_3339": {
+                    "description": "Optionally, the start time of the query in RFC3339 format or relative time (e.g. 'now-1h') (defaults to 1 hour ago)",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "data_source_uid"
+                ],
+                "type": "object"
+              },
+              "name": "list_pyroscope_label_names"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List Pyroscope label values"
+              },
+              "description": "\nLists all available label values for a particular label name found in profiles within a specified Pyroscope datasource,\ntime range, and optional label matchers. Label matchers are typically used to qualify a service name ({service_name=\"foo\"}).\nReturns a list of unique label strings (e.g. for label name \"env\": [\"dev\", \"staging\", \"prod\"]). If the time range\nis not provided, it defaults to the last hour.\n",
+              "inputSchema": {
+                "properties": {
+                  "data_source_uid": {
+                    "description": "The UID of the datasource to query",
+                    "type": "string"
+                  },
+                  "end_rfc_3339": {
+                    "description": "Optionally, the end time of the query in RFC3339 format or relative time (e.g. 'now') (defaults to now)",
+                    "type": "string"
+                  },
+                  "matchers": {
+                    "description": "Optionally, Prometheus style matchers used to filter the result set (defaults to: {})",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "A label name",
+                    "type": "string"
+                  },
+                  "start_rfc_3339": {
+                    "description": "Optionally, the start time of the query in RFC3339 format or relative time (e.g. 'now-1h') (defaults to 1 hour ago)",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "data_source_uid",
+                  "name"
+                ],
+                "type": "object"
+              },
+              "name": "list_pyroscope_label_values"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List Pyroscope profile types"
+              },
+              "description": "\nLists all available profile types available in a specified Pyroscope datasource and time range. Returns a list of all\navailable profile types (example profile type: \"process_cpu:cpu:nanoseconds:cpu:nanoseconds\"). A profile type has the\nfollowing structure: \u003cname\u003e:\u003csample type\u003e:\u003csample unit\u003e:\u003cperiod type\u003e:\u003cperiod unit\u003e. Not all profile types are available\nfor every service. If the time range is not provided, it defaults to the last hour.\n",
+              "inputSchema": {
+                "properties": {
+                  "data_source_uid": {
+                    "description": "The UID of the datasource to query",
+                    "type": "string"
+                  },
+                  "end_rfc_3339": {
+                    "description": "Optionally, the end time of the query in RFC3339 format or relative time (e.g. 'now') (defaults to now)",
+                    "type": "string"
+                  },
+                  "start_rfc_3339": {
+                    "description": "Optionally, the start time of the query in RFC3339 format or relative time (e.g. 'now-1h') (defaults to 1 hour ago)",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "data_source_uid"
+                ],
+                "type": "object"
+              },
+              "name": "list_pyroscope_profile_types"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List Sift investigations"
+              },
+              "description": "Retrieves a list of Sift investigations with an optional limit. If no limit is specified, defaults to 10 investigations.",
+              "inputSchema": {
+                "properties": {
+                  "limit": {
+                    "default": 10,
+                    "description": "Maximum number of investigations to return",
+                    "type": "integer"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "list_sift_investigations"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List snapshots"
+              },
+              "description": "List Grafana dashboard snapshots with optional query and result limit filters.",
+              "inputSchema": {
+                "properties": {
+                  "limit": {
+                    "description": "Maximum number of snapshots to return (Grafana defaults to 1000 when omitted)",
+                    "type": "integer"
+                  },
+                  "query": {
+                    "description": "Optional search query for snapshot name",
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "list_snapshots"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Query Loki logs"
+              },
+              "description": "Executes a log query against a Loki or VictoriaLogs datasource and returns matching log entries (or metric samples on Loki). Defaults to the last hour, a limit of 10 entries, and 'backward' direction (newest first). The `logql` parameter takes LogQL on Loki and LogsQL on VictoriaLogs (e.g., Loki: `{app=\"foo\"} |= \"error\"`; VictoriaLogs: `{app=\"foo\"} \"error\"`). To count matching log lines precisely, use a `count_over_time()` metric query with queryType='instant'. Prefer using `query_loki_stats` first to cheaply check whether a stream contains data (avoiding expensive queries against empty streams) and `list_loki_label_names` / `list_loki_label_values` to verify labels exist before querying. Note: `query_loki_stats` returns approximate storage-level counts, not exact log line counts.",
+              "inputSchema": {
+                "properties": {
+                  "datasourceUid": {
+                    "description": "The UID of the datasource to query",
+                    "type": "string"
+                  },
+                  "direction": {
+                    "description": "Optionally, the direction of the query: 'forward' (oldest first) or 'backward' (newest first, default)",
+                    "type": "string"
+                  },
+                  "endRfc3339": {
+                    "description": "Optionally, the end time of the query in RFC3339 format or relative time (e.g. 'now')",
+                    "type": "string"
+                  },
+                  "limit": {
+                    "default": 10,
+                    "description": "Optionally, the maximum number of log lines to return (default max: 100, configurable by MCP server).",
+                    "type": "integer"
+                  },
+                  "logql": {
+                    "description": "The LogQL query to execute against Loki. This can be a simple label matcher or a complex query with filters, parsers, and expressions. Supports full LogQL syntax including label matchers, filter operators, pattern expressions, and pipeline operations.",
+                    "type": "string"
+                  },
+                  "queryType": {
+                    "description": "Query type: 'range' (default) or 'instant'. Instant queries return a single value at one point in time. Range queries return values over a time window. Use 'instant' for metric queries when you want the current value.",
+                    "type": "string"
+                  },
+                  "startRfc3339": {
+                    "description": "Optionally, the start time of the query in RFC3339 format or relative time (e.g. 'now-1h')",
+                    "type": "string"
+                  },
+                  "stepSeconds": {
+                    "description": "Resolution step in seconds for range metric queries. When running metric queries with queryType='range', this controls the time resolution of the returned data points.",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "datasourceUid",
+                  "logql"
+                ],
+                "type": "object"
+              },
+              "name": "query_loki_logs"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Query Loki patterns"
+              },
+              "description": "Retrieves detected log patterns from a Loki datasource for a given stream selector and time range. Returns a list of patterns, each containing a pattern string and a total count of occurrences. Patterns help identify common log structures and anomalies. The `logql` parameter must be a stream selector (e.g., `{job=\"nginx\"}`) and does not support line filters or aggregations. Defaults to the last hour if the time range is omitted. **Not supported on VictoriaLogs** datasources - use a `| stats` pipeline instead.",
+              "inputSchema": {
+                "properties": {
+                  "datasourceUid": {
+                    "description": "The UID of the datasource to query",
+                    "type": "string"
+                  },
+                  "endRfc3339": {
+                    "description": "Optionally, the end time of the query in RFC3339 format or relative time (e.g. 'now') (defaults to now)",
+                    "type": "string"
+                  },
+                  "logql": {
+                    "description": "A LogQL stream selector to identify the logs to analyze for patterns (e.g. {job=\"foo\", namespace=\"bar\"})",
+                    "type": "string"
+                  },
+                  "startRfc3339": {
+                    "description": "Optionally, the start time of the query in RFC3339 format or relative time (e.g. 'now-1h') (defaults to 1 hour ago)",
+                    "type": "string"
+                  },
+                  "step": {
+                    "description": "Optionally, the query resolution step (e.g. '5m')",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "datasourceUid",
+                  "logql"
+                ],
+                "type": "object"
+              },
+              "name": "query_loki_patterns"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get Loki log statistics"
+              },
+              "description": "Retrieves index-level statistics about log streams matching a given selector within a Loki or VictoriaLogs datasource and time range. Returns an object containing the count of streams, chunks, entries, and total bytes (e.g., `{\"streams\": 5, \"chunks\": 50, \"entries\": 10000, \"bytes\": 512000}`). **Important**: the `entries` count reflects storage-level index entries (chunk metadata), NOT the number of individual log lines matching the selector. To count actual matching log lines, use `query_loki_logs` with a `count_over_time()` metric query instead. On VictoriaLogs only `entries` is populated; the other fields remain zero. The `logql` parameter **must** be a simple label selector (e.g., `{app=\"nginx\", env=\"prod\"}`) and does not support line filters, parsers, or aggregations. Defaults to the last hour if the time range is omitted.",
+              "inputSchema": {
+                "properties": {
+                  "datasourceUid": {
+                    "description": "The UID of the datasource to query",
+                    "type": "string"
+                  },
+                  "endRfc3339": {
+                    "description": "Optionally, the end time of the query in RFC3339 format or relative time (e.g. 'now')",
+                    "type": "string"
+                  },
+                  "logql": {
+                    "description": "The LogQL matcher expression to execute. This parameter only accepts label matcher expressions and does not support full LogQL queries. Line filters, pattern operations, and metric aggregations are not supported by the stats API endpoint. Only simple label selectors can be used here.",
+                    "type": "string"
+                  },
+                  "startRfc3339": {
+                    "description": "Optionally, the start time of the query in RFC3339 format or relative time (e.g. 'now-1h')",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "datasourceUid",
+                  "logql"
+                ],
+                "type": "object"
+              },
+              "name": "query_loki_stats"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Query Prometheus metrics"
+              },
+              "description": "WORKFLOW: list_prometheus_metric_names -\u003e list_prometheus_label_values -\u003e query_prometheus. Query a PromQL-compatible datasource (Prometheus, Thanos, Mimir, Cloud Monitoring, etc.) using a PromQL expression. Supports instant queries (single point) and range queries (time range). Time: RFC3339 or relative expressions like 'now'\\, 'now-1h'.",
+              "inputSchema": {
+                "properties": {
+                  "datasourceUid": {
+                    "description": "The UID of the datasource to query",
+                    "type": "string"
+                  },
+                  "endTime": {
+                    "description": "The end time. Supported formats are RFC3339 or relative to now (e.g. 'now', 'now-1.5h', 'now-2h45m'). Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h', 'd'.",
+                    "type": "string"
+                  },
+                  "expr": {
+                    "description": "The PromQL expression to query",
+                    "type": "string"
+                  },
+                  "projectName": {
+                    "description": "GCP project name to query (Cloud Monitoring datasources only). Overrides or substitutes the defaultProject configured on the datasource.",
+                    "type": "string"
+                  },
+                  "queryType": {
+                    "description": "The type of query to use. Either 'range' or 'instant'",
+                    "type": "string"
+                  },
+                  "startTime": {
+                    "description": "The start time. Required if queryType is 'range', ignored if queryType is 'instant' Supported formats are RFC3339 or relative to now (e.g. 'now', 'now-1.5h', 'now-2h45m'). Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h', 'd'.",
+                    "type": "string"
+                  },
+                  "stepSeconds": {
+                    "description": "The time series step size in seconds. Required if queryType is 'range', ignored if queryType is 'instant'",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "datasourceUid",
+                  "expr",
+                  "endTime"
+                ],
+                "type": "object"
+              },
+              "name": "query_prometheus"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Query Prometheus histogram percentile"
+              },
+              "description": "Query Prometheus histogram percentiles. DISCOVER FIRST: Use list_prometheus_metric_names with regex='.*_bucket$' to find histograms.\n\nGenerates histogram_quantile PromQL. Example: metric='http_duration', percentile=95, labels='job=\"api\"'\n\nTime formats: 'now-1h', '2026-02-02T19:00:00Z', '1738519200000' (Unix ms)",
+              "inputSchema": {
+                "properties": {
+                  "datasourceUid": {
+                    "description": "The UID of the Prometheus datasource",
+                    "type": "string"
+                  },
+                  "endTime": {
+                    "description": "End time (default: now). Supports RFC3339, relative, or Unix ms.",
+                    "type": "string"
+                  },
+                  "labels": {
+                    "description": "Label selector (e.g. job=\"api\", service=\"gateway\")",
+                    "type": "string"
+                  },
+                  "metric": {
+                    "description": "Base histogram metric name (without _bucket suffix)",
+                    "type": "string"
+                  },
+                  "percentile": {
+                    "description": "Percentile to calculate (e.g. 50, 90, 95, 99)",
+                    "type": "number"
+                  },
+                  "projectName": {
+                    "description": "GCP project name to query (Cloud Monitoring datasources only). Overrides or substitutes the defaultProject configured on the datasource.",
+                    "type": "string"
+                  },
+                  "rateInterval": {
+                    "description": "Rate interval for the query (default: 5m)",
+                    "type": "string"
+                  },
+                  "startTime": {
+                    "description": "Start time (default: now-1h). Supports RFC3339, relative (now-1h), or Unix ms.",
+                    "type": "string"
+                  },
+                  "stepSeconds": {
+                    "description": "Step size in seconds for range query (default: 60)",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "datasourceUid",
+                  "metric",
+                  "percentile"
+                ],
+                "type": "object"
+              },
+              "name": "query_prometheus_histogram"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Query Pyroscope"
+              },
+              "description": "\nUnified Pyroscope query tool for fetching profiles or metrics from Pyroscope. Profile data shows WHICH functions consume resources; metrics data\nshows WHEN consumption spiked. Use query_type=\"both\" for complete analysis in one call.\n\nquery_type options (extends Grafana's PyroscopeQueryType):\n- \"profile\": returns DOT-format call graph\n- \"metrics\": returns time-series data points\n- \"both\" (default): returns both profile and metrics in one response\n",
+              "inputSchema": {
+                "properties": {
+                  "data_source_uid": {
+                    "description": "The UID of the datasource to query",
+                    "type": "string"
+                  },
+                  "end_rfc_3339": {
+                    "description": "End time in RFC3339 or relative time (e.g. 'now') (defaults to now)",
+                    "type": "string"
+                  },
+                  "group_by": {
+                    "description": "Labels to group metrics series by",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "matchers": {
+                    "description": "Prometheus style matchers (defaults to: {})",
+                    "type": "string"
+                  },
+                  "max_node_depth": {
+                    "description": "Max depth for profile call graph (default: 100)",
+                    "type": "integer"
+                  },
+                  "profile_type": {
+                    "description": "The profile type, use list_pyroscope_profile_types to discover available types",
+                    "type": "string"
+                  },
+                  "query_type": {
+                    "description": "Query type: \"profile\" (flamegraph), \"metrics\" (time-series), or \"both\" (default). Use \"both\" for complete analysis",
+                    "type": "string"
+                  },
+                  "start_rfc_3339": {
+                    "description": "Start time in RFC3339 or relative time (e.g. 'now-1h') (defaults to 1 hour ago)",
+                    "type": "string"
+                  },
+                  "step": {
+                    "description": "Seconds between metrics data points (default: auto)",
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "data_source_uid",
+                  "profile_type"
+                ],
+                "type": "object"
+              },
+              "name": "query_pyroscope"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Search dashboards"
+              },
+              "description": "Search for Grafana dashboards by a query string. Returns a list of matching dashboards with details like title, UID, folder, tags, and URL.",
+              "inputSchema": {
+                "properties": {
+                  "limit": {
+                    "default": 50,
+                    "description": "Maximum number of results to return (max 100)",
+                    "type": "integer"
+                  },
+                  "page": {
+                    "default": 1,
+                    "description": "Page number for pagination (1-indexed)",
+                    "type": "integer"
+                  },
+                  "query": {
+                    "description": "The query to search for",
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "search_dashboards"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Search folders"
+              },
+              "description": "Search for Grafana folders by a query string. Returns matching folders with details like title, UID, and URL.",
+              "inputSchema": {
+                "properties": {
+                  "query": {
+                    "description": "The query to search for",
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "search_folders"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Search plugins"
+              },
+              "description": "Search the Grafana plugin catalog by keyword to discover available plugins before installing or getting plugin details on a specific instance. Returns results sorted by trust: official Grafana Labs plugins first, then commercial partner plugins, then community plugins. Use this tool when a user describes a plugin by purpose or partial name (e.g. 'azure monitoring', 'loki', 'database') — it returns the exact pluginId to pass to get_plugin or install_plugin. Results include warnings for enterprise-only or Angular-based plugins.",
+              "inputSchema": {
+                "properties": {
+                  "query": {
+                    "description": "Keyword to search for plugins (e.g. 'azure', 'prometheus', 'loki', 'database'). Matches against plugin name, slug, description, and keywords.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "query"
+                ],
+                "type": "object"
+              },
+              "name": "search_plugin_information"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Suggest Alloy label enforcement config"
+              },
+              "description": "Generates an Alloy loki.process snippet enforcing an approved label set via stage.label_keep, with optional log-level normalisation and soft-enforcement placeholders.",
+              "inputSchema": {
+                "properties": {
+                  "approvedLabels": {
+                    "description": "Labels to keep on the index.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "componentName": {
+                    "type": "string"
+                  },
+                  "forwardTo": {
+                    "type": "string"
+                  },
+                  "normalizeLogLevel": {
+                    "type": "boolean"
+                  },
+                  "requiredLabels": {
+                    "description": "Labels that get an 'unknown' placeholder when missing.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "approvedLabels"
+                ],
+                "type": "object"
+              },
+              "name": "suggest_loki_alloy_label_config"
+            },
+            {
+              "annotations": {
+                "destructiveHint": true,
+                "idempotentHint": false,
+                "title": "Update Annotation"
+              },
+              "description": "Updates the provided properties of an annotation by ID. Only fields included in the request are modified; omitted fields are left unchanged.",
+              "inputSchema": {
+                "properties": {
+                  "data": {
+                    "description": "Optional JSON payload",
+                    "type": "object"
+                  },
+                  "id": {
+                    "description": "Annotation ID to update",
+                    "type": "integer"
+                  },
+                  "tags": {
+                    "description": "Tags to replace existing tags",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "text": {
+                    "description": "New annotation text",
+                    "type": "string"
+                  },
+                  "time": {
+                    "description": "New start time epoch ms",
+                    "type": "integer"
+                  },
+                  "timeEnd": {
+                    "description": "New end time epoch ms",
+                    "type": "integer"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "update_annotation"
+            },
+            {
+              "annotations": {
+                "destructiveHint": true,
+                "title": "Create or update dashboard"
+              },
+              "description": "Create or update a dashboard. Two modes: (1) Full JSON — provide 'dashboard' for new dashboards or complete replacements. (2) Patch — provide 'uid' + 'operations' to make targeted changes to an existing dashboard. One of these two modes is required; 'folderUid'\\, 'message'\\, and 'overwrite' are supplementary and do nothing on their own. Dashboard authoring guidance: if a saved query must support one\\, many\\, or All values from a multi-select variable inside a regex expression or matcher\\, save '${var:regex}' rather than plain '$var'. Saved dashboard annotation queries/definitions must be written into dashboard JSON under 'annotations.list'; the create_annotation tool creates annotation events and does not add a reusable dashboard annotation query/definition to the saved dashboard. For stat panels over the current dashboard range\\, make the query return the range-level result the stat should display; panel-side reduction only reduces returned series and does not compute peak-over-range or ratio-of-peaks semantics for you. Patch operations support JSONPaths like '$.panels[0].targets[0].expr'\\, '$.panels[1].title'\\, '$.panels[2].targets[0].datasource'\\, '$.templating.list/-'\\, and '$.annotations.list/-'. Append to arrays with '/- ' syntax: '$.panels/- '. Remove by index: {\"op\": \"remove\"\\, \"path\": \"$.panels[2]\"}. Multiple removes on the same array are automatically reordered to avoid index-shifting issues. Note: only numeric array indices are supported in patch paths; filter expressions like [?(@.id==2)] and wildcards like [*] are not supported. v2 dashboards (check 'isV2' from get_dashboard_by_uid) use a different shape: patch '$.elements.\u003cname\u003e.spec.title' or '$.elements.\u003cname\u003e.spec.data.spec.queries[0].spec' and edit '$.variables'/'$.layout' rather than '$.panels'/'$.templating.list'. Full-JSON saves containing top-level 'elements'/'layout' are written as v2 and require a Kubernetes-capable Grafana. After creating or updating a dashboard\\, verify that panel queries return data by using `run_panel_query` or the appropriate query tool (`query_prometheus`\\, `query_loki_logs`\\, etc.) to validate expressions before considering the task complete.",
+              "inputSchema": {
+                "properties": {
+                  "dashboard": {
+                    "description": "The full dashboard JSON. Use for creating new dashboards or complete updates. Saved dashboard annotation queries/definitions live in 'annotations.list' inside this JSON; they are different from annotation events created with create_annotation. Large dashboards consume significant context - consider using patches for small changes.",
+                    "type": "object"
+                  },
+                  "folderUid": {
+                    "description": "The UID of the dashboard's folder",
+                    "type": "string"
+                  },
+                  "message": {
+                    "description": "Set a commit message for the version history",
+                    "type": "string"
+                  },
+                  "operations": {
+                    "description": "Array of patch operations for targeted updates. More efficient than full dashboard JSON for small changes. Common paths: '$.templating.list/-' to add a variable, '$.annotations.list/-' to add a saved dashboard annotation query/definition, '$.panels[0].targets[0].expr' to replace a panel query.",
+                    "items": {
+                      "properties": {
+                        "op": {
+                          "description": "Operation type: 'replace', 'add', 'remove'",
+                          "type": "string"
+                        },
+                        "path": {
+                          "description": "JSONPath to the property to modify. Supports: '$.title', '$.panels[0].title', '$.panels[0].targets[0].expr', '$.panels[1].targets[0].datasource', '$.templating.list/-' (append a variable), '$.annotations.list/-' (append a saved dashboard annotation query/definition). For appending to arrays, use '/- ' syntax: '$.panels/- ' (append to panels array) or '$.panels[2]/- ' (append to nested array at index 2).",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "New value for replace/add operations. When adding a saved dashboard annotation query/definition, append an object to '$.annotations.list' rather than calling create_annotation."
+                        }
+                      },
+                      "required": [
+                        "op",
+                        "path"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "overwrite": {
+                    "description": "Overwrite the dashboard if it exists. Otherwise create one",
+                    "type": "boolean"
+                  },
+                  "uid": {
+                    "description": "UID of existing dashboard to update. Must be used together with 'operations'. Providing 'uid' without 'operations' will fail.",
+                    "type": "string"
+                  },
+                  "userId": {
+                    "description": "ID of the user making the change",
+                    "type": "integer"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "update_dashboard"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": false,
+                "title": "Update datasource"
+              },
+              "description": "Update non-secret datasource fields by UID. Omitted fields are preserved. For secrets, direct the user to the Grafana UI.",
+              "inputSchema": {
+                "properties": {
+                  "access": {
+                    "description": "proxy or direct",
+                    "type": "string"
+                  },
+                  "basicAuth": {
+                    "description": "Enable basic auth",
+                    "type": "boolean"
+                  },
+                  "database": {
+                    "description": "Database name",
+                    "type": "string"
+                  },
+                  "isDefault": {
+                    "description": "Make this the default datasource",
+                    "type": "boolean"
+                  },
+                  "jsonData": {
+                    "description": "Non-secret plugin settings; replaces existing jsonData when set",
+                    "type": "object"
+                  },
+                  "name": {
+                    "description": "Display name",
+                    "type": "string"
+                  },
+                  "uid": {
+                    "description": "UID of the datasource to update",
+                    "type": "string"
+                  },
+                  "url": {
+                    "description": "Base URL",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "uid"
+                ],
+                "type": "object"
+              },
+              "name": "update_datasource"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Validate provisioning file"
+              },
+              "description": "Validate a file in a provisioning repository at a given branch or commit by dry-run applying it. Returns whether the file would be accepted (valid)\\, what resource action would result (create/update)\\, the target resource type\\, and any structured validation errors. Use to confirm a draft dashboard or other resource will be accepted before merging or applying a PR — this is the same validation surface that Grafana's PR commenter reports.",
+              "inputSchema": {
+                "properties": {
+                  "namespace": {
+                    "description": "Kubernetes-style namespace to read the repository from. Defaults to 'default'.",
+                    "type": "string"
+                  },
+                  "path": {
+                    "description": "File path within the repository (e.g. 'folder/dashboard.json').",
+                    "type": "string"
+                  },
+                  "ref": {
+                    "description": "Branch or commit SHA. Defaults to the repository's main branch.",
+                    "type": "string"
+                  },
+                  "repo": {
+                    "description": "Provisioning repository slug. Get one from list_provisioning_repositories.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "repo",
+                  "path"
+                ],
+                "type": "object"
+              },
+              "name": "validate_provisioning_file"
+            }
+          ],
           "tools": [
             "add_activity_to_incident",
-            "create_alert_rule",
+            "alerting_manage_routing",
+            "alerting_manage_rules",
+            "analyze_loki_labels",
+            "check_datasources_health",
             "create_annotation",
+            "create_datasource",
             "create_folder",
-            "create_graphite_annotation",
             "create_incident",
-            "delete_alert_rule",
-            "fetch_pyroscope_profile",
+            "create_snapshot",
+            "delete_snapshot",
             "find_error_pattern_logs",
             "find_slow_requests",
             "generate_deeplink",
             "get_alert_group",
-            "get_alert_rule_by_uid",
             "get_annotation_tags",
             "get_annotations",
             "get_assertions",
@@ -62,21 +2687,17 @@
             "get_dashboard_panel_queries",
             "get_dashboard_property",
             "get_dashboard_summary",
-            "get_datasource_by_name",
-            "get_datasource_by_uid",
+            "get_datasource",
             "get_incident",
             "get_oncall_shift",
             "get_panel_image",
-            "get_resource_description",
-            "get_resource_permissions",
-            "get_role_assignments",
-            "get_role_details",
+            "get_plugin",
             "get_sift_analysis",
             "get_sift_investigation",
+            "get_snapshot",
+            "grafana_api_request",
+            "install_plugin",
             "list_alert_groups",
-            "list_alert_rules",
-            "list_all_roles",
-            "list_contact_points",
             "list_datasources",
             "list_incidents",
             "list_loki_label_names",
@@ -88,24 +2709,26 @@
             "list_prometheus_label_values",
             "list_prometheus_metric_metadata",
             "list_prometheus_metric_names",
+            "list_provisioning_repositories",
             "list_pyroscope_label_names",
             "list_pyroscope_label_values",
             "list_pyroscope_profile_types",
             "list_sift_investigations",
-            "list_team_roles",
-            "list_teams",
-            "list_user_roles",
-            "list_users_by_org",
-            "patch_annotation",
+            "list_snapshots",
             "query_loki_logs",
             "query_loki_patterns",
             "query_loki_stats",
             "query_prometheus",
+            "query_prometheus_histogram",
+            "query_pyroscope",
             "search_dashboards",
             "search_folders",
-            "update_alert_rule",
+            "search_plugin_information",
+            "suggest_loki_alloy_label_config",
             "update_annotation",
-            "update_dashboard"
+            "update_dashboard",
+            "update_datasource",
+            "validate_provisioning_file"
           ]
         }
       }
@@ -141,11 +2764,10 @@
           "name": "GRAFANA_ORG_ID"
         }
       ],
-      "identifier": "docker.io/grafana/mcp-grafana:0.17.0",
+      "identifier": "docker.io/grafana/mcp-grafana:0.17.2",
       "registryType": "oci",
       "transport": {
-        "type": "sse",
-        "url": "http://localhost:8000"
+        "type": "stdio"
       }
     }
   ],

--- a/registries/official/servers/grafana/server.json
+++ b/registries/official/servers/grafana/server.json
@@ -9,7 +9,7 @@
             "stdio"
           ],
           "metadata": {
-            "last_updated": "2026-07-15T23:57:12Z",
+            "last_updated": "2026-07-16T00:52:21Z",
             "stars": 3239
           },
           "overview": "## Grafana MCP Server\n\nThe grafana MCP server is a Model Context Protocol (MCP) server that enables AI assistants and agents to interact directly with Grafana dashboards, data sources, and observability resources through a structured, AI-friendly interface. It allows AI-driven workflows to explore metrics, logs, alerts, and dashboards without switching tools or manually navigating the Grafana UI. This server is ideal for observability, incident response, performance analysis, and operational workflows where real-time telemetry and monitoring context are essential.\n\n**Note:** the upstream container's entrypoint defaults to the SSE transport, so this entry passes `--transport stdio` via its registry args to force stdio mode. If you run this server with your own custom arguments (`thv run ... -- \u003cyour args\u003e`), those arguments replace the registry defaults, so be sure to include `--transport stdio` yourself or the server will silently fall back to SSE.",

--- a/registries/toolhive/servers/grafana/server.json
+++ b/registries/toolhive/servers/grafana/server.json
@@ -9,7 +9,7 @@
             "stdio"
           ],
           "metadata": {
-            "last_updated": "2026-07-15T23:51:09Z",
+            "last_updated": "2026-07-15T23:57:12Z",
             "stars": 3239
           },
           "overview": "## Grafana MCP Server\n\nThe grafana MCP server is a Model Context Protocol (MCP) server that enables AI assistants and agents to interact directly with Grafana dashboards, data sources, and observability resources through a structured, AI-friendly interface. It allows AI-driven workflows to explore metrics, logs, alerts, and dashboards without switching tools or manually navigating the Grafana UI. This server is ideal for observability, incident response, performance analysis, and operational workflows where real-time telemetry and monitoring context are essential.\n\n**Note:** the upstream container's entrypoint defaults to the SSE transport, so this entry passes `--transport stdio` via its registry args to force stdio mode. If you run this server with your own custom arguments (`thv run ... -- \u003cyour args\u003e`), those arguments replace the registry defaults, so be sure to include `--transport stdio` yourself or the server will silently fall back to SSE.",

--- a/registries/toolhive/servers/grafana/server.json
+++ b/registries/toolhive/servers/grafana/server.json
@@ -3,18 +3,19 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.stacklok": {
-        "docker.io/grafana/mcp-grafana:0.17.0": {
+        "docker.io/grafana/mcp-grafana:0.17.2": {
+          "args": [
+            "--transport",
+            "stdio"
+          ],
           "metadata": {
-            "last_updated": "2026-04-23T03:03:46Z",
-            "stars": 2892
+            "last_updated": "2026-07-15T23:51:09Z",
+            "stars": 3239
           },
-          "overview": "## Grafana MCP Server\n\nThe grafana MCP server is a Model Context Protocol (MCP) server that enables AI assistants and agents to interact directly with Grafana dashboards, data sources, and observability resources through a structured, AI-friendly interface. It allows AI-driven workflows to explore metrics, logs, alerts, and dashboards without switching tools or manually navigating the Grafana UI. This server is ideal for observability, incident response, performance analysis, and operational workflows where real-time telemetry and monitoring context are essential.",
+          "overview": "## Grafana MCP Server\n\nThe grafana MCP server is a Model Context Protocol (MCP) server that enables AI assistants and agents to interact directly with Grafana dashboards, data sources, and observability resources through a structured, AI-friendly interface. It allows AI-driven workflows to explore metrics, logs, alerts, and dashboards without switching tools or manually navigating the Grafana UI. This server is ideal for observability, incident response, performance analysis, and operational workflows where real-time telemetry and monitoring context are essential.\n\n**Note:** the upstream container's entrypoint defaults to the SSE transport, so this entry passes `--transport stdio` via its registry args to force stdio mode. If you run this server with your own custom arguments (`thv run ... -- \u003cyour args\u003e`), those arguments replace the registry defaults, so be sure to include `--transport stdio` yourself or the server will silently fall back to SSE.",
           "permissions": {
             "network": {
               "outbound": {
-                "allow_port": [
-                  443
-                ],
                 "insecure_allow_all": true
               }
             }
@@ -40,20 +41,2644 @@
             "oncall"
           ],
           "tier": "Official",
+          "tool_definitions": [
+            {
+              "annotations": {
+                "title": "Add activity to incident"
+              },
+              "description": "Add a note (userNote activity) to an existing incident's timeline using its ID. The note body can include URLs which will be attached as context. Use this to add context to an incident.",
+              "inputSchema": {
+                "properties": {
+                  "body": {
+                    "description": "The body of the activity. URLs will be parsed and attached as context",
+                    "type": "string"
+                  },
+                  "eventTime": {
+                    "description": "The time that the activity occurred. If not provided, the current time will be used",
+                    "type": "string"
+                  },
+                  "incidentId": {
+                    "description": "The ID of the incident to add the activity to",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "incidentId",
+                  "body"
+                ],
+                "type": "object"
+              },
+              "name": "add_activity_to_incident"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Manage alerting routing"
+              },
+              "description": "Manage Grafana alerting routing configuration, including notification policies, contact points and time intervals.\n\nNotification policies define how alerts are grouped, routed, and which contact points receive them.\nTime intervals define active/mute periods for alert notifications.\n\nWhen to use:\n- Understanding how alerts are routed to contact points/receivers\n- Debugging why an alert went to a specific receiver\n- Checking grouping, timing, or mute interval settings\n\nWhen NOT to use:\n- Checking alert rule configuration or state (use alerting_manage_rules)",
+              "inputSchema": {
+                "properties": {
+                  "contact_point_title": {
+                    "description": "Title of the contact point to retrieve (required for get_contact_point operation)",
+                    "type": "string"
+                  },
+                  "datasource_uid": {
+                    "description": "Optional: UID of an Alertmanager-compatible datasource to query for receivers. If omitted, returns Grafana-managed contact points. Only used with get_contact_points.",
+                    "type": "string"
+                  },
+                  "limit": {
+                    "description": "The maximum number of results to return. Default is 100. Only used with get_contact_points.",
+                    "type": "integer"
+                  },
+                  "name": {
+                    "description": "Filter contact points by name (exact match). Only used with get_contact_points.",
+                    "type": "string"
+                  },
+                  "operation": {
+                    "description": "The operation to perform: 'get_notification_policies' to retrieve the notification policy tree, 'get_contact_points' to list all contact points, 'get_contact_point' to get a specific contact point by name, 'get_time_intervals' to list all time intervals, 'get_time_interval' to get a specific time interval by name",
+                    "enum": [
+                      "get_notification_policies",
+                      "get_contact_points",
+                      "get_contact_point",
+                      "get_time_intervals",
+                      "get_time_interval"
+                    ],
+                    "type": "string"
+                  },
+                  "time_interval_name": {
+                    "description": "Name of the time interval to retrieve (required for get_time_interval operation)",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "operation"
+                ],
+                "type": "object"
+              },
+              "name": "alerting_manage_routing"
+            },
+            {
+              "annotations": {
+                "destructiveHint": true,
+                "title": "Manage alert rules"
+              },
+              "description": "Manage Grafana alert rules with full CRUD capabilities and filtering.\n\nWhen to use:\n- Understanding why an alert is or isn't firing\n- Auditing alert rule configuration (queries, conditions, labels, notification settings)\n- Finding alert rules by state, folder, group, or name\n- Creating, updating, or deleting alert rules\n- Comparing rule versions to see what changed\n\nWhen NOT to use:\n- Checking how alerts are routed to receivers (use alerting_manage_routing)",
+              "inputSchema": {
+                "properties": {
+                  "annotations": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Optional annotations for the alert rule",
+                    "type": "object"
+                  },
+                  "condition": {
+                    "description": "The query condition identifier, e.g. 'A', 'B' (required for 'create', 'update')",
+                    "type": "string"
+                  },
+                  "data": {
+                    "description": "Array of alert query objects (required for 'create'/'update'). Each object has: datasourceUid (string, required), model (object with expr for data queries or type/expression/conditions for expressions), refId (string, auto-assigned if omitted), relativeTimeRange ({from, to} in seconds, defaults to {from:600,to:0}). For server-side expressions use datasourceUid '__expr__'. Example: [{datasourceUid: 'prometheus', model: {expr: 'up == 0'}}, {datasourceUid: '__expr__', model: {type: 'threshold', expression: 'A', conditions: [{evaluator: {type: 'gt', params: [0]}}]}}]",
+                    "items": {
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "datasource_uid": {
+                    "description": "Optional: UID of a Prometheus or Loki datasource to query for datasource-managed alert rules (for 'list' operation)",
+                    "type": "string"
+                  },
+                  "disable_provenance": {
+                    "description": "If true, the alert remains editable in the Grafana UI (sets X-Disable-Provenance header). Defaults to true.",
+                    "type": "boolean"
+                  },
+                  "exec_err_state": {
+                    "description": "State on execution error: NoData, Alerting, OK (required for 'create', 'update')",
+                    "type": "string"
+                  },
+                  "folder_uid": {
+                    "description": "The folder UID. For 'list': filter by exact folder UID (mutually exclusive with search_folder). For 'create'/'update': the folder to store the rule in (required).",
+                    "type": "string"
+                  },
+                  "for": {
+                    "description": "Duration before alert fires, e.g. '5m' (required for 'create', 'update')",
+                    "type": "string"
+                  },
+                  "is_paused": {
+                    "description": "If true, the alert rule remains inactive, Default is false",
+                    "type": "boolean"
+                  },
+                  "keep_firing_for": {
+                    "description": "Enables continous firing of alert for specified time even when condition is no longer met. Default is 0 (resolves immediately)",
+                    "type": "string"
+                  },
+                  "label_selectors": {
+                    "description": "Prometheus-style selectors to filter alert rules by labels. Each string is a selector e.g. '{severity=\"critical\", team=~\"backend.*\"}'. All selectors must match (AND).",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "labels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Optional labels for the alert rule",
+                    "type": "object"
+                  },
+                  "limit_alerts": {
+                    "description": "Limit alert instances per rule. For list: 0 omits alerts. For get: \u003c=0 defaults to 200. Max 200.",
+                    "type": "integer"
+                  },
+                  "matchers": {
+                    "description": "Label matchers to filter alert instances. Each string is a Prometheus-style matcher e.g. 'severity=\"critical\"', 'env!=\"dev\"', 'team=~\"backend.*\"'. Requires Grafana 12.4+.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "missing_series_evals_to_resolve": {
+                    "description": "Consecutive evaluation intervals with no data required to mark the alert as resolved. Default is 2.",
+                    "type": "integer"
+                  },
+                  "no_data_state": {
+                    "description": "State when no data: NoData, Alerting, OK (required for 'create', 'update')",
+                    "type": "string"
+                  },
+                  "notification_settings": {
+                    "description": "Notification settings object. Fields: receiver (string, required), groupBy ([]string), groupWait/groupInterval/repeatInterval (duration strings), muteTimeIntervals/activeTimeIntervals ([]string).",
+                    "type": "object"
+                  },
+                  "operation": {
+                    "description": "The operation to perform: 'list', 'get', 'versions', 'create', 'update', or 'delete'. To create a rule, use operation 'create' and provide all required fields in a single call. To update a rule, first use 'get' to retrieve its full configuration, then 'update' with all required fields plus your changes.",
+                    "enum": [
+                      "list",
+                      "get",
+                      "versions",
+                      "create",
+                      "update",
+                      "delete"
+                    ],
+                    "type": "string"
+                  },
+                  "org_id": {
+                    "description": "The organization ID (required for 'create', 'update')",
+                    "type": "integer"
+                  },
+                  "record": {
+                    "description": "Recording rule config. Fields: from (string, required - ref ID e.g. 'A'), metric (string, required - metric name), targetDatasourceUid (string, optional).",
+                    "type": "object"
+                  },
+                  "rule_group": {
+                    "description": "The rule group name (required for 'create', 'update')",
+                    "type": "string"
+                  },
+                  "rule_limit": {
+                    "default": 200,
+                    "description": "Maximum number of rules to return (default 200, max 200). Requires Grafana 12.4+ (for 'list' operation)",
+                    "type": "integer"
+                  },
+                  "rule_type": {
+                    "description": "Filter by rule type (for 'list' operation)",
+                    "enum": [
+                      "alerting",
+                      "recording"
+                    ],
+                    "type": "string"
+                  },
+                  "rule_uid": {
+                    "description": "The UID of the alert rule (required for 'get', 'versions', 'update', 'delete'; optional for 'create')",
+                    "type": "string"
+                  },
+                  "search_folder": {
+                    "description": "Search folders by path using partial matching (for 'list' operation). Requires Grafana 12.4+. Mutually exclusive with folder_uid.",
+                    "type": "string"
+                  },
+                  "search_rule_name": {
+                    "description": "Search alert rule names/titles using partial matching. Requires Grafana 12.4+ (for 'list' operation)",
+                    "type": "string"
+                  },
+                  "states": {
+                    "description": "Filter by alert state: firing, pending, normal, recovering, nodata, error (for 'list' operation)",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "title": {
+                    "description": "The title of the alert rule (required for 'create', 'update')",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "operation"
+                ],
+                "type": "object"
+              },
+              "name": "alerting_manage_rules"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Analyze Loki label strategy"
+              },
+              "description": "Audits a Loki label strategy and optionally diagnoses query performance. Returns per-label verdicts, missing base labels, normalisation issues, and a recommended set. Pass datasourceUid for live cardinality or labels for static scoring; both may be combined.",
+              "inputSchema": {
+                "properties": {
+                  "datasourceUid": {
+                    "description": "Datasource UID (live mode).",
+                    "type": "string"
+                  },
+                  "endRfc3339": {
+                    "type": "string"
+                  },
+                  "expectedBaseLabels": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "labels": {
+                    "description": "Caller-supplied labels (static mode).",
+                    "items": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "sampleValues": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "unbounded": {
+                          "type": "boolean"
+                        },
+                        "uniqueValues": {
+                          "type": "integer"
+                        },
+                        "usedInQueries": {
+                          "type": "string"
+                        },
+                        "valueKind": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "maxLabels": {
+                    "type": "integer"
+                  },
+                  "perfMetrics": {
+                    "description": "Runtime metrics; presence triggers perf diagnosis.",
+                    "properties": {
+                      "cacheChunkReqs": {
+                        "type": "integer"
+                      },
+                      "chunkRefsFetchTimeSec": {
+                        "type": "number"
+                      },
+                      "executionTimeSec": {
+                        "type": "number"
+                      },
+                      "postFilterLines": {
+                        "type": "integer"
+                      },
+                      "queueTimeSec": {
+                        "type": "number"
+                      },
+                      "storeChunksDownloadTimeSec": {
+                        "type": "number"
+                      },
+                      "totalBytes": {
+                        "type": "integer"
+                      },
+                      "totalLines": {
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "selector": {
+                    "description": "Optional LogQL selector for stats / perf diagnosis.",
+                    "type": "string"
+                  },
+                  "startRfc3339": {
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "analyze_loki_labels"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Check datasources health"
+              },
+              "description": "Check datasource health. Filter by type or UIDs; omit both to check all.",
+              "inputSchema": {
+                "properties": {
+                  "offset": {
+                    "default": 0,
+                    "description": "Number to skip for pagination",
+                    "type": "integer"
+                  },
+                  "type": {
+                    "description": "Plugin type filter; omit to check all",
+                    "type": "string"
+                  },
+                  "uids": {
+                    "description": "UIDs to check",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "check_datasources_health"
+            },
+            {
+              "annotations": {
+                "idempotentHint": false,
+                "title": "Create Annotation"
+              },
+              "description": "Create a new annotation on a dashboard or panel. Set format to 'graphite' and provide 'what' for Graphite-format annotations.",
+              "inputSchema": {
+                "properties": {
+                  "dashboardUid": {
+                    "description": "Dashboard UID",
+                    "type": "string"
+                  },
+                  "data": {
+                    "description": "Optional JSON payload",
+                    "type": "object"
+                  },
+                  "format": {
+                    "description": "Set to 'graphite' to create a Graphite-format annotation",
+                    "enum": [
+                      "graphite"
+                    ],
+                    "type": "string"
+                  },
+                  "graphiteData": {
+                    "description": "Optional string payload for Graphite format",
+                    "type": "string"
+                  },
+                  "panelId": {
+                    "description": "Panel ID",
+                    "type": "integer"
+                  },
+                  "tags": {
+                    "description": "Optional list of tags",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "text": {
+                    "description": "Annotation text (required unless format is graphite)",
+                    "type": "string"
+                  },
+                  "time": {
+                    "description": "Start time epoch ms",
+                    "type": "integer"
+                  },
+                  "timeEnd": {
+                    "description": "End time epoch ms",
+                    "type": "integer"
+                  },
+                  "what": {
+                    "description": "Annotation text for Graphite format (required when format is graphite)",
+                    "type": "string"
+                  },
+                  "when": {
+                    "description": "Epoch ms timestamp for Graphite format",
+                    "type": "integer"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "create_annotation"
+            },
+            {
+              "annotations": {
+                "idempotentHint": false,
+                "readOnlyHint": false,
+                "title": "Create datasource"
+              },
+              "description": "Create a datasource. If type is ambiguous, call search_plugin_information first; install the plugin if needed. IMPORTANT: always call this tool twice. First call: provide only the type — the tool returns a field schema. After receiving the schema, you MUST ask the user for every required field value explicitly; do not infer or use defaults without user confirmation. Second call: provide the type, the display name in the top-level name argument, schemaReviewed=true, and the fields map populated with values confirmed by the user. Never handle credentials — remind the user to rotate any detected. Returns UID, health check, and a config page link. ",
+              "inputSchema": {
+                "properties": {
+                  "access": {
+                    "description": "How Grafana should access the datasource (proxy or direct)",
+                    "type": "string"
+                  },
+                  "basicAuth": {
+                    "description": "Whether Grafana should use basic auth",
+                    "type": "boolean"
+                  },
+                  "database": {
+                    "description": "Optional database name",
+                    "type": "string"
+                  },
+                  "fields": {
+                    "description": "Datasource field values to provision, keyed by field key from the schema returned on the first call. The server uses each field's target (root or jsonData) to place values correctly in the YAML. Example: {\"url\": \"http://prometheus:9090\", \"httpMethod\": \"POST\"}.",
+                    "type": "object"
+                  },
+                  "isDefault": {
+                    "description": "Whether this should become the default datasource",
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "description": "Datasource display name",
+                    "type": "string"
+                  },
+                  "schemaReviewed": {
+                    "description": "Set to true on the second call to confirm you reviewed the schema and collected values from the user.",
+                    "type": "boolean"
+                  },
+                  "type": {
+                    "description": "Grafana datasource plugin type, for example prometheus",
+                    "type": "string"
+                  },
+                  "url": {
+                    "description": "Datasource base URL when required by the plugin",
+                    "type": "string"
+                  },
+                  "withCredentials": {
+                    "description": "Whether Grafana should forward credentials such as cookies",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "name",
+                  "type"
+                ],
+                "type": "object"
+              },
+              "name": "create_datasource"
+            },
+            {
+              "annotations": {
+                "idempotentHint": false,
+                "title": "Create folder"
+              },
+              "description": "Create a Grafana folder. Provide a title and optional UID. Returns the created folder.",
+              "inputSchema": {
+                "properties": {
+                  "parentUid": {
+                    "description": "Optional parent folder UID. If set, the folder will be created under this parent.",
+                    "type": "string"
+                  },
+                  "title": {
+                    "description": "The title of the folder.",
+                    "type": "string"
+                  },
+                  "uid": {
+                    "description": "Optional folder UID. If omitted, Grafana will generate one.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "title"
+                ],
+                "type": "object"
+              },
+              "name": "create_folder"
+            },
+            {
+              "annotations": {
+                "title": "Create incident"
+              },
+              "description": "Create a new Grafana incident. Requires title, severity, and room prefix. Allows setting status and labels. This tool should be used judiciously and sparingly, and only after confirmation from the user, as it may notify or alarm lots of people.",
+              "inputSchema": {
+                "properties": {
+                  "attachCaption": {
+                    "description": "The caption of the attachment",
+                    "type": "string"
+                  },
+                  "attachUrl": {
+                    "description": "The URL of the attachment",
+                    "type": "string"
+                  },
+                  "isDrill": {
+                    "description": "Whether the incident is a drill incident",
+                    "type": "boolean"
+                  },
+                  "labels": {
+                    "description": "The labels to add to the incident",
+                    "items": {
+                      "properties": {
+                        "colorHex": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "key": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "roomPrefix": {
+                    "description": "The prefix of the room to create the incident in",
+                    "type": "string"
+                  },
+                  "severity": {
+                    "description": "The severity of the incident",
+                    "type": "string"
+                  },
+                  "status": {
+                    "description": "The status of the incident",
+                    "type": "string"
+                  },
+                  "title": {
+                    "description": "The title of the incident",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "title",
+                  "severity",
+                  "roomPrefix"
+                ],
+                "type": "object"
+              },
+              "name": "create_incident"
+            },
+            {
+              "annotations": {
+                "idempotentHint": false,
+                "title": "Create snapshot"
+              },
+              "description": "Create a Grafana snapshot from a full dashboard payload. Supports optional expiration and external snapshot fields.",
+              "inputSchema": {
+                "properties": {
+                  "dashboard": {
+                    "description": "Complete dashboard model to snapshot (as returned by Grafana dashboard APIs)",
+                    "type": "object"
+                  },
+                  "deleteKey": {
+                    "description": "Secret key for deleting external snapshots. Required when external is true",
+                    "type": "string"
+                  },
+                  "expires": {
+                    "description": "Snapshot expiration in seconds (e.g. 3600 for 1 hour)",
+                    "type": "integer"
+                  },
+                  "external": {
+                    "description": "Store snapshot on external server. Requires key and deleteKey when true",
+                    "type": "boolean"
+                  },
+                  "key": {
+                    "description": "Custom snapshot key. Required when external is true",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Optional snapshot name",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "dashboard"
+                ],
+                "type": "object"
+              },
+              "name": "create_snapshot"
+            },
+            {
+              "annotations": {
+                "destructiveHint": true,
+                "idempotentHint": false,
+                "title": "Delete snapshot"
+              },
+              "description": "Delete a Grafana snapshot by snapshot key.",
+              "inputSchema": {
+                "properties": {
+                  "key": {
+                    "description": "Snapshot key to delete",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "key"
+                ],
+                "type": "object"
+              },
+              "name": "delete_snapshot"
+            },
+            {
+              "annotations": {
+                "readOnlyHint": true,
+                "title": "Find error patterns in logs"
+              },
+              "description": "Searches Loki logs for elevated error patterns compared to the last day's average, waits for the analysis to complete, and returns the results including any patterns found.",
+              "inputSchema": {
+                "properties": {
+                  "end": {
+                    "description": "End time for the investigation. Defaults to now if not specified.",
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "labels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Labels to scope the analysis",
+                    "type": "object"
+                  },
+                  "name": {
+                    "description": "The name of the investigation",
+                    "type": "string"
+                  },
+                  "start": {
+                    "description": "Start time for the investigation. Defaults to 30 minutes ago if not specified.",
+                    "format": "date-time",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "labels"
+                ],
+                "type": "object"
+              },
+              "name": "find_error_pattern_logs"
+            },
+            {
+              "annotations": {
+                "readOnlyHint": true,
+                "title": "Find slow requests"
+              },
+              "description": "Searches relevant Tempo datasources for slow requests, waits for the analysis to complete, and returns the results.",
+              "inputSchema": {
+                "properties": {
+                  "end": {
+                    "description": "End time for the investigation. Defaults to now if not specified.",
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "labels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Labels to scope the analysis",
+                    "type": "object"
+                  },
+                  "name": {
+                    "description": "The name of the investigation",
+                    "type": "string"
+                  },
+                  "start": {
+                    "description": "Start time for the investigation. Defaults to 30 minutes ago if not specified.",
+                    "format": "date-time",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "labels"
+                ],
+                "type": "object"
+              },
+              "name": "find_slow_requests"
+            },
+            {
+              "annotations": {
+                "idempotentHint": false,
+                "title": "Generate navigation deeplink"
+              },
+              "description": "Generate deeplink URLs for Grafana resources. Supports dashboards (requires dashboardUid or provisioningPreview), panels (requires dashboardUid or provisioningPreview, plus panelId), and Explore queries (requires datasourceUid and optionally queries). For dashboard and panel links, provisioningPreview points at a dashboard staged on a provisioning repository branch (e.g. a git-sync PR preview). For explore links, the time range and queries are embedded inside the Grafana explore state. Set shorten=true to also attempt a /goto/\u003cuid\u003e short URL; if shortening fails, the full deeplink is returned.",
+              "inputSchema": {
+                "properties": {
+                  "dashboardUid": {
+                    "description": "Dashboard UID (for stored dashboards). Mutually exclusive with provisioningPreview for dashboard and panel types.",
+                    "type": "string"
+                  },
+                  "datasourceUid": {
+                    "description": "Datasource UID (required for explore type)",
+                    "type": "string"
+                  },
+                  "panelId": {
+                    "description": "Panel ID (required for panel type)",
+                    "type": "integer"
+                  },
+                  "provisioningPreview": {
+                    "description": "Identifies a dashboard staged on a provisioning repository branch (e.g. a git-sync PR preview). Mutually exclusive with dashboardUid for dashboard and panel types.",
+                    "properties": {
+                      "path": {
+                        "description": "Path to the dashboard file within the repository, relative to its root.",
+                        "type": "string"
+                      },
+                      "pullRequestUrl": {
+                        "description": "Upstream pull request URL to surface in Grafana's preview banner.",
+                        "type": "string"
+                      },
+                      "ref": {
+                        "description": "Branch or commit SHA. Defaults to the repository's main branch when omitted.",
+                        "type": "string"
+                      },
+                      "repo": {
+                        "description": "Provisioning repository slug. List repositories via list_provisioning_repositories if unknown.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "repo",
+                      "path"
+                    ],
+                    "type": "object"
+                  },
+                  "queries": {
+                    "description": "List of query objects for explore links (e.g. [{\"refId\":\"A\",\"expr\":\"up\"}])",
+                    "items": {
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "queryParams": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Additional URL query parameters (for dashboard/panel types)",
+                    "type": "object"
+                  },
+                  "resourceType": {
+                    "description": "Type of resource: dashboard, panel, or explore",
+                    "type": "string"
+                  },
+                  "shorten": {
+                    "description": "If true, try to shorten the generated URL to /goto/\u003cuid\u003e. If shortening fails, return the original deeplink.",
+                    "type": "boolean"
+                  },
+                  "timeRange": {
+                    "description": "Time range for the link",
+                    "properties": {
+                      "from": {
+                        "description": "Start time (e.g., 'now-1h')",
+                        "type": "string"
+                      },
+                      "to": {
+                        "description": "End time (e.g., 'now')",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "resourceType"
+                ],
+                "type": "object"
+              },
+              "name": "generate_deeplink"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get IRM alert group"
+              },
+              "description": "Get a specific alert group from Grafana OnCall by its ID. Returns the full alert group details.",
+              "inputSchema": {
+                "properties": {
+                  "alertGroupId": {
+                    "description": "The ID of the alert group to retrieve",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "alertGroupId"
+                ],
+                "type": "object"
+              },
+              "name": "get_alert_group"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get Annotation Tags"
+              },
+              "description": "Returns annotation tags with optional filtering by tag name. Only the provided filters are applied.",
+              "inputSchema": {
+                "properties": {
+                  "limit": {
+                    "description": "Max results, default 100",
+                    "type": "string"
+                  },
+                  "tag": {
+                    "description": "Optional filter by tag name",
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "get_annotation_tags"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get Annotations"
+              },
+              "description": "Fetch Grafana annotations using filters such as dashboard UID, time range and tags.",
+              "inputSchema": {
+                "properties": {
+                  "alertUid": {
+                    "description": "Filter by alert UID",
+                    "type": "string"
+                  },
+                  "dashboardUid": {
+                    "description": "Filter by dashboard UID",
+                    "type": "string"
+                  },
+                  "from": {
+                    "description": "Epoch ms start time",
+                    "type": "integer"
+                  },
+                  "limit": {
+                    "description": "Max results default 100",
+                    "type": "integer"
+                  },
+                  "matchAny": {
+                    "description": "If true, match any tag (OR). If false, match all tags (AND). Default: false",
+                    "type": "boolean"
+                  },
+                  "panelId": {
+                    "description": "Filter by panel ID",
+                    "type": "integer"
+                  },
+                  "tags": {
+                    "description": "Filter by tags. Multiple tags allowed; use matchAny to control AND/OR logic",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "to": {
+                    "description": "Epoch ms end time",
+                    "type": "integer"
+                  },
+                  "type": {
+                    "description": "annotation or alert",
+                    "type": "string"
+                  },
+                  "userId": {
+                    "description": "Filter by creator user ID",
+                    "type": "integer"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "get_annotations"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get assertions summary"
+              },
+              "description": "Get assertion summary for a given entity with its type, name, env, site, namespace, and a time range",
+              "inputSchema": {
+                "properties": {
+                  "endTime": {
+                    "description": "The end time in RFC3339 format (e.g. 2024-01-01T00:00:00Z) or relative format (e.g. now)",
+                    "type": "string"
+                  },
+                  "entityName": {
+                    "description": "The name of the entity to list",
+                    "type": "string"
+                  },
+                  "entityType": {
+                    "description": "The type of the entity to list (e.g. Service, Node, Pod, etc.)",
+                    "type": "string"
+                  },
+                  "env": {
+                    "description": "The env of the entity to list",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "The namespace of the entity to list",
+                    "type": "string"
+                  },
+                  "site": {
+                    "description": "The site of the entity to list",
+                    "type": "string"
+                  },
+                  "startTime": {
+                    "description": "The start time in RFC3339 format (e.g. 2024-01-01T00:00:00Z) or relative format (e.g. now-1h)",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "startTime",
+                  "endTime"
+                ],
+                "type": "object"
+              },
+              "name": "get_assertions"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get current on-call users"
+              },
+              "description": "Get the list of users currently on-call for a specific Grafana OnCall schedule ID. Returns the schedule ID, name, and a list of detailed user objects for those currently on call.",
+              "inputSchema": {
+                "properties": {
+                  "scheduleId": {
+                    "description": "The ID of the schedule to get current on-call users for",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "scheduleId"
+                ],
+                "type": "object"
+              },
+              "name": "get_current_oncall_users"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get dashboard details"
+              },
+              "description": "Retrieves the complete dashboard, including panels, variables, and settings, for a specific dashboard identified by its UID. The response includes 'apiVersion' and 'isV2': when 'isV2' is true the dashboard uses the v2 schema (panels live under 'elements' keyed by name, arranged by 'layout'; variables under 'variables'), otherwise it is classic v1 ('panels[]' with 'templating.list'). WARNING: Large dashboards can consume significant context window space. Consider using get_dashboard_summary for overview or get_dashboard_property for specific data instead.",
+              "inputSchema": {
+                "properties": {
+                  "uid": {
+                    "description": "The UID of the dashboard",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "uid"
+                ],
+                "type": "object"
+              },
+              "name": "get_dashboard_by_uid"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get dashboard panel queries"
+              },
+              "description": "Retrieve panel queries from a Grafana dashboard. Supports all datasource types (Prometheus, Loki, CloudWatch, SQL, etc.) and row-nested panels. Optionally filter to a specific panel by ID with `panelId`. Optionally provide `variables` for template variable substitution, which populates `processedQuery` and `requiredVariables` fields. Returns an array of objects with fields: title, query (raw expression), datasource (object with uid and type), and optionally processedQuery, refId, and requiredVariables.",
+              "inputSchema": {
+                "properties": {
+                  "panelId": {
+                    "description": "Optional panel ID to filter to a specific panel",
+                    "type": "integer"
+                  },
+                  "uid": {
+                    "description": "The UID of the dashboard",
+                    "type": "string"
+                  },
+                  "variables": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Optional variable substitutions (e.g., {\"job\": \"api-server\"})",
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "uid"
+                ],
+                "type": "object"
+              },
+              "name": "get_dashboard_panel_queries"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get dashboard property"
+              },
+              "description": "Get specific parts of a dashboard using JSONPath expressions to minimize context window usage. JSONPath targets the dashboard's native schema. Classic v1 paths: '$.title' (title)\\, '$.panels[*].title' (all panel titles)\\, '$.panels[0]' (first panel)\\, '$.templating.list' (variables)\\, '$.annotations.list' (saved dashboard annotation queries/definitions)\\, '$.tags' (tags)\\, '$.panels[*].targets[*].expr' (all queries). v2 dashboards (see isV2 from get_dashboard_by_uid) use different paths: '$.title'\\, '$.elements' (panels\\, keyed by name)\\, '$.variables' (variables)\\, '$.annotations'. Use this instead of get_dashboard_by_uid when you only need specific dashboard properties.",
+              "inputSchema": {
+                "properties": {
+                  "jsonPath": {
+                    "description": "JSONPath expression to extract specific data (e.g., '$.panels[0].title' for first panel title, '$.panels[*].title' for all panel titles, '$.templating.list' for variables, '$.annotations.list' for saved dashboard annotation queries/definitions)",
+                    "type": "string"
+                  },
+                  "uid": {
+                    "description": "The UID of the dashboard",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "uid",
+                  "jsonPath"
+                ],
+                "type": "object"
+              },
+              "name": "get_dashboard_property"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get dashboard summary"
+              },
+              "description": "Get a compact summary of a dashboard including title\\, panel count\\, panel types\\, variables\\, and other metadata without the full JSON. Use this for dashboard overview and planning modifications without consuming large context windows.",
+              "inputSchema": {
+                "properties": {
+                  "uid": {
+                    "description": "The UID of the dashboard",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "uid"
+                ],
+                "type": "object"
+              },
+              "name": "get_dashboard_summary"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get datasource"
+              },
+              "description": "Retrieves detailed information about a specific datasource by UID or name. Returns the full datasource model, including name, type, URL, access settings, JSON data, and secure JSON field status. Provide either uid or name; uid takes priority if both are given.",
+              "inputSchema": {
+                "properties": {
+                  "name": {
+                    "description": "The name of the datasource. Used if UID is not provided.",
+                    "type": "string"
+                  },
+                  "uid": {
+                    "description": "The UID of the datasource. If provided, takes priority over name.",
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "get_datasource"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get incident details"
+              },
+              "description": "Get a single incident by ID. Returns the full incident details including title, status, severity, labels, timestamps, and other metadata.",
+              "inputSchema": {
+                "properties": {
+                  "id": {
+                    "description": "The ID of the incident to retrieve",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "type": "object"
+              },
+              "name": "get_incident"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get OnCall shift"
+              },
+              "description": "Get detailed information for a specific Grafana OnCall shift using its ID. A shift represents a designated time period within a schedule when users are actively on-call. Returns the full shift details.",
+              "inputSchema": {
+                "properties": {
+                  "shiftId": {
+                    "description": "The ID of the shift to get details for",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "shiftId"
+                ],
+                "type": "object"
+              },
+              "name": "get_oncall_shift"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get panel or dashboard image"
+              },
+              "description": "Render a Grafana dashboard panel or full dashboard as a PNG image. Returns the image as base64 encoded data. Requires the Grafana Image Renderer service to be installed. Either dashboardUid (for stored dashboards) or provisioningPreview (for dashboards staged on a provisioning repository branch, e.g. a git-sync PR) must be supplied. Use this for generating visual snapshots of dashboards for reports, alerts, or presentations.",
+              "inputSchema": {
+                "properties": {
+                  "dashboardUid": {
+                    "description": "The UID of a stored dashboard containing the panel. Required unless provisioningPreview is provided.",
+                    "type": "string"
+                  },
+                  "height": {
+                    "description": "Height of the rendered image in pixels. Defaults to 500",
+                    "type": "integer"
+                  },
+                  "panelId": {
+                    "description": "The ID of the panel to render. If omitted, the entire dashboard is rendered",
+                    "type": "integer"
+                  },
+                  "provisioningPreview": {
+                    "description": "Render a dashboard from a provisioning repository branch (e.g. a git-sync PR preview). Mutually exclusive with dashboardUid.",
+                    "properties": {
+                      "path": {
+                        "description": "Path to the dashboard file within the repository, relative to its root.",
+                        "type": "string"
+                      },
+                      "ref": {
+                        "description": "Branch or commit SHA to render from. Defaults to the repository's main branch when omitted.",
+                        "type": "string"
+                      },
+                      "repo": {
+                        "description": "Provisioning repository slug. List repositories via /apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories if unknown.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "repo",
+                      "path"
+                    ],
+                    "type": "object"
+                  },
+                  "scale": {
+                    "description": "Scale factor for the image (1-3). Defaults to 1",
+                    "type": "integer"
+                  },
+                  "theme": {
+                    "description": "Theme for the rendered image: light or dark. Defaults to dark",
+                    "type": "string"
+                  },
+                  "timeRange": {
+                    "description": "Time range for the rendered image",
+                    "properties": {
+                      "from": {
+                        "description": "Start time (e.g., 'now-1h', '2024-01-01T00:00:00Z')",
+                        "type": "string"
+                      },
+                      "to": {
+                        "description": "End time (e.g., 'now', '2024-01-01T12:00:00Z')",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "timeout": {
+                    "description": "Rendering timeout in seconds. Defaults to 60",
+                    "type": "integer"
+                  },
+                  "variables": {
+                    "additionalProperties": {
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      ]
+                    },
+                    "description": "Dashboard variables to apply. Values can be a single string or an array of strings for multi-value variables (e.g., {\"var-datasource\": \"prometheus\", \"var-instance\": [\"server1\", \"server2\"]})",
+                    "type": "object"
+                  },
+                  "width": {
+                    "description": "Width of the rendered image in pixels. Defaults to 1000",
+                    "type": "integer"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "get_panel_image"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get plugin"
+              },
+              "description": "Check whether a Grafana plugin is installed and retrieve its details (name, version, type, enabled status). Returns installed=false when the plugin is not found. Use install_plugin when a plugin is not installed to install plugin after confirming this action with the user.",
+              "inputSchema": {
+                "properties": {
+                  "pluginId": {
+                    "description": "The plugin ID to check (e.g. 'prometheus', 'grafana-piechart-panel', 'grafana-oncall-app')",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "pluginId"
+                ],
+                "type": "object"
+              },
+              "name": "get_plugin"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get Sift analysis"
+              },
+              "description": "Retrieves a specific analysis from an investigation by its UUID. The investigation ID and analysis ID should be provided as strings in UUID format.",
+              "inputSchema": {
+                "properties": {
+                  "analysisId": {
+                    "description": "The UUID of the specific analysis to retrieve",
+                    "type": "string"
+                  },
+                  "investigationId": {
+                    "description": "The UUID of the investigation as a string (e.g. '02adab7c-bf5b-45f2-9459-d71a2c29e11b')",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "investigationId",
+                  "analysisId"
+                ],
+                "type": "object"
+              },
+              "name": "get_sift_analysis"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get Sift investigation"
+              },
+              "description": "Retrieves an existing Sift investigation by its UUID. The ID should be provided as a string in UUID format (e.g. '02adab7c-bf5b-45f2-9459-d71a2c29e11b').",
+              "inputSchema": {
+                "properties": {
+                  "id": {
+                    "description": "The UUID of the investigation as a string (e.g. '02adab7c-bf5b-45f2-9459-d71a2c29e11b')",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "type": "object"
+              },
+              "name": "get_sift_investigation"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get snapshot"
+              },
+              "description": "Get a Grafana snapshot by key, including snapshot metadata and dashboard payload.",
+              "inputSchema": {
+                "properties": {
+                  "key": {
+                    "description": "Snapshot key to retrieve",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "key"
+                ],
+                "type": "object"
+              },
+              "name": "get_snapshot"
+            },
+            {
+              "annotations": {
+                "title": "Grafana API request"
+              },
+              "description": "Make an authenticated HTTP request to the Grafana API. Similar to 'gh api' for GitHub. Supports any Grafana API endpoint with optional jq-style response filtering. Use this for API endpoints that don't have a dedicated tool.",
+              "inputSchema": {
+                "properties": {
+                  "body": {
+                    "description": "Request body (JSON string). Used with POST, PUT, and PATCH requests.",
+                    "type": "string"
+                  },
+                  "endpoint": {
+                    "description": "The API path relative to the Grafana base URL (e.g. '/api/org', '/api/dashboards/uid/abc123'). Must start with '/'.",
+                    "type": "string"
+                  },
+                  "headers": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Additional HTTP headers to include in the request.",
+                    "type": "object"
+                  },
+                  "jq": {
+                    "description": "A jq expression to filter or transform the JSON response (e.g. '.dashboards[] | .title').",
+                    "type": "string"
+                  },
+                  "method": {
+                    "description": "HTTP method. Defaults to GET",
+                    "enum": [
+                      "GET",
+                      "POST",
+                      "PUT",
+                      "PATCH",
+                      "DELETE"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "endpoint"
+                ],
+                "type": "object"
+              },
+              "name": "grafana_api_request"
+            },
+            {
+              "annotations": {
+                "destructiveHint": true,
+                "idempotentHint": false,
+                "readOnlyHint": false,
+                "title": "Install plugin"
+              },
+              "description": "Install a Grafana plugin by its plugin ID. If the version is not already confirmed with the user, omit it — the tool will look up the latest version and return it for confirmation before installing.",
+              "inputSchema": {
+                "properties": {
+                  "pluginId": {
+                    "description": "The plugin ID to install (e.g. 'grafana-image-renderer', 'grafana-piechart-panel')",
+                    "type": "string"
+                  },
+                  "version": {
+                    "description": "The exact version to install. Must be confirmed with the user before calling — if unknown, omit this field to look up the latest version first.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "pluginId"
+                ],
+                "type": "object"
+              },
+              "name": "install_plugin"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List IRM alert groups"
+              },
+              "description": "List alert groups from Grafana OnCall with filtering options. Supports filtering by alert group ID, route ID, integration ID, state (new, acknowledged, resolved, silenced), team ID, time range, labels, and name. For time ranges, use format '{start}_{end}' ISO 8601 timestamp range (e.g., '2025-01-19T00:00:00_2025-01-19T23:59:59' for a specific day). For labels, use format 'key:value' (e.g., ['env:prod', 'severity:high']). Returns a list of alert group objects with their details. Supports pagination.",
+              "inputSchema": {
+                "properties": {
+                  "id": {
+                    "description": "Filter by specific alert group ID",
+                    "type": "string"
+                  },
+                  "integrationId": {
+                    "description": "Filter by integration ID",
+                    "type": "string"
+                  },
+                  "labels": {
+                    "description": "Filter by labels in format key:value (e.g., ['env:prod', 'severity:high'])",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "description": "Filter by alert group name",
+                    "type": "string"
+                  },
+                  "page": {
+                    "description": "The page number to return",
+                    "type": "integer"
+                  },
+                  "routeId": {
+                    "description": "Filter by route ID",
+                    "type": "string"
+                  },
+                  "startedAt": {
+                    "description": "Filter by time range in format '{start}_{end}' ISO 8601 timestamp range (UTC assumed, no timezone indicator needed) (e.g., '2025-01-19T00:00:00_2025-01-19T23:59:59')",
+                    "type": "string"
+                  },
+                  "state": {
+                    "description": "Filter by alert group state (one of: new, acknowledged, resolved, silenced)",
+                    "type": "string"
+                  },
+                  "teamId": {
+                    "description": "Filter by team ID",
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "list_alert_groups"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List datasources"
+              },
+              "description": "List all configured datasources in Grafana. Use this to discover available datasources and their UIDs. Supports filtering by type and pagination.",
+              "inputSchema": {
+                "properties": {
+                  "limit": {
+                    "default": 50,
+                    "description": "Maximum number of datasources to return (max 100)",
+                    "type": "integer"
+                  },
+                  "offset": {
+                    "default": 0,
+                    "description": "Number of datasources to skip for pagination",
+                    "type": "integer"
+                  },
+                  "type": {
+                    "description": "The type of datasources to search for. For example, 'prometheus', 'loki', 'tempo', etc...",
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "list_datasources"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List incidents"
+              },
+              "description": "List Grafana incidents. Allows filtering by status ('active', 'resolved') and optionally including drill incidents. Returns a preview list with basic details.",
+              "inputSchema": {
+                "properties": {
+                  "drill": {
+                    "description": "Whether to include drill incidents",
+                    "type": "boolean"
+                  },
+                  "limit": {
+                    "default": 10,
+                    "description": "The maximum number of incidents to return",
+                    "type": "integer"
+                  },
+                  "status": {
+                    "description": "The status of the incidents to include. Valid values: 'active', 'resolved'",
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "list_incidents"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List Loki label names"
+              },
+              "description": "Lists all available label/field names (keys) found in logs within a specified Loki or VictoriaLogs datasource and time range. Returns a list of unique label strings (e.g., `[\"app\", \"env\", \"pod\"]`). If the time range is not provided, it defaults to the last hour.",
+              "inputSchema": {
+                "properties": {
+                  "datasourceUid": {
+                    "description": "The UID of the datasource to query",
+                    "type": "string"
+                  },
+                  "endRfc3339": {
+                    "description": "Optionally, the end time of the query in RFC3339 format or relative time (e.g. 'now') (defaults to now)",
+                    "type": "string"
+                  },
+                  "startRfc3339": {
+                    "description": "Optionally, the start time of the query in RFC3339 format or relative time (e.g. 'now-1h') (defaults to 1 hour ago)",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "datasourceUid"
+                ],
+                "type": "object"
+              },
+              "name": "list_loki_label_names"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List Loki label values"
+              },
+              "description": "Retrieves all unique values associated with a specific `labelName` within a Loki or VictoriaLogs datasource and time range. Returns a list of string values (e.g., for `labelName=\"env\"`, might return `[\"prod\", \"staging\", \"dev\"]`). Useful for discovering filter options. Defaults to the last hour if the time range is omitted.",
+              "inputSchema": {
+                "properties": {
+                  "datasourceUid": {
+                    "description": "The UID of the datasource to query",
+                    "type": "string"
+                  },
+                  "endRfc3339": {
+                    "description": "Optionally, the end time of the query in RFC3339 format or relative time (e.g. 'now') (defaults to now)",
+                    "type": "string"
+                  },
+                  "labelName": {
+                    "description": "The name of the label to retrieve values for (e.g. 'app', 'env', 'pod')",
+                    "type": "string"
+                  },
+                  "startRfc3339": {
+                    "description": "Optionally, the start time of the query in RFC3339 format or relative time (e.g. 'now-1h') (defaults to 1 hour ago)",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "datasourceUid",
+                  "labelName"
+                ],
+                "type": "object"
+              },
+              "name": "list_loki_label_values"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List OnCall schedules"
+              },
+              "description": "List Grafana OnCall schedules, optionally filtering by team ID. If a specific schedule ID is provided, retrieves details for only that schedule. Returns a list of schedule summaries including ID, name, team ID, timezone, and shift IDs. Supports pagination.",
+              "inputSchema": {
+                "properties": {
+                  "page": {
+                    "description": "The page number to return (1-based)",
+                    "type": "integer"
+                  },
+                  "scheduleId": {
+                    "description": "The ID of the schedule to get details for. If provided, returns only that schedule's details",
+                    "type": "string"
+                  },
+                  "teamId": {
+                    "description": "The ID of the team to list schedules for",
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "list_oncall_schedules"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List OnCall teams"
+              },
+              "description": "List teams configured in Grafana OnCall. Returns a list of team objects with their details. Supports pagination.",
+              "inputSchema": {
+                "properties": {
+                  "page": {
+                    "description": "The page number to return",
+                    "type": "integer"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "list_oncall_teams"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List OnCall users"
+              },
+              "description": "List users from Grafana OnCall. These are OnCall users (separate from Grafana users). Can retrieve all users in the OnCall directory, a specific user by ID, or filter by username. Returns a list of user objects with their details. Supports pagination.",
+              "inputSchema": {
+                "properties": {
+                  "page": {
+                    "description": "The page number to return",
+                    "type": "integer"
+                  },
+                  "userId": {
+                    "description": "The ID of the user to get details for. If provided, returns only that user's details",
+                    "type": "string"
+                  },
+                  "username": {
+                    "description": "The username to filter users by. If provided, returns only the user matching this username",
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "list_oncall_users"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List Prometheus label names"
+              },
+              "description": "List label names in a PromQL-compatible datasource (Prometheus, Thanos, Mimir, Cloud Monitoring, etc.). Allows filtering by series selectors and time range.",
+              "inputSchema": {
+                "properties": {
+                  "datasourceUid": {
+                    "description": "The UID of the datasource to query",
+                    "type": "string"
+                  },
+                  "endRfc3339": {
+                    "description": "Optionally, the end time of the time range to filter the results by. Supports RFC3339 or relative time (e.g. 'now')",
+                    "type": "string"
+                  },
+                  "limit": {
+                    "default": 100,
+                    "description": "Optionally, the maximum number of results to return",
+                    "type": "integer"
+                  },
+                  "matches": {
+                    "description": "Optionally, a list of label matchers to filter the results by",
+                    "items": {
+                      "properties": {
+                        "filters": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "description": "The name of the label to match against",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "One of the '=' or '!=' or '=~' or '!~'",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "The value to match against",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value",
+                              "type"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "projectName": {
+                    "description": "GCP project name to query (Cloud Monitoring datasources only). Overrides or substitutes the defaultProject configured on the datasource.",
+                    "type": "string"
+                  },
+                  "startRfc3339": {
+                    "description": "Optionally, the start time of the time range to filter the results by. Supports RFC3339 or relative time (e.g. 'now-1h')",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "datasourceUid"
+                ],
+                "type": "object"
+              },
+              "name": "list_prometheus_label_names"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List Prometheus label values"
+              },
+              "description": "Use after list_prometheus_metric_names to find label values for filtering queries. Gets the values for a specific label name in a PromQL-compatible datasource (Prometheus, Thanos, Mimir, Cloud Monitoring, etc.). Allows filtering by series selectors and time range.",
+              "inputSchema": {
+                "properties": {
+                  "datasourceUid": {
+                    "description": "The UID of the datasource to query",
+                    "type": "string"
+                  },
+                  "endRfc3339": {
+                    "description": "Optionally, the end time of the query. Supports RFC3339 or relative time (e.g. 'now')",
+                    "type": "string"
+                  },
+                  "labelName": {
+                    "description": "The name of the label to query",
+                    "type": "string"
+                  },
+                  "limit": {
+                    "default": 100,
+                    "description": "Optionally, the maximum number of results to return",
+                    "type": "integer"
+                  },
+                  "matches": {
+                    "description": "Optionally, a list of selectors to filter the results by",
+                    "items": {
+                      "properties": {
+                        "filters": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "description": "The name of the label to match against",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "One of the '=' or '!=' or '=~' or '!~'",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "The value to match against",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value",
+                              "type"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "projectName": {
+                    "description": "GCP project name to query (Cloud Monitoring datasources only). Overrides or substitutes the defaultProject configured on the datasource.",
+                    "type": "string"
+                  },
+                  "startRfc3339": {
+                    "description": "Optionally, the start time of the query. Supports RFC3339 or relative time (e.g. 'now-1h')",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "datasourceUid",
+                  "labelName"
+                ],
+                "type": "object"
+              },
+              "name": "list_prometheus_label_values"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List Prometheus metric metadata"
+              },
+              "description": "List Prometheus metric metadata. Returns metadata about metrics currently scraped from targets. Note: This endpoint is experimental.",
+              "inputSchema": {
+                "properties": {
+                  "datasourceUid": {
+                    "description": "The UID of the datasource to query",
+                    "type": "string"
+                  },
+                  "limit": {
+                    "default": 10,
+                    "description": "The maximum number of metrics to return",
+                    "type": "integer"
+                  },
+                  "limitPerMetric": {
+                    "description": "The maximum number of metrics to return per metric",
+                    "type": "integer"
+                  },
+                  "metric": {
+                    "description": "The metric to query",
+                    "type": "string"
+                  },
+                  "projectName": {
+                    "description": "GCP project name to query (Cloud Monitoring datasources only). Overrides or substitutes the defaultProject configured on the datasource.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "datasourceUid"
+                ],
+                "type": "object"
+              },
+              "name": "list_prometheus_metric_metadata"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List Prometheus metric names"
+              },
+              "description": "DISCOVERY: Call this first to find available metrics before querying. Lists metric names in a PromQL-compatible datasource (Prometheus, Thanos, Mimir, Cloud Monitoring, etc.). Retrieves all metric names and filters them using the provided regex. Supports pagination and an optional time range to restrict results to metrics active within that window.",
+              "inputSchema": {
+                "properties": {
+                  "datasourceUid": {
+                    "description": "The UID of the datasource to query",
+                    "type": "string"
+                  },
+                  "endRfc3339": {
+                    "description": "Optionally, the end time of the time range to filter the results by. Supports RFC3339 or relative time (e.g. 'now')",
+                    "type": "string"
+                  },
+                  "limit": {
+                    "default": 10,
+                    "description": "The maximum number of results to return",
+                    "type": "integer"
+                  },
+                  "page": {
+                    "default": 1,
+                    "description": "The page number to return",
+                    "type": "integer"
+                  },
+                  "projectName": {
+                    "description": "GCP project name to query (Cloud Monitoring datasources only). Overrides or substitutes the defaultProject configured on the datasource.",
+                    "type": "string"
+                  },
+                  "regex": {
+                    "description": "The regex to match against the metric names",
+                    "type": "string"
+                  },
+                  "startRfc3339": {
+                    "description": "Optionally, the start time of the time range to filter the results by. Supports RFC3339 or relative time (e.g. 'now-1h')",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "datasourceUid"
+                ],
+                "type": "object"
+              },
+              "name": "list_prometheus_metric_names"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List provisioning repositories"
+              },
+              "description": "List provisioning repositories (e.g. git-sync sources) configured for this Grafana instance. Returns each repository's slug along with its source URL, branch, path, sync state, and health. Use the returned `name` as the `repo` argument when rendering a not-yet-applied dashboard preview via get_panel_image's provisioningPreview parameter.",
+              "inputSchema": {
+                "properties": {
+                  "namespace": {
+                    "description": "Kubernetes-style namespace to list repositories from. Defaults to 'default' which matches single-tenant Grafana deployments.",
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "list_provisioning_repositories"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List Pyroscope label names"
+              },
+              "description": "\nLists all available label names (keys) found in profiles within a specified Pyroscope datasource, time range, and\noptional label matchers. Label matchers are typically used to qualify a service name ({service_name=\"foo\"}). Returns a\nlist of unique label strings (e.g., [\"app\", \"env\", \"pod\"]). Label names with double underscores (e.g. __name__) are\ninternal and rarely useful to users. If the time range is not provided, it defaults to the last hour.\n",
+              "inputSchema": {
+                "properties": {
+                  "data_source_uid": {
+                    "description": "The UID of the datasource to query",
+                    "type": "string"
+                  },
+                  "end_rfc_3339": {
+                    "description": "Optionally, the end time of the query in RFC3339 format or relative time (e.g. 'now') (defaults to now)",
+                    "type": "string"
+                  },
+                  "matchers": {
+                    "type": "string"
+                  },
+                  "start_rfc_3339": {
+                    "description": "Optionally, the start time of the query in RFC3339 format or relative time (e.g. 'now-1h') (defaults to 1 hour ago)",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "data_source_uid"
+                ],
+                "type": "object"
+              },
+              "name": "list_pyroscope_label_names"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List Pyroscope label values"
+              },
+              "description": "\nLists all available label values for a particular label name found in profiles within a specified Pyroscope datasource,\ntime range, and optional label matchers. Label matchers are typically used to qualify a service name ({service_name=\"foo\"}).\nReturns a list of unique label strings (e.g. for label name \"env\": [\"dev\", \"staging\", \"prod\"]). If the time range\nis not provided, it defaults to the last hour.\n",
+              "inputSchema": {
+                "properties": {
+                  "data_source_uid": {
+                    "description": "The UID of the datasource to query",
+                    "type": "string"
+                  },
+                  "end_rfc_3339": {
+                    "description": "Optionally, the end time of the query in RFC3339 format or relative time (e.g. 'now') (defaults to now)",
+                    "type": "string"
+                  },
+                  "matchers": {
+                    "description": "Optionally, Prometheus style matchers used to filter the result set (defaults to: {})",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "A label name",
+                    "type": "string"
+                  },
+                  "start_rfc_3339": {
+                    "description": "Optionally, the start time of the query in RFC3339 format or relative time (e.g. 'now-1h') (defaults to 1 hour ago)",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "data_source_uid",
+                  "name"
+                ],
+                "type": "object"
+              },
+              "name": "list_pyroscope_label_values"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List Pyroscope profile types"
+              },
+              "description": "\nLists all available profile types available in a specified Pyroscope datasource and time range. Returns a list of all\navailable profile types (example profile type: \"process_cpu:cpu:nanoseconds:cpu:nanoseconds\"). A profile type has the\nfollowing structure: \u003cname\u003e:\u003csample type\u003e:\u003csample unit\u003e:\u003cperiod type\u003e:\u003cperiod unit\u003e. Not all profile types are available\nfor every service. If the time range is not provided, it defaults to the last hour.\n",
+              "inputSchema": {
+                "properties": {
+                  "data_source_uid": {
+                    "description": "The UID of the datasource to query",
+                    "type": "string"
+                  },
+                  "end_rfc_3339": {
+                    "description": "Optionally, the end time of the query in RFC3339 format or relative time (e.g. 'now') (defaults to now)",
+                    "type": "string"
+                  },
+                  "start_rfc_3339": {
+                    "description": "Optionally, the start time of the query in RFC3339 format or relative time (e.g. 'now-1h') (defaults to 1 hour ago)",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "data_source_uid"
+                ],
+                "type": "object"
+              },
+              "name": "list_pyroscope_profile_types"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List Sift investigations"
+              },
+              "description": "Retrieves a list of Sift investigations with an optional limit. If no limit is specified, defaults to 10 investigations.",
+              "inputSchema": {
+                "properties": {
+                  "limit": {
+                    "default": 10,
+                    "description": "Maximum number of investigations to return",
+                    "type": "integer"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "list_sift_investigations"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "List snapshots"
+              },
+              "description": "List Grafana dashboard snapshots with optional query and result limit filters.",
+              "inputSchema": {
+                "properties": {
+                  "limit": {
+                    "description": "Maximum number of snapshots to return (Grafana defaults to 1000 when omitted)",
+                    "type": "integer"
+                  },
+                  "query": {
+                    "description": "Optional search query for snapshot name",
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "list_snapshots"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Query Loki logs"
+              },
+              "description": "Executes a log query against a Loki or VictoriaLogs datasource and returns matching log entries (or metric samples on Loki). Defaults to the last hour, a limit of 10 entries, and 'backward' direction (newest first). The `logql` parameter takes LogQL on Loki and LogsQL on VictoriaLogs (e.g., Loki: `{app=\"foo\"} |= \"error\"`; VictoriaLogs: `{app=\"foo\"} \"error\"`). To count matching log lines precisely, use a `count_over_time()` metric query with queryType='instant'. Prefer using `query_loki_stats` first to cheaply check whether a stream contains data (avoiding expensive queries against empty streams) and `list_loki_label_names` / `list_loki_label_values` to verify labels exist before querying. Note: `query_loki_stats` returns approximate storage-level counts, not exact log line counts.",
+              "inputSchema": {
+                "properties": {
+                  "datasourceUid": {
+                    "description": "The UID of the datasource to query",
+                    "type": "string"
+                  },
+                  "direction": {
+                    "description": "Optionally, the direction of the query: 'forward' (oldest first) or 'backward' (newest first, default)",
+                    "type": "string"
+                  },
+                  "endRfc3339": {
+                    "description": "Optionally, the end time of the query in RFC3339 format or relative time (e.g. 'now')",
+                    "type": "string"
+                  },
+                  "limit": {
+                    "default": 10,
+                    "description": "Optionally, the maximum number of log lines to return (default max: 100, configurable by MCP server).",
+                    "type": "integer"
+                  },
+                  "logql": {
+                    "description": "The LogQL query to execute against Loki. This can be a simple label matcher or a complex query with filters, parsers, and expressions. Supports full LogQL syntax including label matchers, filter operators, pattern expressions, and pipeline operations.",
+                    "type": "string"
+                  },
+                  "queryType": {
+                    "description": "Query type: 'range' (default) or 'instant'. Instant queries return a single value at one point in time. Range queries return values over a time window. Use 'instant' for metric queries when you want the current value.",
+                    "type": "string"
+                  },
+                  "startRfc3339": {
+                    "description": "Optionally, the start time of the query in RFC3339 format or relative time (e.g. 'now-1h')",
+                    "type": "string"
+                  },
+                  "stepSeconds": {
+                    "description": "Resolution step in seconds for range metric queries. When running metric queries with queryType='range', this controls the time resolution of the returned data points.",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "datasourceUid",
+                  "logql"
+                ],
+                "type": "object"
+              },
+              "name": "query_loki_logs"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Query Loki patterns"
+              },
+              "description": "Retrieves detected log patterns from a Loki datasource for a given stream selector and time range. Returns a list of patterns, each containing a pattern string and a total count of occurrences. Patterns help identify common log structures and anomalies. The `logql` parameter must be a stream selector (e.g., `{job=\"nginx\"}`) and does not support line filters or aggregations. Defaults to the last hour if the time range is omitted. **Not supported on VictoriaLogs** datasources - use a `| stats` pipeline instead.",
+              "inputSchema": {
+                "properties": {
+                  "datasourceUid": {
+                    "description": "The UID of the datasource to query",
+                    "type": "string"
+                  },
+                  "endRfc3339": {
+                    "description": "Optionally, the end time of the query in RFC3339 format or relative time (e.g. 'now') (defaults to now)",
+                    "type": "string"
+                  },
+                  "logql": {
+                    "description": "A LogQL stream selector to identify the logs to analyze for patterns (e.g. {job=\"foo\", namespace=\"bar\"})",
+                    "type": "string"
+                  },
+                  "startRfc3339": {
+                    "description": "Optionally, the start time of the query in RFC3339 format or relative time (e.g. 'now-1h') (defaults to 1 hour ago)",
+                    "type": "string"
+                  },
+                  "step": {
+                    "description": "Optionally, the query resolution step (e.g. '5m')",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "datasourceUid",
+                  "logql"
+                ],
+                "type": "object"
+              },
+              "name": "query_loki_patterns"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Get Loki log statistics"
+              },
+              "description": "Retrieves index-level statistics about log streams matching a given selector within a Loki or VictoriaLogs datasource and time range. Returns an object containing the count of streams, chunks, entries, and total bytes (e.g., `{\"streams\": 5, \"chunks\": 50, \"entries\": 10000, \"bytes\": 512000}`). **Important**: the `entries` count reflects storage-level index entries (chunk metadata), NOT the number of individual log lines matching the selector. To count actual matching log lines, use `query_loki_logs` with a `count_over_time()` metric query instead. On VictoriaLogs only `entries` is populated; the other fields remain zero. The `logql` parameter **must** be a simple label selector (e.g., `{app=\"nginx\", env=\"prod\"}`) and does not support line filters, parsers, or aggregations. Defaults to the last hour if the time range is omitted.",
+              "inputSchema": {
+                "properties": {
+                  "datasourceUid": {
+                    "description": "The UID of the datasource to query",
+                    "type": "string"
+                  },
+                  "endRfc3339": {
+                    "description": "Optionally, the end time of the query in RFC3339 format or relative time (e.g. 'now')",
+                    "type": "string"
+                  },
+                  "logql": {
+                    "description": "The LogQL matcher expression to execute. This parameter only accepts label matcher expressions and does not support full LogQL queries. Line filters, pattern operations, and metric aggregations are not supported by the stats API endpoint. Only simple label selectors can be used here.",
+                    "type": "string"
+                  },
+                  "startRfc3339": {
+                    "description": "Optionally, the start time of the query in RFC3339 format or relative time (e.g. 'now-1h')",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "datasourceUid",
+                  "logql"
+                ],
+                "type": "object"
+              },
+              "name": "query_loki_stats"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Query Prometheus metrics"
+              },
+              "description": "WORKFLOW: list_prometheus_metric_names -\u003e list_prometheus_label_values -\u003e query_prometheus. Query a PromQL-compatible datasource (Prometheus, Thanos, Mimir, Cloud Monitoring, etc.) using a PromQL expression. Supports instant queries (single point) and range queries (time range). Time: RFC3339 or relative expressions like 'now'\\, 'now-1h'.",
+              "inputSchema": {
+                "properties": {
+                  "datasourceUid": {
+                    "description": "The UID of the datasource to query",
+                    "type": "string"
+                  },
+                  "endTime": {
+                    "description": "The end time. Supported formats are RFC3339 or relative to now (e.g. 'now', 'now-1.5h', 'now-2h45m'). Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h', 'd'.",
+                    "type": "string"
+                  },
+                  "expr": {
+                    "description": "The PromQL expression to query",
+                    "type": "string"
+                  },
+                  "projectName": {
+                    "description": "GCP project name to query (Cloud Monitoring datasources only). Overrides or substitutes the defaultProject configured on the datasource.",
+                    "type": "string"
+                  },
+                  "queryType": {
+                    "description": "The type of query to use. Either 'range' or 'instant'",
+                    "type": "string"
+                  },
+                  "startTime": {
+                    "description": "The start time. Required if queryType is 'range', ignored if queryType is 'instant' Supported formats are RFC3339 or relative to now (e.g. 'now', 'now-1.5h', 'now-2h45m'). Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h', 'd'.",
+                    "type": "string"
+                  },
+                  "stepSeconds": {
+                    "description": "The time series step size in seconds. Required if queryType is 'range', ignored if queryType is 'instant'",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "datasourceUid",
+                  "expr",
+                  "endTime"
+                ],
+                "type": "object"
+              },
+              "name": "query_prometheus"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Query Prometheus histogram percentile"
+              },
+              "description": "Query Prometheus histogram percentiles. DISCOVER FIRST: Use list_prometheus_metric_names with regex='.*_bucket$' to find histograms.\n\nGenerates histogram_quantile PromQL. Example: metric='http_duration', percentile=95, labels='job=\"api\"'\n\nTime formats: 'now-1h', '2026-02-02T19:00:00Z', '1738519200000' (Unix ms)",
+              "inputSchema": {
+                "properties": {
+                  "datasourceUid": {
+                    "description": "The UID of the Prometheus datasource",
+                    "type": "string"
+                  },
+                  "endTime": {
+                    "description": "End time (default: now). Supports RFC3339, relative, or Unix ms.",
+                    "type": "string"
+                  },
+                  "labels": {
+                    "description": "Label selector (e.g. job=\"api\", service=\"gateway\")",
+                    "type": "string"
+                  },
+                  "metric": {
+                    "description": "Base histogram metric name (without _bucket suffix)",
+                    "type": "string"
+                  },
+                  "percentile": {
+                    "description": "Percentile to calculate (e.g. 50, 90, 95, 99)",
+                    "type": "number"
+                  },
+                  "projectName": {
+                    "description": "GCP project name to query (Cloud Monitoring datasources only). Overrides or substitutes the defaultProject configured on the datasource.",
+                    "type": "string"
+                  },
+                  "rateInterval": {
+                    "description": "Rate interval for the query (default: 5m)",
+                    "type": "string"
+                  },
+                  "startTime": {
+                    "description": "Start time (default: now-1h). Supports RFC3339, relative (now-1h), or Unix ms.",
+                    "type": "string"
+                  },
+                  "stepSeconds": {
+                    "description": "Step size in seconds for range query (default: 60)",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "datasourceUid",
+                  "metric",
+                  "percentile"
+                ],
+                "type": "object"
+              },
+              "name": "query_prometheus_histogram"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Query Pyroscope"
+              },
+              "description": "\nUnified Pyroscope query tool for fetching profiles or metrics from Pyroscope. Profile data shows WHICH functions consume resources; metrics data\nshows WHEN consumption spiked. Use query_type=\"both\" for complete analysis in one call.\n\nquery_type options (extends Grafana's PyroscopeQueryType):\n- \"profile\": returns DOT-format call graph\n- \"metrics\": returns time-series data points\n- \"both\" (default): returns both profile and metrics in one response\n",
+              "inputSchema": {
+                "properties": {
+                  "data_source_uid": {
+                    "description": "The UID of the datasource to query",
+                    "type": "string"
+                  },
+                  "end_rfc_3339": {
+                    "description": "End time in RFC3339 or relative time (e.g. 'now') (defaults to now)",
+                    "type": "string"
+                  },
+                  "group_by": {
+                    "description": "Labels to group metrics series by",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "matchers": {
+                    "description": "Prometheus style matchers (defaults to: {})",
+                    "type": "string"
+                  },
+                  "max_node_depth": {
+                    "description": "Max depth for profile call graph (default: 100)",
+                    "type": "integer"
+                  },
+                  "profile_type": {
+                    "description": "The profile type, use list_pyroscope_profile_types to discover available types",
+                    "type": "string"
+                  },
+                  "query_type": {
+                    "description": "Query type: \"profile\" (flamegraph), \"metrics\" (time-series), or \"both\" (default). Use \"both\" for complete analysis",
+                    "type": "string"
+                  },
+                  "start_rfc_3339": {
+                    "description": "Start time in RFC3339 or relative time (e.g. 'now-1h') (defaults to 1 hour ago)",
+                    "type": "string"
+                  },
+                  "step": {
+                    "description": "Seconds between metrics data points (default: auto)",
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "data_source_uid",
+                  "profile_type"
+                ],
+                "type": "object"
+              },
+              "name": "query_pyroscope"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Search dashboards"
+              },
+              "description": "Search for Grafana dashboards by a query string. Returns a list of matching dashboards with details like title, UID, folder, tags, and URL.",
+              "inputSchema": {
+                "properties": {
+                  "limit": {
+                    "default": 50,
+                    "description": "Maximum number of results to return (max 100)",
+                    "type": "integer"
+                  },
+                  "page": {
+                    "default": 1,
+                    "description": "Page number for pagination (1-indexed)",
+                    "type": "integer"
+                  },
+                  "query": {
+                    "description": "The query to search for",
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "search_dashboards"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Search folders"
+              },
+              "description": "Search for Grafana folders by a query string. Returns matching folders with details like title, UID, and URL.",
+              "inputSchema": {
+                "properties": {
+                  "query": {
+                    "description": "The query to search for",
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "search_folders"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Search plugins"
+              },
+              "description": "Search the Grafana plugin catalog by keyword to discover available plugins before installing or getting plugin details on a specific instance. Returns results sorted by trust: official Grafana Labs plugins first, then commercial partner plugins, then community plugins. Use this tool when a user describes a plugin by purpose or partial name (e.g. 'azure monitoring', 'loki', 'database') — it returns the exact pluginId to pass to get_plugin or install_plugin. Results include warnings for enterprise-only or Angular-based plugins.",
+              "inputSchema": {
+                "properties": {
+                  "query": {
+                    "description": "Keyword to search for plugins (e.g. 'azure', 'prometheus', 'loki', 'database'). Matches against plugin name, slug, description, and keywords.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "query"
+                ],
+                "type": "object"
+              },
+              "name": "search_plugin_information"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Suggest Alloy label enforcement config"
+              },
+              "description": "Generates an Alloy loki.process snippet enforcing an approved label set via stage.label_keep, with optional log-level normalisation and soft-enforcement placeholders.",
+              "inputSchema": {
+                "properties": {
+                  "approvedLabels": {
+                    "description": "Labels to keep on the index.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "componentName": {
+                    "type": "string"
+                  },
+                  "forwardTo": {
+                    "type": "string"
+                  },
+                  "normalizeLogLevel": {
+                    "type": "boolean"
+                  },
+                  "requiredLabels": {
+                    "description": "Labels that get an 'unknown' placeholder when missing.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "approvedLabels"
+                ],
+                "type": "object"
+              },
+              "name": "suggest_loki_alloy_label_config"
+            },
+            {
+              "annotations": {
+                "destructiveHint": true,
+                "idempotentHint": false,
+                "title": "Update Annotation"
+              },
+              "description": "Updates the provided properties of an annotation by ID. Only fields included in the request are modified; omitted fields are left unchanged.",
+              "inputSchema": {
+                "properties": {
+                  "data": {
+                    "description": "Optional JSON payload",
+                    "type": "object"
+                  },
+                  "id": {
+                    "description": "Annotation ID to update",
+                    "type": "integer"
+                  },
+                  "tags": {
+                    "description": "Tags to replace existing tags",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "text": {
+                    "description": "New annotation text",
+                    "type": "string"
+                  },
+                  "time": {
+                    "description": "New start time epoch ms",
+                    "type": "integer"
+                  },
+                  "timeEnd": {
+                    "description": "New end time epoch ms",
+                    "type": "integer"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "update_annotation"
+            },
+            {
+              "annotations": {
+                "destructiveHint": true,
+                "title": "Create or update dashboard"
+              },
+              "description": "Create or update a dashboard. Two modes: (1) Full JSON — provide 'dashboard' for new dashboards or complete replacements. (2) Patch — provide 'uid' + 'operations' to make targeted changes to an existing dashboard. One of these two modes is required; 'folderUid'\\, 'message'\\, and 'overwrite' are supplementary and do nothing on their own. Dashboard authoring guidance: if a saved query must support one\\, many\\, or All values from a multi-select variable inside a regex expression or matcher\\, save '${var:regex}' rather than plain '$var'. Saved dashboard annotation queries/definitions must be written into dashboard JSON under 'annotations.list'; the create_annotation tool creates annotation events and does not add a reusable dashboard annotation query/definition to the saved dashboard. For stat panels over the current dashboard range\\, make the query return the range-level result the stat should display; panel-side reduction only reduces returned series and does not compute peak-over-range or ratio-of-peaks semantics for you. Patch operations support JSONPaths like '$.panels[0].targets[0].expr'\\, '$.panels[1].title'\\, '$.panels[2].targets[0].datasource'\\, '$.templating.list/-'\\, and '$.annotations.list/-'. Append to arrays with '/- ' syntax: '$.panels/- '. Remove by index: {\"op\": \"remove\"\\, \"path\": \"$.panels[2]\"}. Multiple removes on the same array are automatically reordered to avoid index-shifting issues. Note: only numeric array indices are supported in patch paths; filter expressions like [?(@.id==2)] and wildcards like [*] are not supported. v2 dashboards (check 'isV2' from get_dashboard_by_uid) use a different shape: patch '$.elements.\u003cname\u003e.spec.title' or '$.elements.\u003cname\u003e.spec.data.spec.queries[0].spec' and edit '$.variables'/'$.layout' rather than '$.panels'/'$.templating.list'. Full-JSON saves containing top-level 'elements'/'layout' are written as v2 and require a Kubernetes-capable Grafana. After creating or updating a dashboard\\, verify that panel queries return data by using `run_panel_query` or the appropriate query tool (`query_prometheus`\\, `query_loki_logs`\\, etc.) to validate expressions before considering the task complete.",
+              "inputSchema": {
+                "properties": {
+                  "dashboard": {
+                    "description": "The full dashboard JSON. Use for creating new dashboards or complete updates. Saved dashboard annotation queries/definitions live in 'annotations.list' inside this JSON; they are different from annotation events created with create_annotation. Large dashboards consume significant context - consider using patches for small changes.",
+                    "type": "object"
+                  },
+                  "folderUid": {
+                    "description": "The UID of the dashboard's folder",
+                    "type": "string"
+                  },
+                  "message": {
+                    "description": "Set a commit message for the version history",
+                    "type": "string"
+                  },
+                  "operations": {
+                    "description": "Array of patch operations for targeted updates. More efficient than full dashboard JSON for small changes. Common paths: '$.templating.list/-' to add a variable, '$.annotations.list/-' to add a saved dashboard annotation query/definition, '$.panels[0].targets[0].expr' to replace a panel query.",
+                    "items": {
+                      "properties": {
+                        "op": {
+                          "description": "Operation type: 'replace', 'add', 'remove'",
+                          "type": "string"
+                        },
+                        "path": {
+                          "description": "JSONPath to the property to modify. Supports: '$.title', '$.panels[0].title', '$.panels[0].targets[0].expr', '$.panels[1].targets[0].datasource', '$.templating.list/-' (append a variable), '$.annotations.list/-' (append a saved dashboard annotation query/definition). For appending to arrays, use '/- ' syntax: '$.panels/- ' (append to panels array) or '$.panels[2]/- ' (append to nested array at index 2).",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "New value for replace/add operations. When adding a saved dashboard annotation query/definition, append an object to '$.annotations.list' rather than calling create_annotation."
+                        }
+                      },
+                      "required": [
+                        "op",
+                        "path"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "overwrite": {
+                    "description": "Overwrite the dashboard if it exists. Otherwise create one",
+                    "type": "boolean"
+                  },
+                  "uid": {
+                    "description": "UID of existing dashboard to update. Must be used together with 'operations'. Providing 'uid' without 'operations' will fail.",
+                    "type": "string"
+                  },
+                  "userId": {
+                    "description": "ID of the user making the change",
+                    "type": "integer"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "name": "update_dashboard"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": false,
+                "title": "Update datasource"
+              },
+              "description": "Update non-secret datasource fields by UID. Omitted fields are preserved. For secrets, direct the user to the Grafana UI.",
+              "inputSchema": {
+                "properties": {
+                  "access": {
+                    "description": "proxy or direct",
+                    "type": "string"
+                  },
+                  "basicAuth": {
+                    "description": "Enable basic auth",
+                    "type": "boolean"
+                  },
+                  "database": {
+                    "description": "Database name",
+                    "type": "string"
+                  },
+                  "isDefault": {
+                    "description": "Make this the default datasource",
+                    "type": "boolean"
+                  },
+                  "jsonData": {
+                    "description": "Non-secret plugin settings; replaces existing jsonData when set",
+                    "type": "object"
+                  },
+                  "name": {
+                    "description": "Display name",
+                    "type": "string"
+                  },
+                  "uid": {
+                    "description": "UID of the datasource to update",
+                    "type": "string"
+                  },
+                  "url": {
+                    "description": "Base URL",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "uid"
+                ],
+                "type": "object"
+              },
+              "name": "update_datasource"
+            },
+            {
+              "annotations": {
+                "idempotentHint": true,
+                "readOnlyHint": true,
+                "title": "Validate provisioning file"
+              },
+              "description": "Validate a file in a provisioning repository at a given branch or commit by dry-run applying it. Returns whether the file would be accepted (valid)\\, what resource action would result (create/update)\\, the target resource type\\, and any structured validation errors. Use to confirm a draft dashboard or other resource will be accepted before merging or applying a PR — this is the same validation surface that Grafana's PR commenter reports.",
+              "inputSchema": {
+                "properties": {
+                  "namespace": {
+                    "description": "Kubernetes-style namespace to read the repository from. Defaults to 'default'.",
+                    "type": "string"
+                  },
+                  "path": {
+                    "description": "File path within the repository (e.g. 'folder/dashboard.json').",
+                    "type": "string"
+                  },
+                  "ref": {
+                    "description": "Branch or commit SHA. Defaults to the repository's main branch.",
+                    "type": "string"
+                  },
+                  "repo": {
+                    "description": "Provisioning repository slug. Get one from list_provisioning_repositories.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "repo",
+                  "path"
+                ],
+                "type": "object"
+              },
+              "name": "validate_provisioning_file"
+            }
+          ],
           "tools": [
             "add_activity_to_incident",
-            "create_alert_rule",
+            "alerting_manage_routing",
+            "alerting_manage_rules",
+            "analyze_loki_labels",
+            "check_datasources_health",
             "create_annotation",
+            "create_datasource",
             "create_folder",
-            "create_graphite_annotation",
             "create_incident",
-            "delete_alert_rule",
-            "fetch_pyroscope_profile",
+            "create_snapshot",
+            "delete_snapshot",
             "find_error_pattern_logs",
             "find_slow_requests",
             "generate_deeplink",
             "get_alert_group",
-            "get_alert_rule_by_uid",
             "get_annotation_tags",
             "get_annotations",
             "get_assertions",
@@ -62,21 +2687,17 @@
             "get_dashboard_panel_queries",
             "get_dashboard_property",
             "get_dashboard_summary",
-            "get_datasource_by_name",
-            "get_datasource_by_uid",
+            "get_datasource",
             "get_incident",
             "get_oncall_shift",
             "get_panel_image",
-            "get_resource_description",
-            "get_resource_permissions",
-            "get_role_assignments",
-            "get_role_details",
+            "get_plugin",
             "get_sift_analysis",
             "get_sift_investigation",
+            "get_snapshot",
+            "grafana_api_request",
+            "install_plugin",
             "list_alert_groups",
-            "list_alert_rules",
-            "list_all_roles",
-            "list_contact_points",
             "list_datasources",
             "list_incidents",
             "list_loki_label_names",
@@ -88,24 +2709,26 @@
             "list_prometheus_label_values",
             "list_prometheus_metric_metadata",
             "list_prometheus_metric_names",
+            "list_provisioning_repositories",
             "list_pyroscope_label_names",
             "list_pyroscope_label_values",
             "list_pyroscope_profile_types",
             "list_sift_investigations",
-            "list_team_roles",
-            "list_teams",
-            "list_user_roles",
-            "list_users_by_org",
-            "patch_annotation",
+            "list_snapshots",
             "query_loki_logs",
             "query_loki_patterns",
             "query_loki_stats",
             "query_prometheus",
+            "query_prometheus_histogram",
+            "query_pyroscope",
             "search_dashboards",
             "search_folders",
-            "update_alert_rule",
+            "search_plugin_information",
+            "suggest_loki_alloy_label_config",
             "update_annotation",
-            "update_dashboard"
+            "update_dashboard",
+            "update_datasource",
+            "validate_provisioning_file"
           ]
         }
       }
@@ -141,11 +2764,10 @@
           "name": "GRAFANA_ORG_ID"
         }
       ],
-      "identifier": "docker.io/grafana/mcp-grafana:0.17.0",
+      "identifier": "docker.io/grafana/mcp-grafana:0.17.2",
       "registryType": "oci",
       "transport": {
-        "type": "sse",
-        "url": "http://localhost:8000"
+        "type": "stdio"
       }
     }
   ],

--- a/registries/toolhive/servers/grafana/server.json
+++ b/registries/toolhive/servers/grafana/server.json
@@ -9,7 +9,7 @@
             "stdio"
           ],
           "metadata": {
-            "last_updated": "2026-07-15T23:57:12Z",
+            "last_updated": "2026-07-16T00:52:19Z",
             "stars": 3239
           },
           "overview": "## Grafana MCP Server\n\nThe grafana MCP server is a Model Context Protocol (MCP) server that enables AI assistants and agents to interact directly with Grafana dashboards, data sources, and observability resources through a structured, AI-friendly interface. It allows AI-driven workflows to explore metrics, logs, alerts, and dashboards without switching tools or manually navigating the Grafana UI. This server is ideal for observability, incident response, performance analysis, and operational workflows where real-time telemetry and monitoring context are essential.\n\n**Note:** the upstream container's entrypoint defaults to the SSE transport, so this entry passes `--transport stdio` via its registry args to force stdio mode. If you run this server with your own custom arguments (`thv run ... -- \u003cyour args\u003e`), those arguments replace the registry defaults, so be sure to include `--transport stdio` yourself or the server will silently fall back to SSE.",


### PR DESCRIPTION
## Summary

- Bump `docker.io/grafana/mcp-grafana` from 0.17.0 to 0.17.2.
- Switch the declared transport from SSE to stdio, since SSE is deprecated. Streamable-http would be the other modern alternative, but 0.17.2 added DNS-rebinding protection that validates the `Host` header for both HTTP-based transports (sse and streamable-http); using either would mean also passing `--allowed-hosts` to allowlist expected hosts, or `--allowed-hosts '*'` to disable the check. Stdio sidesteps this: mcp-grafana only applies that check to its HTTP-based transports, so stdio needs no `--allowed-hosts` at all.
- mcp-grafana's Dockerfile hardcodes `--transport sse` in its ENTRYPOINT, so this adds `--transport stdio` via the registry's `args` extension to override it (last flag wins on the container's command line).
- Drop `allow_port: [443]` from the permission profile; it was a no-op alongside `insecure_allow_all: true`, which allows all outbound traffic unconditionally regardless of port.
- Note in the overview that custom `thv run ... -- <args>` replace the registry's default args entirely rather than merging, so anyone passing their own args needs to include `--transport stdio` themselves to avoid silently falling back to SSE.
- Refresh `tool_definitions` and `last_updated` for 0.17.2.

## Test plan

- [x] `task catalog:validate` passes
- [x] Verified `--transport stdio` override works against the running container
