### PR TITLE
chore: tune Renovate throughput and group non-catalog deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -53,9 +53,39 @@
       "commitMessageTopic": "MCP registry dependency",
       "semanticCommitType": "chore",
       "semanticCommitScope": "deps"
+    },
+    {
+      "description": "Group non-major Go module updates (excluding functionally significant deps handled individually)",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "digest"
+      ],
+      "matchPackageNames": [
+        "!github.com/modelcontextprotocol/registry",
+        "!github.com/stacklok/toolhive*"
+      ],
+      "groupName": "go modules"
+    },
+    {
+      "description": "Group non-major GitHub Actions updates",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "digest",
+        "pin"
+      ],
+      "groupName": "github-actions"
     }
   ],
-  "prConcurrentLimit": 10,
+  "prConcurrentLimit": 20,
+  "prHourlyLimit": 0,
   "prCreation": "immediate",
   "semanticCommits": "enabled",
   "semanticCommitType": "chore",


### PR DESCRIPTION
Addresses the rate-limiting / missing-updates pain tracked via the dependency dashboard (#3).

**Throughput**
- `prHourlyLimit: 0` (was inheriting Renovate's default of `2`). Combined with the once-weekly schedule window, the default capped us at ~6 new PRs/week while the backlog grew faster, so updates sat for weeks. `prCreation` stays `immediate` and the weekly `schedule` is unchanged, the deliberate noise gate on *new* PRs stays intact.
- `prConcurrentLimit: 20` (was `10`) so the current backlog can clear in a single window.

**Grouping non-catalog deps** (catalog image PRs stay one-per-server for review)
- New `github-actions` group: all Action minor/patch/digest/pin updates in one PR; majors land standalone.
- New `go modules` group: all `go.mod` minor/patch/digest updates in one PR; majors land standalone.
- `github.com/modelcontextprotocol/registry` and `github.com/stacklok/toolhive*` are excluded from the group and remain individual PRs, they're functionally significant to the CLI build.

Validated with `renovate-config-validator`.