### PR TITLE
chore: remove unneeded env var from Okta MCP

### DIFF
--- a/registries/official/servers/okta/server.json
+++ b/registries/official/servers/okta/server.json
@@ -207,13 +207,6 @@
           "isRequired": false,
           "isSecret": false,
           "name": "OKTA_LOG_LEVEL"
-        },
-        {
-          "default": "keyrings.alt.file.PlaintextKeyring",
-          "description": "Keyring backend for token storage. The container has no system keyring, so this must point at a file-based backend or the server blocks waiting for a keyring password at startup, even with Private Key JWT auth.",
-          "isRequired": true,
-          "isSecret": false,
-          "name": "PYTHON_KEYRING_BACKEND"
         }
       ],
       "identifier": "ghcr.io/stacklok/dockyard/uvx/okta:1.1.3",

--- a/registries/toolhive/servers/okta/server.json
+++ b/registries/toolhive/servers/okta/server.json
@@ -207,13 +207,6 @@
           "isRequired": false,
           "isSecret": false,
           "name": "OKTA_LOG_LEVEL"
-        },
-        {
-          "default": "keyrings.alt.file.PlaintextKeyring",
-          "description": "Keyring backend for token storage. The container has no system keyring, so this must point at a file-based backend or the server blocks waiting for a keyring password at startup, even with Private Key JWT auth.",
-          "isRequired": true,
-          "isSecret": false,
-          "name": "PYTHON_KEYRING_BACKEND"
         }
       ],
       "identifier": "ghcr.io/stacklok/dockyard/uvx/okta:1.1.3",


### PR DESCRIPTION
The PYTHON_KEYRING_BACKEND env var is now baked into the Okta image via Dockyard (https://github.com/stacklok/dockyard/pull/768), so we don't need it in the catalog spec anymore.