### PR TITLE
chore(deps): bump github.com/stacklok/toolhive-core to v0.0.30

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/go-containerregistry v0.21.7
 	github.com/modelcontextprotocol/registry v1.8.0
 	github.com/spf13/cobra v1.10.2
-	github.com/stacklok/toolhive-core v0.0.29
+	github.com/stacklok/toolhive-core v0.0.30
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -290,8 +290,8 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/stacklok/toolhive-core v0.0.29 h1:3djwGLG/+mav8zM9wKYFlBMmcNnyQ2rW3cS7tEJsIH0=
-github.com/stacklok/toolhive-core v0.0.29/go.mod h1:t8dqTOjyT67i+xidAS1cRWh3K5qYW38R/NgP7xlvirE=
+github.com/stacklok/toolhive-core v0.0.30 h1:qu3Oyz/CGgD/ase35dPYvJzk3PT1QlTziZVHlcopoaU=
+github.com/stacklok/toolhive-core v0.0.30/go.mod h1:t8dqTOjyT67i+xidAS1cRWh3K5qYW38R/NgP7xlvirE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=


### PR DESCRIPTION
## Summary
- Bumps `github.com/stacklok/toolhive-core` from v0.0.29 to v0.0.30 (latest available)

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `task lint`