### PR TITLE
Add BountyVerdict remote server

### DIFF
--- a/registries/toolhive/servers/bountyverdict/server.json
+++ b/registries/toolhive/servers/bountyverdict/server.json
@@ -58,5 +58,5 @@
     "url": "https://github.com/Mimirs402/bountyverdict"
   },
   "title": "BountyVerdict Agent Decision Tools",
-  "version": "1.1.6"
+  "version": "1.1.7"
 }

--- a/registries/toolhive/servers/bountyverdict/server.json
+++ b/registries/toolhive/servers/bountyverdict/server.json
@@ -10,7 +10,7 @@
             "license": "MIT"
           },
           "metadata": {
-            "last_updated": "2026-07-21T23:58:03Z"
+            "last_updated": "2026-07-22T00:29:46Z"
           },
           "overview": "## BountyVerdict Agent Decision Tools\n\nBountyVerdict exposes six paid, read-only decision tools for coding agents. Agents can assess one public GitHub bounty, rank 2-10 bounty opportunities, audit repository agent instructions, diagnose a failed GitHub Actions run, classify whether a failure should be retried once or fixed, and detect breaking MCP tools/list drift. Initialization and tool discovery require no account or API key. A valid first unsigned call cannot charge and returns a structured product, price, use-boundary, decision, value, and free-sample preview plus the exact x402 v2 Base USDC handoff. Only an explicitly authorized signed retry can settle; prices range from $0.02 to $0.40 USDC.",
           "status": "Active",
@@ -58,5 +58,5 @@
     "url": "https://github.com/Mimirs402/bountyverdict"
   },
   "title": "BountyVerdict Agent Decision Tools",
-  "version": "1.1.5"
+  "version": "1.1.6"
 }

--- a/registries/toolhive/servers/bountyverdict/server.json
+++ b/registries/toolhive/servers/bountyverdict/server.json
@@ -58,5 +58,5 @@
     "url": "https://github.com/Mimirs402/bountyverdict"
   },
   "title": "BountyVerdict Agent Decision Tools",
-  "version": "1.1.1"
+  "version": "1.1.3"
 }

--- a/registries/toolhive/servers/bountyverdict/server.json
+++ b/registries/toolhive/servers/bountyverdict/server.json
@@ -9,10 +9,7 @@
             "homepage": "https://mimirs402.github.io/bountyverdict/",
             "license": "MIT"
           },
-          "metadata": {
-            "last_updated": "2026-07-22T00:29:46Z"
-          },
-          "overview": "## BountyVerdict Agent Decision Tools\n\nBountyVerdict exposes six paid, read-only decision tools for coding agents. Agents can assess one public GitHub bounty, rank 2-10 bounty opportunities, audit repository agent instructions, diagnose a failed GitHub Actions run, classify whether a failure should be retried once or fixed, and detect breaking MCP tools/list drift. Initialization and tool discovery require no account or API key. A valid first unsigned call cannot charge and returns a structured product, price, use-boundary, decision, value, and free-sample preview plus the exact x402 v2 Base USDC handoff. Only an explicitly authorized signed retry can settle; prices range from $0.02 to $0.40 USDC.",
+          "overview": "## BountyVerdict Agent Decision Tools\n\nBountyVerdict exposes one free selector and six paid, read-only decision tools for coding agents. Agents can assess one public GitHub bounty, rank 2-10 bounty opportunities, audit repository agent instructions, diagnose a failed GitHub Actions run, classify whether a failure should be retried once or fixed, and detect breaking MCP tools/list drift. Call `choose_github_agent_decision` without arguments to receive a deterministic catalog of use boundaries, prices, required fields, samples, and exact next-call templates without a verdict or payment request. Each paid tool validates its input before returning an x402 v2 Base USDC challenge, and only an explicitly authorized signed retry can settle; prices range from $0.02 to $0.40 USDC.",
           "status": "Active",
           "tags": [
             "remote",
@@ -25,6 +22,7 @@
           ],
           "tier": "Community",
           "tools": [
+            "choose_github_agent_decision",
             "check_github_bounty",
             "rank_github_bounties",
             "audit_agent_harness",
@@ -36,7 +34,7 @@
       }
     }
   },
-  "description": "GitHub bounty, coding-agent, CI failure, flake, and MCP drift decisions via x402",
+  "description": "Free selector plus x402 GitHub bounty, coding-agent, CI failure, flake, and MCP drift decisions",
   "icons": [
     {
       "mimeType": "image/svg+xml",
@@ -58,5 +56,5 @@
     "url": "https://github.com/Mimirs402/bountyverdict"
   },
   "title": "BountyVerdict Agent Decision Tools",
-  "version": "1.1.9"
+  "version": "1.1.14"
 }

--- a/registries/toolhive/servers/bountyverdict/server.json
+++ b/registries/toolhive/servers/bountyverdict/server.json
@@ -10,7 +10,7 @@
             "license": "MIT"
           },
           "metadata": {
-            "last_updated": "2026-07-21T22:15:00Z"
+            "last_updated": "2026-07-21T23:58:03Z"
           },
           "overview": "## BountyVerdict Agent Decision Tools\n\nBountyVerdict exposes six paid, read-only decision tools for coding agents. Agents can assess one public GitHub bounty, rank 2-10 bounty opportunities, audit repository agent instructions, diagnose a failed GitHub Actions run, classify whether a failure should be retried once or fixed, and detect breaking MCP tools/list drift. Initialization and tool discovery require no account or API key. A valid first unsigned call cannot charge and returns a structured product, price, use-boundary, decision, value, and free-sample preview plus the exact x402 v2 Base USDC handoff. Only an explicitly authorized signed retry can settle; prices range from $0.02 to $0.40 USDC.",
           "status": "Active",
@@ -58,5 +58,5 @@
     "url": "https://github.com/Mimirs402/bountyverdict"
   },
   "title": "BountyVerdict Agent Decision Tools",
-  "version": "1.1.4"
+  "version": "1.1.5"
 }

--- a/registries/toolhive/servers/bountyverdict/server.json
+++ b/registries/toolhive/servers/bountyverdict/server.json
@@ -58,5 +58,5 @@
     "url": "https://github.com/Mimirs402/bountyverdict"
   },
   "title": "BountyVerdict Agent Decision Tools",
-  "version": "1.1.3"
+  "version": "1.1.4"
 }

--- a/registries/toolhive/servers/bountyverdict/server.json
+++ b/registries/toolhive/servers/bountyverdict/server.json
@@ -56,5 +56,5 @@
     "url": "https://github.com/Mimirs402/bountyverdict"
   },
   "title": "BountyVerdict Agent Decision Tools",
-  "version": "1.1.14"
+  "version": "1.1.26"
 }

--- a/registries/toolhive/servers/bountyverdict/server.json
+++ b/registries/toolhive/servers/bountyverdict/server.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "io.github.stacklok": {
+        "https://bountyverdict-agent-production.mimirslab.workers.dev/mcp": {
+          "custom_metadata": {
+            "author": "Mimir's Lab",
+            "homepage": "https://mimirs402.github.io/bountyverdict/",
+            "license": "MIT"
+          },
+          "metadata": {
+            "last_updated": "2026-07-21T22:15:00Z"
+          },
+          "overview": "## BountyVerdict Agent Decision Tools\n\nBountyVerdict exposes six paid, read-only decision tools for coding agents. Agents can assess one public GitHub bounty, rank 2-10 bounty opportunities, audit repository agent instructions, diagnose a failed GitHub Actions run, classify whether a failure should be retried once or fixed, and detect breaking MCP tools/list drift. Initialization and tool discovery require no account or API key. A valid first unsigned call cannot charge and returns a structured product, price, use-boundary, decision, value, and free-sample preview plus the exact x402 v2 Base USDC handoff. Only an explicitly authorized signed retry can settle; prices range from $0.02 to $0.40 USDC.",
+          "status": "Active",
+          "tags": [
+            "remote",
+            "github",
+            "coding-agents",
+            "continuous-integration",
+            "developer-tools",
+            "read-only",
+            "x402"
+          ],
+          "tier": "Community",
+          "tools": [
+            "check_github_bounty",
+            "rank_github_bounties",
+            "audit_agent_harness",
+            "diagnose_github_actions_run",
+            "classify_github_actions_flake",
+            "check_mcp_tool_drift"
+          ]
+        }
+      }
+    }
+  },
+  "description": "GitHub bounty, coding-agent, CI failure, flake, and MCP drift decisions via x402",
+  "icons": [
+    {
+      "mimeType": "image/svg+xml",
+      "sizes": [
+        "any"
+      ],
+      "src": "https://mimirs402.github.io/bountyverdict/favicon.svg"
+    }
+  ],
+  "name": "io.github.stacklok/bountyverdict",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://bountyverdict-agent-production.mimirslab.workers.dev/mcp"
+    }
+  ],
+  "repository": {
+    "source": "github",
+    "url": "https://github.com/Mimirs402/bountyverdict"
+  },
+  "title": "BountyVerdict Agent Decision Tools",
+  "version": "1.1.1"
+}

--- a/registries/toolhive/servers/bountyverdict/server.json
+++ b/registries/toolhive/servers/bountyverdict/server.json
@@ -58,5 +58,5 @@
     "url": "https://github.com/Mimirs402/bountyverdict"
   },
   "title": "BountyVerdict Agent Decision Tools",
-  "version": "1.1.7"
+  "version": "1.1.9"
 }


### PR DESCRIPTION
## Summary

- add the hosted BountyVerdict Streamable HTTP server under the dedicated Mimir's Lab account
- expose the exact six read-only GitHub and MCP decision tools
- document the structured non-charging unsigned selection preview and explicit x402 authorization boundary

## Validation

- `go run ./cmd/catalog validate -v`
- official registry: 84 servers valid
- ToolHive registry: 111 servers and 180 skills valid
- live unsigned MCP contract smoke test: passing
- source product CI, dependency audit, and remote container smoke test: passing

This supersedes #1385, which was opened from the maintainer's personal fork before the project moved to `Mimirs402`.
