### PR TITLE
chore: gitignore local catalog-audit reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ go.work.sum
 
 # CLI binaries (built in repo root by workflows)
 /catalog
+
+# Local audit reports (catalog-audit skill) - not meant to be committed
+/audits/


### PR DESCRIPTION
## Summary
- The `catalog-audit` skill writes dated reports under `audits/` for a human to review across a session; they're a local scratch artifact, not something meant to be committed.
- Ignoring the directory makes that structural rather than relying on remembering not to `git add` it.

## Test plan
- [x] `.gitignore` change only, no code paths affected