### PR TITLE
chore: deprecate mcp-server-neon in favor of remote server

### DIFF
--- a/registries/toolhive/servers/mcp-server-neon/server.json
+++ b/registries/toolhive/servers/mcp-server-neon/server.json
@@ -8,7 +8,7 @@
             "last_updated": "2026-04-21T03:03:49Z",
             "stars": 587
           },
-          "overview": "## Neon MCP Server\n\nThe mcp-server-neon is a Model Context Protocol (MCP) server that enables AI assistants and agents to interact directly with Neon, the serverless PostgreSQL platform. It allows AI-driven workflows to inspect databases, manage branches, and reason about environments and schema state — bringing modern, branch-based database context directly into MCP-powered assistants. This server is especially useful for development, testing, preview environments, and workflows where database branching and isolation are key to rapid iteration.",
+          "overview": "## Neon MCP Server (Deprecated)\n\n**Deprecated:** This local containerized server has been deprecated in favor of Neon's official remote MCP server, available in the catalog as `neon`. See https://neon.com/docs/ai/neon-mcp-server for details.\n\nThe mcp-server-neon is a Model Context Protocol (MCP) server that enables AI assistants and agents to interact directly with Neon, the serverless PostgreSQL platform. It allows AI-driven workflows to inspect databases, manage branches, and reason about environments and schema state — bringing modern, branch-based database context directly into MCP-powered assistants. This server is especially useful for development, testing, preview environments, and workflows where database branching and isolation are key to rapid iteration.",
           "permissions": {
             "network": {
               "outbound": {
@@ -31,7 +31,7 @@
             "signer_identity": "/.github/workflows/build-containers.yml",
             "sigstore_url": "tuf-repo-cdn.sigstore.dev"
           },
-          "status": "Active",
+          "status": "Deprecated",
           "tags": [
             "database",
             "postgresql",


### PR DESCRIPTION
## Summary

- Neon's local `mcp-server-neon` npm package is deprecated upstream in favor of their official remote MCP server.
- Marks `mcp-server-neon` as `"status": "Deprecated"` and adds a note in its overview pointing to the `neon` catalog entry (already present, remote transport) and the [Neon MCP docs](https://neon.com/docs/ai/neon-mcp-server), following the same pattern used for `mcp-server-box` → `box-remote`.

## Test plan

- [x] `task catalog:validate` passes