### PR TITLE
Add Palisade DMARC Agent remote entry

### DIFF
--- a/registries/toolhive/servers/palisade-dmarc-agent/icon.svg
+++ b/registries/toolhive/servers/palisade-dmarc-agent/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="Palisade">
+  <circle cx="64" cy="64" r="60" fill="#111111"/>
+  <path fill="#ffffff" d="M64 27 103 96H25L64 27Zm0 22-20.1 36h40.2L64 49Z"/>
+</svg>

--- a/registries/toolhive/servers/palisade-dmarc-agent/server.json
+++ b/registries/toolhive/servers/palisade-dmarc-agent/server.json
@@ -28,16 +28,22 @@
             "get_domain",
             "add_domain",
             "remove_domain",
-            "verify_domain",
             "get_dns_records",
+            "enable_hosted_dmarc",
+            "verify_domain",
             "get_mta_sts",
             "enable_mta_sts",
             "list_tasks",
             "get_task",
             "list_groups",
+            "create_group",
             "get_subscription",
             "start_checkout",
-            "get_billing_portal_url"
+            "get_billing_portal_url",
+            "list_webhook_events",
+            "list_webhook_endpoints",
+            "create_webhook_endpoint",
+            "delete_webhook_endpoint"
           ]
         }
       }

--- a/registries/toolhive/servers/palisade-dmarc-agent/server.json
+++ b/registries/toolhive/servers/palisade-dmarc-agent/server.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "io.github.stacklok": {
+        "https://api.palisade.email/mcp": {
+          "custom_metadata": {
+            "author": "Palisade Technologies",
+            "homepage": "https://palisade.email",
+            "license": "MIT"
+          },
+          "overview": "## Palisade DMARC Agent\n\nPalisade is the official MCP server for managing email authentication from compatible AI agents. It provides domain visibility and remediation workflows for DMARC, SPF, DKIM, BIMI, MTA-STS, and related DNS records. Authenticate requests with a Palisade API key to inspect accounts and domains, verify configurations, and manage remediation tasks.",
+          "status": "Active",
+          "tags": [
+            "remote",
+            "email-security",
+            "dmarc",
+            "spf",
+            "dkim",
+            "dns",
+            "mta-sts",
+            "bimi"
+          ],
+          "tier": "Official",
+          "tools": [
+            "get_account",
+            "list_domains",
+            "get_domain",
+            "add_domain",
+            "remove_domain",
+            "verify_domain",
+            "get_dns_records",
+            "get_mta_sts",
+            "enable_mta_sts",
+            "list_tasks",
+            "get_task",
+            "list_groups",
+            "get_subscription",
+            "start_checkout",
+            "get_billing_portal_url"
+          ]
+        }
+      }
+    }
+  },
+  "description": "Official MCP server for DMARC, SPF, DKIM, DNS, and email authentication management",
+  "icons": [
+    {
+      "mimeType": "image/svg+xml",
+      "sizes": [
+        "any"
+      ],
+      "src": "https://raw.githubusercontent.com/stacklok/toolhive-registry/main/registries/toolhive/servers/palisade-dmarc-agent/icon.svg"
+    }
+  ],
+  "name": "io.github.stacklok/palisade-dmarc-agent",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://api.palisade.email/mcp"
+    }
+  ],
+  "repository": {
+    "source": "github",
+    "url": "https://github.com/palisadeemail/palisade-mcp"
+  },
+  "title": "Palisade DMARC Agent (Remote)",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
## Summary

Adds Palisade's official Streamable HTTP MCP endpoint to the ToolHive catalog.

- Declares the public endpoint, source repository, MIT license, and official-vendor metadata.
- Lists the email-authentication tools for DMARC, SPF, DKIM, BIMI, MTA-STS, DNS, domains, and remediation.
- Adds a compact Palisade icon for the catalog entry.

## Validation

- `jq empty registries/toolhive/servers/palisade-dmarc-agent/server.json`
- `xmllint --noout registries/toolhive/servers/palisade-dmarc-agent/icon.svg`
- `git diff --check`

The catalog's full validator could not run locally because this checkout lacks both Go and Task; CI will run the repository validator.