### PR TITLE
ci: add zizmor GitHub Actions security scan

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -29,3 +29,7 @@ jobs:
           inputs: ./.github/workflows/
           advanced-security: 'false'
           annotations: 'true'
+          # Low/informational findings (e.g. style nits, unexploitable
+          # low-confidence flags) still show as annotations but don't fail
+          # the check; only real security-relevant findings gate the PR.
+          min-severity: medium

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,31 @@
+name: 'GitHub Actions Security (zizmor)'
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          inputs: ./.github/workflows/
+          advanced-security: 'false'
+          annotations: 'true'


### PR DESCRIPTION
Adds a workflow that runs [zizmor](https://zizmor.sh) against `.github/workflows/` on push to `main` and on PRs that touch workflow files, following the pattern used in `docs-website` (single job, annotations, no SARIF/Security-tab integration since this repo doesn't have code scanning enabled).

A local run against the existing workflows surfaces 38 findings (2 high, 12 medium) — those will be addressed in a follow-up PR.