### PR TITLE
ci: fix zizmor findings in GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -47,6 +49,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -108,6 +112,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           token: ${{ steps.app-token.outputs.token }}
+          # This job pushes to the catalog-data branch below using the
+          # checked-out credential, so it must persist.
+          persist-credentials: true
 
       # On a scheduled/manual run we always proceed (opening a new PR if none exists).
       # On a plain push to main, only proceed if a catalog-data PR is already open —
@@ -229,6 +236,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -44,9 +44,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@3f854a8fb5146b39d5cbf8b57f70d80810e1366f # v1
+        uses: anthropics/claude-code-action@3f854a8fb5146b39d5cbf8b57f70d80810e1366f # v1.0.198
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Generate version
         id: metadata
@@ -52,12 +53,14 @@ jobs:
       - name: Generate release body
         if: steps.check_changes.outputs.has_changes != 'false'
         id: release_body
+        env:
+          RELEASE_DATE: ${{ steps.metadata.outputs.date }}
         run: |
           {
             echo "body<<EOF"
             echo "## ToolHive Catalog Release"
             echo ""
-            echo "**Date**: ${{ steps.metadata.outputs.date }}"
+            echo "**Date**: $RELEASE_DATE"
             echo ""
 
             for registry_dir in pkg/catalog/*/; do
@@ -130,7 +133,7 @@ jobs:
 
       - name: Create or update release
         if: steps.check_changes.outputs.has_changes != 'false'
-        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           tag: v${{ steps.metadata.outputs.version }}
           name: Catalog v${{ steps.metadata.outputs.date }}

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -48,6 +48,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           token: ${{ steps.app-token.outputs.token }}
+          # This job pushes to the sync branch below using the checked-out
+          # credential, so it must persist.
+          persist-credentials: true
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7

--- a/.github/workflows/update-metadata.yml
+++ b/.github/workflows/update-metadata.yml
@@ -48,6 +48,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           token: ${{ steps.app-token.outputs.token }}
+          # This job pushes to the metadata branch below using the
+          # checked-out credential, so it must persist.
+          persist-credentials: true
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7

--- a/.github/workflows/update-tools.yml
+++ b/.github/workflows/update-tools.yml
@@ -11,15 +11,15 @@ on:
         required: false
         type: string
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   # Security check for fork PRs - prevents untrusted code execution with write permissions
   security-check:
     name: Security Check for Fork PRs
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     if: github.event_name == 'pull_request'
     outputs:
       is-fork: ${{ steps.check-fork.outputs.is-fork }}
@@ -93,6 +93,8 @@ jobs:
   detect-changes:
     name: Detect Changed Servers
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [security-check]
     # Skip on the bot's own synchronize pushes: commit-all-changes pushes with
     # an app token, which (unlike GITHUB_TOKEN) re-triggers pull_request events.
@@ -112,6 +114,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Get changed files
         id: changed-files
@@ -203,6 +206,8 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.has-changes == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix: ${{ fromJson(needs.detect-changes.outputs.matrix) }}
       fail-fast: false
@@ -212,6 +217,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.head_ref || github.ref }}
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -356,6 +362,8 @@ jobs:
     needs: [detect-changes, update-tools]
     if: always() && needs.detect-changes.outputs.has-changes == 'true' && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Generate app token
         id: app-token
@@ -380,6 +388,9 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           ref: ${{ github.head_ref || github.ref }}
+          # This job pushes the commit below using the checked-out
+          # credential, so it must persist.
+          persist-credentials: true
 
       - name: Download all commit info artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -468,6 +479,8 @@ jobs:
     needs: [detect-changes, update-tools]
     if: always() && needs.detect-changes.outputs.has-changes == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Download all commit info artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -539,11 +552,14 @@ jobs:
     needs: update-tools
     if: always()
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.head_ref || github.ref }}
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7


### PR DESCRIPTION
Follow-up to #1496: addresses the findings zizmor surfaces across the existing workflows now that the scan is in place.

- Sets `persist-credentials` explicitly on every checkout: `false` where the job never pushes, `true` (with a comment) where it does and genuinely needs the persisted credential.
- Scopes `update-tools.yml`'s `contents: write` / `pull-requests: write` permissions down from the whole workflow to just the jobs that need them.
- Routes a template expression in `release.yml` through an env var instead of interpolating it directly into the script body.
- Fixes two stale action pin comments to the specific version each SHA actually resolves to (`claude-code-action`'s comment claimed the floating `v1` tag, which has since moved to a newer commit; `ncipollo/release-action`'s is now specific enough to make Renovate's version bumps more informative).

With #1496 gating on medium+ severity only, this clears everything at that threshold. One informational finding (`superfluous-actions`, suggesting `gh release` in place of `ncipollo/release-action`) is left as-is — it's a reasonable abstraction for this use case, not a security issue.