### PR TITLE
feat: add MainBook Bank Statement Converter (remote)

### DIFF
--- a/registries/toolhive/servers/mainbook-bank-statement-converter/icon.svg
+++ b/registries/toolhive/servers/mainbook-bank-statement-converter/icon.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-label="MainBook">
+<!--
+  MainBook catalogue mark.
+
+  A simplification of the brand mark, not a new idea: the original is an
+  isometric 3x3 grid of cells drawn in hairlines, which turns to mush below
+  about 32px — verified against ToolHive's own listed icons at 16, 24, 40 and
+  64px. This keeps the isometric cell-grid reading with 2x2 cells per face and
+  solid fills, so the silhouette survives at 16px.
+
+  Three tones, no background plate: catalogue cards come in light and dark, and
+  a single-tone mark loses one of them (GitHub's own icon disappears on a dark
+  card; our old black cube did too). Mid-tone olive faces carry the shape on
+  white, the lime top carries it on near-black.
+
+  Lime #c8ff3c is the product accent from frontend/app/globals.css, not the
+  green in marketing/facebook/branding — that green is a Facebook-era variant.
+-->
+<title>MainBook</title>
+<g fill="#7f9e2a">
+<polygon points="8.12,22.19 18.38,28.13 18.38,37.56 8.12,31.62"/>
+<polygon points="8.12,33.69 18.38,39.63 18.38,49.06 8.12,43.12"/>
+<polygon points="20.62,29.44 30.88,35.38 30.88,44.81 20.62,38.87"/>
+<polygon points="20.62,40.94 30.88,46.88 30.88,56.31 20.62,50.37"/>
+</g>
+<g fill="#4c6116">
+<polygon points="55.88,22.19 45.62,28.13 45.62,37.56 55.88,31.62"/>
+<polygon points="55.88,33.69 45.62,39.63 45.62,49.06 55.88,43.12"/>
+<polygon points="43.38,29.44 33.12,35.38 33.12,44.81 43.38,38.87"/>
+<polygon points="43.38,40.94 33.12,46.88 33.12,56.31 43.38,50.37"/>
+</g>
+<g fill="#c8ff3c">
+<polygon points="32.00,7.30 42.25,13.25 32.00,19.20 21.75,13.25"/>
+<polygon points="19.50,14.55 29.75,20.50 19.50,26.45 9.25,20.50"/>
+<polygon points="44.50,14.55 54.75,20.50 44.50,26.45 34.25,20.50"/>
+<polygon points="32.00,21.80 42.25,27.75 32.00,33.70 21.75,27.75"/>
+</g>
+</svg>

--- a/registries/toolhive/servers/mainbook-bank-statement-converter/server.json
+++ b/registries/toolhive/servers/mainbook-bank-statement-converter/server.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.stacklok/mainbook-bank-statement-converter",
+  "description": "Convert PDF bank statements to checked Excel, CSV or JSON with balance validation.",
+  "title": "MainBook Bank Statement Converter (Remote)",
+  "repository": {
+    "url": "https://github.com/human-beyond/mainbook-mcp",
+    "source": "github"
+  },
+  "version": "1.0.0",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.mainbook.ai/mcp"
+    }
+  ],
+  "icons": [
+    {
+      "src": "https://raw.githubusercontent.com/stacklok/toolhive-registry/main/registries/toolhive/servers/mainbook-bank-statement-converter/icon.svg",
+      "mimeType": "image/svg+xml",
+      "sizes": [
+        "any"
+      ]
+    }
+  ],
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "io.github.stacklok": {
+        "https://mcp.mainbook.ai/mcp": {
+          "tier": "Community",
+          "status": "Active",
+          "tags": [
+            "remote",
+            "finance",
+            "accounting",
+            "bookkeeping",
+            "pdf",
+            "excel",
+            "csv",
+            "document-conversion",
+            "oauth"
+          ],
+          "tools": [
+            "convert_bank_statement",
+            "get_conversion",
+            "list_conversions",
+            "get_balance"
+          ],
+          "overview": "## MainBook Bank Statement Converter (Remote)\n\nConverts PDF bank and credit-card statements into Excel, CSV or JSON, and checks the arithmetic while it does it: every transaction is reconciled against the statement's own opening and closing balances, and rows that do not add up are reported rather than quietly shipped.\n\nIt reads the statement PDF you point it at \u2014 it never connects to a bank account and never asks for banking credentials. Alongside the workbook it returns the evidence behind it: transaction count, whether the balances reconcile, how many rows mismatched and which rows carry warnings.\n\nSign-in is a browser OAuth 2.1 flow against your own MainBook account. Conversions cost page credits, one per statement page, and a new account starts with free pages; every other call is free. `convert_bank_statement` is the only tool that spends anything.",
+          "oauth_config": {
+            "issuer": "https://api.mainbook.ai",
+            "authorize_url": "https://api.mainbook.ai/oauth/authorize/",
+            "token_url": "https://api.mainbook.ai/oauth/token/",
+            "client_id": "mainbook-toolhive",
+            "scopes": [
+              "mainbook:read",
+              "mainbook:convert"
+            ],
+            "use_pkce": true,
+            "resource": "https://mcp.mainbook.ai/mcp",
+            "callback_port": 8765
+          },
+          "custom_metadata": {
+            "author": "Human Beyond LLC",
+            "homepage": "https://mainbook.ai/mcp",
+            "license": "MIT"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #1499

Adds the MainBook Bank Statement Converter as a remote MCP server under `registries/toolhive/servers/`.

It converts PDF bank and credit-card statements into Excel, CSV or JSON and reconciles every transaction against the statement's own opening and closing balances, so rows that do not add up are reported rather than silently shipped. It reads the PDF it is given — it never connects to a bank account and never asks for banking credentials.

| | |
|---|---|
| Endpoint | `https://mcp.mainbook.ai/mcp` (`streamable-http`) |
| Tools | `convert_bank_statement`, `get_conversion`, `list_conversions`, `get_balance` |
| Paid calls | only `convert_bank_statement` — one page credit per statement page |
| Auth | OAuth 2.1 + PKCE, browser sign-in to the user's own MainBook account |
| Source | https://github.com/human-beyond/mainbook-mcp (MIT) |
| Tier | Community |

### On the pinned `oauth_config`

Every remote entry currently in the catalogue leaves `oauth_config` out and lets discovery do the work. This one does not, and the reason is specific rather than stylistic: our authorization server implements client-ID metadata documents and pre-registered clients, but **not** RFC 7591 dynamic client registration. Falling through to DCR would fail, and the card would look correct while authorising nothing.

So the entry pins:

- `client_id: mainbook-toolhive` — registered on our side for ToolHive specifically, with the loopback callback `http://localhost:8765/callback`. Loopback callbacks are accepted on any port per RFC 8252, so changing `callback_port` will not break it.
- `resource` — our authorization server requires the RFC 8707 indicator and answers `invalid_request` without it.

Verified against production: an authorization request with this `client_id` reaches the consent screen, an unregistered `client_id` is rejected, and a redirect URI on a non-loopback host is rejected.

If you would rather entries did not pin a `client_id`, tell me and I will take it out — but the connection will not complete without it until we ship dynamic registration.

### Validation

`server.json` and its `_meta` block validate clean against toolhive-core's own `server.schema.json` and `publisher-provided.schema.json`. Go and Task were not available on this machine, so `task catalog:validate` was not run locally — please let CI be the judge there.

### Icon

`icon.svg` is a purpose-made simplification of our brand mark: solid fills instead of hairlines, three tones and no background plate, so it holds up at 16px and reads on both light and dark cards. Checked side by side with icons already in this catalogue at 16, 24, 40 and 64px.
