### PR TITLE
Add Noodle and Folklore remote MCP servers

### DIFF
--- a/registries/toolhive/servers/folklore-clinical-variant-interpretation-mcp/server.json
+++ b/registries/toolhive/servers/folklore-clinical-variant-interpretation-mcp/server.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.helena-bioinformatics/folklore",
+  "title": "Folklore Clinical Variant Interpretation MCP",
+  "description": "Classify germline variants under ACMG/AMP with structured evidence, provenance and literature.",
+  "version": "1.4.1",
+  "websiteUrl": "https://folklore.helena.bio",
+  "repository": {
+    "url": "https://github.com/helena-bioinformatics/folklore-mcp",
+    "source": "github",
+    "id": "1331454884"
+  },
+  "icons": [
+    {
+      "src": "https://folklore.helena.bio/images/logos/folklore.png",
+      "mimeType": "image/png"
+    }
+  ],
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://api.helena.bio/folklore/v1/mcp"
+    }
+  ],
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "io.github.stacklok": {
+        "https://api.helena.bio/folklore/v1/mcp": {
+          "tier": "Community",
+          "status": "Active",
+          "tags": [
+            "clinical-variant-interpretation",
+            "genomics",
+            "bioinformatics",
+            "acmg-amp",
+            "biomedical-literature",
+            "read-only"
+          ],
+          "tools": [
+            "search_variant_evidence",
+            "search_variant_literature",
+            "get_publication_details",
+            "search_literature_corpus",
+            "support_helena"
+          ],
+          "custom_metadata": {
+            "author": "Helena Bioinformatics",
+            "homepage": "https://folklore.helena.bio",
+            "license": "Apache-2.0"
+          }
+        }
+      }
+    }
+  }
+}

--- a/registries/toolhive/servers/noodle-biomedical-literature-discovery-mcp/server.json
+++ b/registries/toolhive/servers/noodle-biomedical-literature-discovery-mcp/server.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.helena-bioinformatics/noodle",
+  "title": "Noodle Biomedical Literature Discovery MCP",
+  "description": "Search biomedical papers, inspect publication records, and traverse citation or semantic graphs.",
+  "version": "0.2.1",
+  "websiteUrl": "https://noodle.helena.bio",
+  "repository": {
+    "url": "https://github.com/helena-bioinformatics/noodle-mcp",
+    "source": "github",
+    "id": "1350901429"
+  },
+  "icons": [
+    {
+      "src": "https://noodle.helena.bio/favicon.svg",
+      "mimeType": "image/svg+xml"
+    }
+  ],
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://api.helena.bio/noodle/v1/mcp"
+    }
+  ],
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "io.github.stacklok": {
+        "https://api.helena.bio/noodle/v1/mcp": {
+          "tier": "Community",
+          "status": "Active",
+          "tags": [
+            "biomedical-literature",
+            "research",
+            "citation-graph",
+            "semantic-search",
+            "pubmed",
+            "read-only"
+          ],
+          "tools": [
+            "search_biomedical_literature",
+            "get_publication_details",
+            "get_work_details",
+            "get_publication_neighborhood",
+            "get_work_neighborhood",
+            "get_corpus_summary",
+            "support_helena"
+          ],
+          "custom_metadata": {
+            "author": "Helena Bioinformatics",
+            "homepage": "https://noodle.helena.bio",
+            "license": "Apache-2.0"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds two public, read-only Streamable HTTP MCP servers maintained by Helena Bioinformatics.

Noodle supports biomedical literature search, publication details, corpus coverage, and bounded citation or semantic graph traversal.

Folklore supports GRCh38 germline variant evidence, ACMG/AMP interpretation context, and biomedical literature. It does not accept patient data and does not provide diagnostic output.

Both entries use their active Official MCP Registry identities, public Apache-2.0 adapter repositories, canonical endpoints, exact tool inventories, and product websites. No authentication is required.