### PR TITLE
Route Claude PR Assistant through Stacklok LLM gateway

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -49,5 +49,7 @@ jobs:
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@833fb0f8c9f6686b33d963a8bae0a94f4936ab2a # v1.0.211
+        env:
+          ANTHROPIC_BASE_URL: https://llm-gateway.stacklok.dev/anthropic
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.STACKLOK_GATEWAY_KEY_CLAUDE_TAG }}


### PR DESCRIPTION
## Summary
- Switch the Claude PR Assistant workflow's API key from `secrets.ANTHROPIC_API_KEY` to `secrets.STACKLOK_GATEWAY_KEY_CLAUDE_TAG`
- Set `ANTHROPIC_BASE_URL` to `https://llm-gateway.stacklok.dev/anthropic` so all requests route through the Stacklok LLM gateway instead of hitting the Anthropic API directly

## Test plan
- [ ] Confirm `STACKLOK_GATEWAY_KEY_CLAUDE_TAG` secret is present in the repo (confirmed by requester)
- [ ] Trigger the workflow (e.g. comment `@claude` on a PR/issue) and verify it completes successfully via the gateway