### PR TITLE
Add QVeris remote MCP server

### DIFF
--- a/registries/toolhive/servers/qveris-remote/icon.svg
+++ b/registries/toolhive/servers/qveris-remote/icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
+  <defs>
+    <linearGradient id="q" x1="3" y1="3" x2="37" y2="37" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#12DDE8"/>
+      <stop offset="0.58" stop-color="#008DFF"/>
+      <stop offset="1" stop-color="#2E39F3"/>
+    </linearGradient>
+  </defs>
+  <path fill="url(#q)" fill-rule="evenodd" d="M20 2a18 18 0 1 0 11.93 31.48l4.19 4.19 2.12-2.12-4.18-4.18A18 18 0 0 0 20 2Zm0 7a11 11 0 1 0 7.78 18.78l-3.54-3.54 2.12-2.12 3.54 3.54A11 11 0 0 0 20 9Z" clip-rule="evenodd"/>
+</svg>

--- a/registries/toolhive/servers/qveris-remote/server.json
+++ b/registries/toolhive/servers/qveris-remote/server.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.stacklok/qveris-remote",
+  "description": "Official QVeris MCP server for discovering, inspecting, calling, and auditing external tools",
+  "title": "QVeris (Remote)",
+  "repository": {
+    "url": "https://github.com/QVerisAI/qveris-agent-toolkit",
+    "source": "github",
+    "subfolder": "packages/mcp"
+  },
+  "version": "1.0.0",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.qveris.ai/mcp",
+      "headers": [
+        {
+          "name": "Authorization",
+          "description": "Bearer QVeris API key (format: Bearer YOUR_QVERIS_API_KEY)",
+          "isRequired": true,
+          "isSecret": true
+        }
+      ]
+    }
+  ],
+  "icons": [
+    {
+      "src": "https://raw.githubusercontent.com/stacklok/toolhive-registry/main/registries/toolhive/servers/qveris-remote/icon.svg",
+      "mimeType": "image/svg+xml",
+      "sizes": [
+        "any"
+      ]
+    }
+  ],
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "io.github.stacklok": {
+        "https://mcp.qveris.ai/mcp": {
+          "tier": "Official",
+          "status": "Active",
+          "tags": [
+            "remote",
+            "qveris",
+            "api",
+            "tool-discovery",
+            "capability-routing",
+            "automation",
+            "usage-audit"
+          ],
+          "tools": [
+            "discover",
+            "inspect",
+            "call",
+            "usage_history",
+            "credits_ledger",
+            "search_tools",
+            "get_tools_by_ids",
+            "execute_tool"
+          ],
+          "overview": "## QVeris Remote MCP Server\n\nQVeris is the official hosted Model Context Protocol server for the QVeris capability routing network. It lets AI assistants discover ranked external tools, inspect their schemas and operational signals, call selected capabilities, and audit usage and credit settlement through a compact set of MCP tools. The server uses Streamable HTTP transport and requires a QVeris API key in the Authorization header. It is suited to agents that need on-demand access to external APIs without preloading thousands of tool schemas.",
+          "custom_metadata": {
+            "author": "QVerisAI",
+            "homepage": "https://qveris.ai",
+            "license": "MIT"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add the official hosted QVeris MCP server.
- Document Bearer API-key authentication as a required secret header.
- Include the live tool list and official QVeris icon.

## Validation
- `go run ./cmd/catalog validate -v`
- `go run ./cmd/catalog build -v`
- Live `initialize` handshake negotiated MCP `2025-06-18`.
- Live `tools/list` returned the eight declared tools.
- `npm audit --omit=dev --audit-level=high` reported 0 vulnerabilities for `@qverisai/mcp`.

Closes #1546