### PR TITLE
Add Playgama remote MCP server

### DIFF
--- a/registries/toolhive/servers/playgama-developer-cabinet/server.json
+++ b/registries/toolhive/servers/playgama-developer-cabinet/server.json
@@ -45,7 +45,7 @@
       }
     }
   },
-  "description": "Publish and manage HTML5 games on Playgama: game form, builds, covers, in-app catalog, leaderboards, sandbox",
+  "description": "Manage Playgama HTML5 games: forms, builds, covers, in-app catalog, leaderboards, sandbox.",
   "name": "io.github.stacklok/playgama-developer-cabinet",
   "remotes": [
     {

--- a/registries/toolhive/servers/playgama-developer-cabinet/server.json
+++ b/registries/toolhive/servers/playgama-developer-cabinet/server.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "io.github.stacklok": {
+        "https://developer.playgama.com/api/mcp": {
+          "custom_metadata": {
+            "author": "Playgama",
+            "homepage": "https://playgama.com/mcp/",
+            "license": "MIT"
+          },
+          "overview": "## Playgama MCP Server\n\nPlaygama hosts HTML5 games. This server puts the Playgama developer cabinet behind an MCP endpoint, so a coding agent can take a game from a local build to a public link without leaving the editor.\n\nThe agent creates a game and fills in its form, uploads a build and polls until the engine analysis finishes, uploads covers in the exact sizes the form requires, edits the in-app catalog and leaderboards, gets a QA Tool link, and publishes a sandbox — a public link anyone can play, with no moderation step.\n\n20 tools, 10 of them read-only; every write is annotated as destructive so the client asks first. Submitting to moderation, deleting and payouts are deliberately left out: the agent prepares everything, a human presses the button.\n\nAuthentication is an API key issued in the cabinet at developer.playgama.com/mcp and sent as `Authorization: Bearer pgm_mcp_...`. Sign-up is open to any developer.",
+          "status": "Active",
+          "tags": [
+            "games",
+            "game-development",
+            "html5-games",
+            "game-publishing",
+            "remote"
+          ],
+          "tier": "Community",
+          "tools": [
+            "list_applications",
+            "create_application",
+            "get_application",
+            "update_application_form",
+            "get_submission_state",
+            "list_moderation_comments",
+            "list_leaderboards",
+            "create_leaderboard",
+            "update_leaderboard",
+            "list_in_app_products",
+            "replace_in_app_products",
+            "start_archive_upload",
+            "get_archive_status",
+            "get_archive_qa_tool_link",
+            "confirm_archive_upload",
+            "start_cover_upload",
+            "confirm_cover_upload",
+            "get_local_game_qa_tool_link",
+            "get_sandbox_state",
+            "publish_sandbox"
+          ]
+        }
+      }
+    }
+  },
+  "description": "Publish and manage HTML5 games on Playgama: game form, builds, covers, in-app catalog, leaderboards, sandbox",
+  "name": "io.github.stacklok/playgama-developer-cabinet",
+  "remotes": [
+    {
+      "headers": [
+        {
+          "description": "Bearer token issued in the Playgama developer cabinet: Bearer pgm_mcp_...",
+          "isRequired": true,
+          "isSecret": true,
+          "name": "Authorization"
+        }
+      ],
+      "type": "streamable-http",
+      "url": "https://developer.playgama.com/api/mcp"
+    }
+  ],
+  "repository": {
+    "source": "github",
+    "url": "https://github.com/Playgama/developer-cabinet-mcp"
+  },
+  "title": "Playgama (Remote)",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
Adds the Playgama remote MCP server under `registries/toolhive/servers/playgama-developer-cabinet`.

**What it does.** Playgama hosts HTML5 games. This server puts the Playgama developer cabinet behind an MCP endpoint, so a coding agent can take a game from a local build to a public link without leaving the editor: it creates the game and fills in its form, uploads a build and polls until the engine analysis finishes, uploads covers in the exact sizes the form requires, edits the in-app catalog and leaderboards, gets a QA Tool link, and publishes a sandbox — a public link anyone can play.

20 tools, 10 of them read-only; every write is annotated as destructive so the client asks first. Submitting to moderation, deleting and payouts are deliberately not exposed, so the agent prepares everything and a human presses the button.

**Entry**

- Remote server, `streamable-http`, endpoint `https://developer.playgama.com/api/mcp` (MCP protocol `2025-06-18`, stateless POST)
- `_meta` extension keyed by the `remotes[0].url`, as the README requires, with tier `Community`, status `Active`, tags, all 20 tool names and `custom_metadata`
- Auth is an API key issued in the cabinet, declared as a required secret `Authorization` header
- Source repository is MIT: https://github.com/Playgama/developer-cabinet-mcp

**Checklist**

- Public sign-up: any developer registers at developer.playgama.com and issues a free token at developer.playgama.com/mcp
- Docs: https://wiki.playgama.com/playgama/mcp · product page: https://playgama.com/mcp/
- Test credentials for review are ready — tell me where to send them and I will supply a token for a dedicated test account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)